### PR TITLE
chore: ignore accidental terminal paste files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 lychee_*.txt
 md_files.txt
 /docs/context/TRACEABILITY_SNAPSHOT.md
+
+# accidental terminal paste files
+*ssh-keygen*
+*sh-keygen*
+


### PR DESCRIPTION
## Summary
Prevents accidental files created by terminal copy/paste (e.g. `ssh-keygen`/`sh-keygen` fragments) from showing up as untracked noise.

## Rationale (diplomacy ops)
Keeps the working tree clean and reduces operator error during audit/traceability runs.

## Changes
- Adds ignore patterns for `*ssh-keygen*` and `*sh-keygen*`.

## Risk
Low (ignore-only change). Rollback: revert this PR.
