### PR TITLE
feat: fail-fast scenario input validation with stable exit code

### DIFF
--- a/run_scenario.py
+++ b/run_scenario.py
@@ -1,21 +1,113 @@
 """
-Command-line utility to run negotiation scenarios using the HUB_Optimus simulation kernel.
-
-This script loads a scenario from a JSON file, instantiates a simulator and executes the negotiation
-rounds.  The output is printed as pretty‑formatted JSON, including the status, the number of rounds
-executed, the complete history of actions and a descriptive detail message.
+Command-line utility to run negotiation scenarios with fail-fast input validation.
 """
+
+from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
+from typing import Any
 
 from hub_optimus_simulator import Scenario, Simulator
 
 
-def main() -> None:
+REQUIRED_FIELDS = ("title", "description", "roles", "success_criteria", "max_rounds")
+INPUT_ERROR_EXIT_CODE = 2
+
+
+def _validate_role(role: object, index: int) -> list[str]:
+    if not isinstance(role, dict):
+        return [f"roles[{index}] must be an object"]
+
+    errors: list[str] = []
+    name = role.get("name")
+    role_type = role.get("role")
+
+    if not isinstance(name, str) or not name.strip():
+        errors.append(f"roles[{index}].name must be a non-empty string")
+    if not isinstance(role_type, str) or not role_type.strip():
+        errors.append(f"roles[{index}].role must be a non-empty string")
+
+    unknown_keys = sorted(set(role.keys()) - {"name", "role"})
+    if unknown_keys:
+        errors.append(f"roles[{index}] has unknown field(s): {', '.join(unknown_keys)}")
+
+    return errors
+
+
+def validate_scenario_payload(payload: object) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["Scenario root must be a JSON object"]
+
+    errors: list[str] = []
+
+    missing = [field for field in REQUIRED_FIELDS if field not in payload]
+    if missing:
+        errors.append(f"Missing required field(s): {', '.join(missing)}")
+
+    unknown = sorted(set(payload.keys()) - set(REQUIRED_FIELDS))
+    if unknown:
+        errors.append(f"Unknown field(s): {', '.join(unknown)}")
+
+    title = payload.get("title")
+    if not isinstance(title, str) or not title.strip():
+        errors.append("title must be a non-empty string")
+
+    description = payload.get("description")
+    if not isinstance(description, str) or not description.strip():
+        errors.append("description must be a non-empty string")
+
+    roles = payload.get("roles")
+    if not isinstance(roles, list) or not roles:
+        errors.append("roles must be a non-empty list")
+    elif isinstance(roles, list):
+        for idx, role in enumerate(roles):
+            errors.extend(_validate_role(role, idx))
+
+    success_criteria = payload.get("success_criteria")
+    if not isinstance(success_criteria, dict) or not success_criteria:
+        errors.append("success_criteria must be a non-empty object")
+
+    max_rounds = payload.get("max_rounds")
+    if type(max_rounds) is not int or max_rounds < 1:
+        errors.append("max_rounds must be an integer >= 1")
+
+    return errors
+
+
+def load_validated_scenario(scenario_path: Path) -> Scenario:
+    try:
+        payload: Any = json.loads(scenario_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+
+    errors = validate_scenario_payload(payload)
+    if errors:
+        raise ValueError("\n".join(errors))
+
+    assert isinstance(payload, dict)
+    assert isinstance(payload["title"], str)
+    assert isinstance(payload["description"], str)
+    assert isinstance(payload["roles"], list)
+    assert isinstance(payload["success_criteria"], dict)
+    assert isinstance(payload["max_rounds"], int)
+
+    return Scenario(
+        title=payload["title"],
+        description=payload["description"],
+        roles=payload["roles"],
+        success_criteria=payload["success_criteria"],
+        max_rounds=payload["max_rounds"],
+    )
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Run a HUB_Optimus negotiation scenario and output the results as JSON."
+        description="Run a HUB_Optimus negotiation scenario and output JSON results."
     )
     parser.add_argument(
         "--scenario",
@@ -27,7 +119,7 @@ def main() -> None:
         type=int,
         default=None,
         help=(
-            "Optional seed for reproducibility.  If provided, random actions will be deterministic,"
+            "Optional seed for reproducibility. If provided, random actions will be deterministic,"
             " enabling reproducible runs."
         ),
     )
@@ -35,13 +127,20 @@ def main() -> None:
 
     scenario_path = Path(args.scenario)
     if not scenario_path.is_file():
-        raise FileNotFoundError(f"Scenario file not found: {scenario_path}")
-    scenario = Scenario.from_json(str(scenario_path))
+        print(f"[input-error] Scenario file not found: {scenario_path}", file=sys.stderr)
+        return INPUT_ERROR_EXIT_CODE
+
+    try:
+        scenario = load_validated_scenario(scenario_path)
+    except ValueError as exc:
+        print(f"[schema-error] {exc}", file=sys.stderr)
+        return INPUT_ERROR_EXIT_CODE
+
     simulator = Simulator(scenario)
     result = simulator.run(seed=args.seed)
-    # Pretty print the result as UTF‑8 encoded JSON
     print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_run_scenario_cli.py
+++ b/tests/test_run_scenario_cli.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCENARIO = REPO_ROOT / "run_scenario.py"
+EXAMPLE = REPO_ROOT / "example_scenario.json"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [sys.executable, str(RUN_SCENARIO), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+
+def test_example_scenario_happy_path() -> None:
+    assert EXAMPLE.exists()
+    proc = _run_cli("--scenario", str(EXAMPLE), "--seed", "42")
+    assert proc.returncode == 0
+
+    payload = json.loads(proc.stdout)
+    assert payload["status"] in {"success", "failure"}
+    assert isinstance(payload["rounds"], int)
+    assert isinstance(payload["history"], list)
+    assert isinstance(payload["detail"], str)
+
+
+def test_invalid_schema_fails_fast_with_stable_exit_code(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid_scenario.json"
+    invalid.write_text(
+        json.dumps(
+            {
+                "title": "bad scenario",
+                "description": "missing required constraints",
+                "roles": [],
+                "success_criteria": {},
+                "max_rounds": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run_cli("--scenario", str(invalid))
+    assert proc.returncode == 2
+    assert "[schema-error]" in proc.stderr
+    assert "roles must be a non-empty list" in proc.stderr
+    assert "success_criteria must be a non-empty object" in proc.stderr
+    assert "max_rounds must be an integer >= 1" in proc.stderr
+
+
+def test_missing_file_returns_input_error_code() -> None:
+    missing = REPO_ROOT / "does_not_exist_scenario.json"
+    proc = _run_cli("--scenario", str(missing))
+    assert proc.returncode == 2
+    assert "[input-error]" in proc.stderr
+    assert "Scenario file not found" in proc.stderr
+
+
+def test_invalid_json_returns_schema_error(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"title": "oops", "roles": [}', encoding="utf-8")
+    proc = _run_cli("--scenario", str(bad))
+    assert proc.returncode == 2
+    assert "[schema-error]" in proc.stderr
+    assert "Invalid JSON" in proc.stderr


### PR DESCRIPTION
Summary:
- add fail-fast scenario payload validation in un_scenario.py
- return stable exit code 2 for user input/schema errors with actionable stderr tags
- preserve compatible JSON output contract on valid runs
- add CLI tests for happy path, invalid schema, invalid JSON, and missing file

Validation:
- python -m pytest -q tests/test_run_scenario_cli.py

Dependency note:
- aligns with schema contract introduced in #67

Closes #68