### PR TITLE
ci: enforce diff-based kernel guard with auditable PR override

### DIFF
--- a/.github/workflows/kernel-guard.yml
+++ b/.github/workflows/kernel-guard.yml
@@ -1,0 +1,44 @@
+name: Kernel Guard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect override label
+        id: labels
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'allow-kernel-change') }}" == "true" ]]; then
+            echo "allow=true" >> "$GITHUB_OUTPUT"
+            echo "Kernel guard override enabled by label: allow-kernel-change"
+          else
+            echo "allow=false" >> "$GITHUB_OUTPUT"
+            echo "Kernel guard override label not present."
+          fi
+
+      - name: Run kernel guard (diff-based)
+        run: |
+          git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
+          if [[ "${{ steps.labels.outputs.allow }}" == "true" ]]; then
+            python tools/kernel_guard.py \
+              --base-ref "origin/${{ github.base_ref }}" \
+              --head-ref "${{ github.sha }}" \
+              --allow-kernel-changes
+          else
+            python tools/kernel_guard.py \
+              --base-ref "origin/${{ github.base_ref }}" \
+              --head-ref "${{ github.sha }}"
+          fi

--- a/tools/kernel_guard.py
+++ b/tools/kernel_guard.py
@@ -1,44 +1,108 @@
 #!/usr/bin/env python3
-import sys
+from __future__ import annotations
+
+import argparse
 import subprocess
+import sys
+from typing import Iterable
 
-ALLOW = (sys.argv[1].strip().lower() == "true") if len(sys.argv) > 1 else False
 
-PROTECTED_PREFIXES = (
+DEFAULT_PROTECTED_PREFIXES = (
     "docs/governance/",
-    "v1_core/languages/en/",
+    "v1_core/languages/es/",
 )
 
 
-def changed_files():
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    files = []
-    for line in result.stdout.splitlines():
+def _run_git(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise RuntimeError(f"git command failed: {' '.join(cmd)}\n{stderr}")
+    return proc.stdout
+
+
+def changed_files(base_ref: str | None, head_ref: str) -> list[str]:
+    if base_ref:
+        output = _run_git(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMR",
+                f"{base_ref}..{head_ref}",
+            ]
+        )
+        return [line.strip() for line in output.splitlines() if line.strip()]
+
+    # Backward-compatible local mode: inspect working tree changes.
+    output = _run_git(["git", "status", "--porcelain"])
+    files: list[str] = []
+    for line in output.splitlines():
         if not line.strip():
             continue
-        files.append(line[3:])
+        files.append(line[3:].strip())
     return files
 
 
-def main():
-    files = changed_files()
-    protected = [path for path in files if path.startswith(PROTECTED_PREFIXES)]
+def protected_changes(paths: Iterable[str], prefixes: tuple[str, ...]) -> list[str]:
+    return sorted(path for path in paths if path.startswith(prefixes))
 
-    if protected and not ALLOW:
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Block changes in protected kernel/governance paths unless override is enabled."
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help="Base git ref for diff mode (example: origin/main).",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help="Head git ref for diff mode. Defaults to HEAD.",
+    )
+    parser.add_argument(
+        "--allow-kernel-changes",
+        action="store_true",
+        help="Allow protected-path changes (use only with auditable governance override).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        files = changed_files(args.base_ref, args.head_ref)
+    except RuntimeError as exc:
+        print(f"Kernel guard failed to compute changed files: {exc}", file=sys.stderr)
+        return 2
+
+    blocked = protected_changes(files, DEFAULT_PROTECTED_PREFIXES)
+
+    if blocked and not args.allow_kernel_changes:
         print(
-            "KERNEL GUARD BLOCKED: protected files changed but allow_kernel_changes=false"
+            "KERNEL GUARD BLOCKED: protected files changed and override is not enabled.",
+            file=sys.stderr,
         )
-        for path in protected:
-            print(" -", path)
-        sys.exit(1)
+        print(
+            "To override in PR workflow, apply auditable label 'allow-kernel-change'.",
+            file=sys.stderr,
+        )
+        print("Blocked files:", file=sys.stderr)
+        for path in blocked:
+            print(f" - {path}", file=sys.stderr)
+        return 1
 
-    print("Kernel guard OK. Protected changed:", protected)
+    if blocked and args.allow_kernel_changes:
+        print("Kernel guard override active. Protected changes allowed:")
+        for path in blocked:
+            print(f" - {path}")
+        return 0
+
+    print("Kernel guard OK: no protected path changes detected.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
Summary:
- rewrite 	ools/kernel_guard.py to evaluate git diff --name-only base..head
- protect canonical/sensitive prefixes: docs/governance/ and 1_core/languages/es/
- add auditable override path using PR label llow-kernel-change
- emit blocked file list in failure output

Validation:
- python tools/kernel_guard.py --base-ref origin/main --head-ref HEAD
- python tools/kernel_guard.py --base-ref origin/main --head-ref origin/chore/mkdocs-strict
- python tools/kernel_guard.py --base-ref origin/main --head-ref origin/chore/mkdocs-strict --allow-kernel-changes

Closes #66