### PR TITLE
chore: ignore local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ __pycache__/
 *$py.class
 *.so
 .Python
+
+# Local build/test artifacts
+site/
+out_pr41/
+.pytest_cache/


### PR DESCRIPTION
## Summary\n- add local artifact ignores to .gitignore\n- include site/ and out_pr41/\n- include .pytest_cache/ as generated local test artifact\n\n## Validation\n- python -m pytest -q\n- python -m pytest -q -p no:cacheprovider (confirms tests do not require .pytest_cache)