### PR TITLE
docs: clean onboarding links (no content changes)

### DIFF
--- a/docs/ca/00_start_here.md
+++ b/docs/ca/00_start_here.md
@@ -34,16 +34,16 @@ HUB_Optimus exists to break that cycle.
 
 **20 minutes (practitioner):**
 - Core spec (ES, canonical v1):  
-  [01_base_declaracion](../.../../../v1_core/languages/es/01_base_declaracion.md) ? 
-  [02_arquitectura_base](../.../../../v1_core/languages/es/02_arquitectura_base.md) ? 
-  [03_flujo_operativo](../.../../../v1_core/languages/es/03_flujo_operativo.md)
+  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md)
+  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md)
+  [03_flujo_operativo](../../v1_core/languages/es/03_flujo_operativo.md)
 - English reference:  
-  [01_base_declaracion (EN)](../.../../../v1_core/languages/en/01_base_declaracion.md)
+  [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)
 
 **Try it (hands-on):**
-- Template: [Scenario Template](../.../../../v1_core/workflow/04_scenario_template.md)
-- Examples: [Scenario 001](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- Learning loop: [Meta Learning](../.../../../v1_core/workflow/05_meta_learning.md)
+- Template: [Scenario Template](../../v1_core/workflow/04_scenario_template.md)
+- Examples: [Scenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- Learning loop: [Meta Learning](../../v1_core/workflow/05_meta_learning.md)
 <!-- /HUB:TRACKS -->
 
 ## Governance
@@ -77,19 +77,19 @@ HUB_Optimus exists to break that cycle.
 - [README.md](../../README.md)
 
 2) Read the simulator overview:
-- [../../v1_core/workflow/README.md](../.../../../v1_core/workflow/README.md)
+- [../../v1_core/workflow/README.md](../../v1_core/workflow/README.md)
 
 ### If you have 15-30 minutes
 Read the Kernel (English reference):
-1) [../../v1_core/languages/en/01_base_declaracion.md](../.../../../v1_core/languages/en/01_base_declaracion.md)
-2) [../../v1_core/languages/en/02_arquitectura_base.md](../.../../../v1_core/languages/en/02_arquitectura_base.md)
-3) [../../v1_core/languages/en/03_flujo_operativo.md](../.../../../v1_core/languages/en/03_flujo_operativo.md)
+1) [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+2) [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+3) [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 Then try the simulator:
-- [../../v1_core/workflow/04_scenario_template.md](../.../../../v1_core/workflow/04_scenario_template.md)
-- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- [../../v1_core/workflow/05_meta_learning.md](../.../../../v1_core/workflow/05_meta_learning.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
+- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 ---
 

--- a/docs/ca/03_try_a_scenario.md
+++ b/docs/ca/03_try_a_scenario.md
@@ -12,7 +12,7 @@ Estimated time: 10-15 minutes.
 ## Step 1 — Open the scenario template
 
 Open:
-- [../../v1_core/workflow/04_scenario_template.md](../.../../../v1_core/workflow/04_scenario_template.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
 
 Just note the structure:
 - Context
@@ -26,7 +26,7 @@ Just note the structure:
 ## Step 2 — Scenario 001: Partial Ceasefire (false success)
 
 Open:
-- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
 Focus on:
 - What is declared vs what is verified
 - Which incentives are rewarded
@@ -37,7 +37,7 @@ Focus on:
 ## Step 3 — Scenario 002: Verified Ceasefire (structural success)
 
 Open:
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 Focus on:
 - What changed compared to Scenario 001
@@ -64,7 +64,7 @@ It asks:
 ## Step 5 — Learning layer
 
 Read:
-- [../../v1_core/workflow/05_meta_learning.md](../.../../../v1_core/workflow/05_meta_learning.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 This explains how patterns are extracted and remembered.
 
@@ -82,9 +82,9 @@ This is the core of HUB_Optimus.
 ## Next steps
 
 Foundations:
-- [../../v1_core/languages/en/01_base_declaracion.md](../.../../../v1_core/languages/en/01_base_declaracion.md)
-- [../../v1_core/languages/en/02_arquitectura_base.md](../.../../../v1_core/languages/en/02_arquitectura_base.md)
-- [../../v1_core/languages/en/03_flujo_operativo.md](../.../../../v1_core/languages/en/03_flujo_operativo.md)
+- [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+- [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+- [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 To contribute:
 - Read [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/de/00_start_here.md
+++ b/docs/de/00_start_here.md
@@ -94,8 +94,8 @@ Sende diesen Link:
 
 **20 minutes (practitioner):**
 - Core spec (ES, canonical v1):  
-  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md) ? 
-  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md) ? 
+  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md)
+  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md)
   [03_flujo_operativo](../../v1_core/languages/es/03_flujo_operativo.md)
 - English reference:  
   [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)

--- a/docs/es/00_start_here.md
+++ b/docs/es/00_start_here.md
@@ -96,8 +96,8 @@ Envía este enlace:
 
 **20 minutes (practitioner):**
 - Core spec (ES, canonical v1):  
-  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md) ? 
-  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md) ? 
+  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md)
+  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md)
   [03_flujo_operativo](../../v1_core/languages/es/03_flujo_operativo.md)
 - English reference:  
   [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)

--- a/docs/fr/00_start_here.md
+++ b/docs/fr/00_start_here.md
@@ -34,16 +34,16 @@ HUB_Optimus exists to break that cycle.
 
 **20 minutes (practitioner):**
 - Core spec (ES, canonical v1):  
-  [01_base_declaracion](../.../../../v1_core/languages/es/01_base_declaracion.md) ? 
-  [02_arquitectura_base](../.../../../v1_core/languages/es/02_arquitectura_base.md) ? 
-  [03_flujo_operativo](../.../../../v1_core/languages/es/03_flujo_operativo.md)
+  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md)
+  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md)
+  [03_flujo_operativo](../../v1_core/languages/es/03_flujo_operativo.md)
 - English reference:  
-  [01_base_declaracion (EN)](../.../../../v1_core/languages/en/01_base_declaracion.md)
+  [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)
 
 **Try it (hands-on):**
-- Template: [Scenario Template](../.../../../v1_core/workflow/04_scenario_template.md)
-- Examples: [Scenario 001](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- Learning loop: [Meta Learning](../.../../../v1_core/workflow/05_meta_learning.md)
+- Template: [Scenario Template](../../v1_core/workflow/04_scenario_template.md)
+- Examples: [Scenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- Learning loop: [Meta Learning](../../v1_core/workflow/05_meta_learning.md)
 <!-- /HUB:TRACKS -->
 
 ## Governance
@@ -77,19 +77,19 @@ HUB_Optimus exists to break that cycle.
 - [README.md](../../README.md)
 
 2) Read the simulator overview:
-- [../../v1_core/workflow/README.md](../.../../../v1_core/workflow/README.md)
+- [../../v1_core/workflow/README.md](../../v1_core/workflow/README.md)
 
 ### If you have 15-30 minutes
 Read the Kernel (English reference):
-1) [../../v1_core/languages/en/01_base_declaracion.md](../.../../../v1_core/languages/en/01_base_declaracion.md)
-2) [../../v1_core/languages/en/02_arquitectura_base.md](../.../../../v1_core/languages/en/02_arquitectura_base.md)
-3) [../../v1_core/languages/en/03_flujo_operativo.md](../.../../../v1_core/languages/en/03_flujo_operativo.md)
+1) [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+2) [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+3) [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 Then try the simulator:
-- [../../v1_core/workflow/04_scenario_template.md](../.../../../v1_core/workflow/04_scenario_template.md)
-- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- [../../v1_core/workflow/05_meta_learning.md](../.../../../v1_core/workflow/05_meta_learning.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
+- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 ---
 

--- a/docs/fr/03_try_a_scenario.md
+++ b/docs/fr/03_try_a_scenario.md
@@ -12,7 +12,7 @@ Estimated time: 10-15 minutes.
 ## Step 1 — Open the scenario template
 
 Open:
-- [../../v1_core/workflow/04_scenario_template.md](../.../../../v1_core/workflow/04_scenario_template.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
 
 Just note the structure:
 - Context
@@ -26,7 +26,7 @@ Just note the structure:
 ## Step 2 — Scenario 001: Partial Ceasefire (false success)
 
 Open:
-- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
 Focus on:
 - What is declared vs what is verified
 - Which incentives are rewarded
@@ -37,7 +37,7 @@ Focus on:
 ## Step 3 — Scenario 002: Verified Ceasefire (structural success)
 
 Open:
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 Focus on:
 - What changed compared to Scenario 001
@@ -64,7 +64,7 @@ It asks:
 ## Step 5 — Learning layer
 
 Read:
-- [../../v1_core/workflow/05_meta_learning.md](../.../../../v1_core/workflow/05_meta_learning.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 This explains how patterns are extracted and remembered.
 
@@ -82,9 +82,9 @@ This is the core of HUB_Optimus.
 ## Next steps
 
 Foundations:
-- [../../v1_core/languages/en/01_base_declaracion.md](../.../../../v1_core/languages/en/01_base_declaracion.md)
-- [../../v1_core/languages/en/02_arquitectura_base.md](../.../../../v1_core/languages/en/02_arquitectura_base.md)
-- [../../v1_core/languages/en/03_flujo_operativo.md](../.../../../v1_core/languages/en/03_flujo_operativo.md)
+- [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+- [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+- [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 To contribute:
 - Read [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/ru/00_start_here.md
+++ b/docs/ru/00_start_here.md
@@ -34,16 +34,16 @@ HUB_Optimus exists to break that cycle.
 
 **20 minutes (practitioner):**
 - Core spec (ES, canonical v1):  
-  [01_base_declaracion](../.../../../v1_core/languages/es/01_base_declaracion.md) ? 
-  [02_arquitectura_base](../.../../../v1_core/languages/es/02_arquitectura_base.md) ? 
-  [03_flujo_operativo](../.../../../v1_core/languages/es/03_flujo_operativo.md)
+  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md)
+  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md)
+  [03_flujo_operativo](../../v1_core/languages/es/03_flujo_operativo.md)
 - English reference:  
-  [01_base_declaracion (EN)](../.../../../v1_core/languages/en/01_base_declaracion.md)
+  [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)
 
 **Try it (hands-on):**
-- Template: [Scenario Template](../.../../../v1_core/workflow/04_scenario_template.md)
-- Examples: [Scenario 001](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- Learning loop: [Meta Learning](../.../../../v1_core/workflow/05_meta_learning.md)
+- Template: [Scenario Template](../../v1_core/workflow/04_scenario_template.md)
+- Examples: [Scenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- Learning loop: [Meta Learning](../../v1_core/workflow/05_meta_learning.md)
 <!-- /HUB:TRACKS -->
 
 ## Governance
@@ -77,19 +77,19 @@ HUB_Optimus exists to break that cycle.
 - [README.md](../../README.md)
 
 2) Read the simulator overview:
-- [../../v1_core/workflow/README.md](../.../../../v1_core/workflow/README.md)
+- [../../v1_core/workflow/README.md](../../v1_core/workflow/README.md)
 
 ### If you have 15-30 minutes
 Read the Kernel (English reference):
-1) [../../v1_core/languages/en/01_base_declaracion.md](../.../../../v1_core/languages/en/01_base_declaracion.md)
-2) [../../v1_core/languages/en/02_arquitectura_base.md](../.../../../v1_core/languages/en/02_arquitectura_base.md)
-3) [../../v1_core/languages/en/03_flujo_operativo.md](../.../../../v1_core/languages/en/03_flujo_operativo.md)
+1) [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+2) [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+3) [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 Then try the simulator:
-- [../../v1_core/workflow/04_scenario_template.md](../.../../../v1_core/workflow/04_scenario_template.md)
-- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- [../../v1_core/workflow/05_meta_learning.md](../.../../../v1_core/workflow/05_meta_learning.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
+- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 ---
 

--- a/docs/ru/03_try_a_scenario.md
+++ b/docs/ru/03_try_a_scenario.md
@@ -12,7 +12,7 @@ Estimated time: 10-15 minutes.
 ## Step 1 — Open the scenario template
 
 Open:
-- [../../v1_core/workflow/04_scenario_template.md](../.../../../v1_core/workflow/04_scenario_template.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
 
 Just note the structure:
 - Context
@@ -26,7 +26,7 @@ Just note the structure:
 ## Step 2 — Scenario 001: Partial Ceasefire (false success)
 
 Open:
-- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../.../../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
 Focus on:
 - What is declared vs what is verified
 - Which incentives are rewarded
@@ -37,7 +37,7 @@ Focus on:
 ## Step 3 — Scenario 002: Verified Ceasefire (structural success)
 
 Open:
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../.../../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 Focus on:
 - What changed compared to Scenario 001
@@ -64,7 +64,7 @@ It asks:
 ## Step 5 — Learning layer
 
 Read:
-- [../../v1_core/workflow/05_meta_learning.md](../.../../../v1_core/workflow/05_meta_learning.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 This explains how patterns are extracted and remembered.
 
@@ -82,9 +82,9 @@ This is the core of HUB_Optimus.
 ## Next steps
 
 Foundations:
-- [../../v1_core/languages/en/01_base_declaracion.md](../.../../../v1_core/languages/en/01_base_declaracion.md)
-- [../../v1_core/languages/en/02_arquitectura_base.md](../.../../../v1_core/languages/en/02_arquitectura_base.md)
-- [../../v1_core/languages/en/03_flujo_operativo.md](../.../../../v1_core/languages/en/03_flujo_operativo.md)
+- [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+- [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+- [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 To contribute:
 - Read [CONTRIBUTING.md](../../CONTRIBUTING.md)


### PR DESCRIPTION
## Scope\n- clean malformed relative links (e.g. ../.../../../)\n- remove trailing ? in links\n- only onboarding docs (