### PR TITLE
ci: harden maintenance bot with clean secret-missing skip

### DIFF
--- a/.github/workflows/repo_maintenance_bot.yml
+++ b/.github/workflows/repo_maintenance_bot.yml
@@ -35,8 +35,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check required secrets
+        id: secrets
+        env:
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "${GH_APP_ID}" ] || [ -z "${GH_APP_PRIVATE_KEY}" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping maintenance bot: GH_APP_ID or GH_APP_PRIVATE_KEY is not configured."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub App token
         id: app-token
+        if: steps.secrets.outputs.available == 'true'
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.GH_APP_ID }}
@@ -45,18 +59,21 @@ jobs:
           repositories: HUB_Optimus
 
       - name: Checkout
+        if: steps.secrets.outputs.available == 'true'
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Python
+        if: steps.secrets.outputs.available == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Create working branch
         id: vars
+        if: steps.secrets.outputs.available == 'true'
         run: |
           echo "BRANCH=chore/maintenance-${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
           git config user.name "hub-optimus-maintainer[bot]"
@@ -72,15 +89,18 @@ jobs:
           git checkout -b "chore/maintenance-${GITHUB_RUN_NUMBER}"
 
       - name: Run maintenance bot
+        if: steps.secrets.outputs.available == 'true'
         run: |
           python tools/maintenance_bot.py "${{ inputs.mode }}"
 
       - name: Kernel guard (block protected changes unless allowed)
+        if: steps.secrets.outputs.available == 'true'
         run: |
           python tools/kernel_guard.py "${{ inputs.allow_kernel_changes }}"
 
       - name: Commit changes if any
         id: commit
+        if: steps.secrets.outputs.available == 'true'
         run: |
           git add -A
           if git diff --cached --quiet; then
@@ -92,12 +112,12 @@ jobs:
           echo "NO_CHANGES=false" >> $GITHUB_OUTPUT
 
       - name: Push branch
-        if: steps.commit.outputs.NO_CHANGES == 'false'
+        if: steps.secrets.outputs.available == 'true' && steps.commit.outputs.NO_CHANGES == 'false'
         run: |
           git push -u origin "${{ steps.vars.outputs.BRANCH }}"
 
       - name: Create PR automatically
-        if: steps.commit.outputs.NO_CHANGES == 'false'
+        if: steps.secrets.outputs.available == 'true' && steps.commit.outputs.NO_CHANGES == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -112,7 +132,7 @@ jobs:
           echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
 
       - name: "PRO: labels + summary comment"
-        if: steps.commit.outputs.NO_CHANGES == 'false'
+        if: steps.secrets.outputs.available == 'true' && steps.commit.outputs.NO_CHANGES == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
@@ -121,3 +141,7 @@ jobs:
         run: |
           git fetch origin main
           python tools/pr_pro.py
+
+      - name: Skip summary
+        if: steps.secrets.outputs.available != 'true'
+        run: echo "Maintenance workflow skipped cleanly due to missing secrets."


### PR DESCRIPTION
Summary:
- add explicit secret-presence gate for GH_APP_ID and GH_APP_PRIVATE_KEY
- skip token creation and all maintenance steps when secrets are missing
- emit clear skip notices in logs to avoid noisy red failures

Validation:
- workflow YAML parses correctly
- token step is now guarded by if: steps.secrets.outputs.available == 'true'

Closes #69