### PR TITLE
docs: publish real PROJECT_OVERVIEW (MVP + no-go zones)

### DIFF
--- a/docs/context/AI_CONTEXT.md
+++ b/docs/context/AI_CONTEXT.md
@@ -13,11 +13,11 @@ Eres el copiloto técnico del repositorio. Tu trabajo es:
 - Cuando propongas cambios, incluye impacto, riesgo y plan de rollback.
 
 ## Fuente de verdad
-1) docs/context/STATUS.md
-2) docs/context/PROJECT_OVERVIEW.md
-3) docs/context/WORKFLOWS.md
-4) docs/context/GLOSSARY.md
-5) docs/context/TRACEABILITY.md
+1) [docs/context/STATUS.md](STATUS.md)
+2) [docs/context/PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md)
+3) [docs/context/WORKFLOWS.md](WORKFLOWS.md)
+4) [docs/context/GLOSSARY.md](GLOSSARY.md)
+5) [docs/context/TRACEABILITY.md](TRACEABILITY.md)
 
 ## Output esperado
 - Respuestas accionables.

--- a/docs/context/PROJECT_OVERVIEW.md
+++ b/docs/context/PROJECT_OVERVIEW.md
@@ -1,26 +1,41 @@
-# PROJECT OVERVIEW — HUB_Optimus
+# PROJECT OVERVIEW - HUB_Optimus
 
-## Elevator pitch
-(1-3 líneas: qué es, para qué sirve, quién lo usa)
+## What it is
+HUB_Optimus is an integrity-first evaluation framework for diplomatic and institutional scenarios.
+It compares declared commitments against verifiable structure: incentives, sequencing, and monitoring.
 
-## Objetivos
-- Objetivo 1:
-- Objetivo 2:
-- Objetivo 3:
+## Who it is for
+- Policy analysts
+- Mediation and negotiation teams
+- Repository maintainers building reproducible scenario reviews
 
-## Arquitectura (alto nivel)
-- Core:
-- Workflows/Automation:
-- Docs/Scenarios (.md):
-- Inputs/Outputs:
+## MVP definition (current release target)
+- Evaluate scenario markdown with deterministic CLI commands.
+- Produce machine-readable JSON and human-readable markdown outputs.
+- Keep docs and governance navigable with automated link and test checks.
+- Block unsafe edits in protected kernel/governance paths unless explicitly authorized.
 
-## Componentes / carpetas clave
-- /core:
-- /workflows:
-- /docs:
-- Otros:
+## Out of scope (no-go zones)
+- Prediction engines or probabilistic forecasting claims.
+- Automated coercive enforcement or sanctions logic.
+- Personal blame scoring; analysis remains structural and evidence-driven.
+- Legacy rewrites to force-fit old content into v1.
 
-## Cómo se ejecuta (si aplica)
-- Local:
-- CI/CD:
-- Entornos:
+## Architecture at a glance
+- `hub_optimus/`: evaluator package and CLI behavior.
+- `run_scenario.py` and `hub_optimus_simulator.py`: scenario execution loop.
+- `v1_core/`: active kernel language specs and workflow scenarios.
+- `docs/`: onboarding and governance documentation.
+- `.github/workflows/` and `tools/`: CI checks and maintenance automation.
+
+## Success metrics (MVP)
+- `pytest` passes on every `pull_request` and `push` to `main`.
+- Link-check reports zero broken links on docs touched by PRs.
+- Invalid scenario input fails fast with stable exit code and clear error message.
+- Example scenario smoke test runs in CI without network dependencies.
+- Source-of-truth policy remains consistent in onboarding and contribution docs.
+
+## Operating constraints
+- Source-of-truth for policy conflicts is `docs/context/STATUS.md`.
+- For `v1_core/languages/`, Spanish (`es`) is canonical and English (`en`) is parity reference.
+- Changes should ship as small PRs with one objective each.


### PR DESCRIPTION
Summary:
- replace placeholder PROJECT_OVERVIEW with concrete MVP scope and operating constraints
- add explicit no-go zones and measurable success metrics
- make docs/context source-of-truth index links clickable in AI_CONTEXT

Validation:
- lychee --config .github/lychee.toml docs/context/PROJECT_OVERVIEW.md docs/context/AI_CONTEXT.md

Closes #63