### PR TITLE
docs: align canonical source-of-truth across repo

### DIFF
--- a/docs/00_start_here.md
+++ b/docs/00_start_here.md
@@ -1,5 +1,7 @@
 # Start Here — HUB_Optimus in 10 minutes
 
+> **Source-of-truth:** For HUB_Optimus v1, the canonical source is `v1_core/languages/es/`. English and other languages are reference or parity translations. If documentation conflicts, `docs/context/STATUS.md` is the authoritative governance record.
+
 ## What is HUB_Optimus?
 HUB_Optimus is an open, integrity-first framework that helps evaluate diplomatic and institutional decisions using:
 - systemic incentive analysis,

--- a/docs/context/STATUS.md
+++ b/docs/context/STATUS.md
@@ -10,7 +10,9 @@
 - Stub languages: **zh, he** (directory + governance stub only; full translation pending)
 
 **Source-of-truth rule:**
-- If repository docs conflict, this file wins.
+- If repository docs conflict, **this file (`docs/context/STATUS.md`) wins**.
+- For HUB_Optimus v1, the canonical source-of-truth is `v1_core/languages/es/`.
+- English and other languages are reference or parity translations unless explicitly stated otherwise.
 
 **Planned switch (later, not now):**
 - Once en reaches stable parity, we may declare **en as canonical** for a future version (v1.1 or v2).

--- a/docs/es/00_start_here.md
+++ b/docs/es/00_start_here.md
@@ -1,4 +1,4 @@
-> 🇬🇧 English source: [docs/00_start_here.md](../00_start_here.md)
+> 🇬🇧 English version: [docs/00_start_here.md](../00_start_here.md)
 
 # HUB_Optimus — Start Here (ES)
 


### PR DESCRIPTION
## Summary
Resolves source-of-truth contradictions across repo documentation.

Closes #92

## Changes
1. **docs/es/00_start_here.md**  Changed misleading `English source` label to `English version`. ES is canonical, not a translation of EN.
2. **docs/00_start_here.md**  Added explicit source-of-truth notice at the top of the EN onboarding entry point.
3. **docs/context/STATUS.md**  Clarified the source-of-truth rule with the full canonical policy statement.

## Policy applied
> For HUB_Optimus v1, the canonical source-of-truth is `v1_core/languages/es/`.
> English and other languages are reference or parity translations unless explicitly stated otherwise.
> If documentation conflicts, `docs/context/STATUS.md` is the authoritative governance record.

## Rationale (Layer 0)
- Integrity first: canonical source must be unambiguous
- Evaluation over narrative: labeling matters for governance clarity
- Anti-capture: prevents drift via translation ambiguity

## Affected files
- docs/es/00_start_here.md
- docs/00_start_here.md
- docs/context/STATUS.md

## Risks
None. Minimal text changes, no structural or kernel modifications.