### PR TITLE
test: add runner contract regression suite (fixes #98)

### DIFF
--- a/tests/fixtures/extra_field.json
+++ b/tests/fixtures/extra_field.json
@@ -1,0 +1,8 @@
+{
+  "title": "Valid title",
+  "description": "Valid description",
+  "roles": [{"name": "A", "role": "mediator"}],
+  "success_criteria": {"threshold": 5},
+  "max_rounds": 3,
+  "unexpected_field": true
+}

--- a/tests/fixtures/whitespace_title.json
+++ b/tests/fixtures/whitespace_title.json
@@ -1,0 +1,7 @@
+{
+  "title": "   ",
+  "description": "Valid description",
+  "roles": [{"name": "A", "role": "mediator"}],
+  "success_criteria": {"threshold": 5},
+  "max_rounds": 3
+}

--- a/tests/test_regression_runner.py
+++ b/tests/test_regression_runner.py
@@ -1,0 +1,193 @@
+"""
+Regression suite for the run_scenario.py runner contract.
+
+Covers gaps not addressed by test_run_scenario_cli.py:
+  - Whitespace-only string rejection  (schema pattern constraint from PR #89)
+  - Additional-properties rejection   (schema additionalProperties: false)
+  - Invalid output path               (write-error handling from PR #90)
+  - Byte-identical deterministic output
+  - Output format contract             (trailing newline, sorted keys, UTF-8)
+  - No-arguments edge case
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCENARIO = REPO_ROOT / "run_scenario.py"
+EXAMPLE = REPO_ROOT / "example_scenario.json"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [sys.executable, str(RUN_SCENARIO), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema rejection: whitespace-only strings
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceRejection:
+    """Verify the pattern constraint rejects whitespace-only strings."""
+
+    def test_whitespace_only_title_rejected(self) -> None:
+        proc = _run_cli("--scenario", str(FIXTURES / "whitespace_title.json"))
+        assert proc.returncode == 2
+        assert "[schema-error]" in proc.stderr
+        assert "title" in proc.stderr
+
+    def test_whitespace_only_role_name_rejected(self, tmp_path: Path) -> None:
+        scenario = {
+            "title": "Valid",
+            "description": "Valid",
+            "roles": [{"name": "  ", "role": "mediator"}],
+            "success_criteria": {"k": 1},
+            "max_rounds": 3,
+        }
+        f = tmp_path / "ws_role.json"
+        f.write_text(json.dumps(scenario), encoding="utf-8")
+        proc = _run_cli("--scenario", str(f))
+        assert proc.returncode == 2
+        assert "[schema-error]" in proc.stderr
+
+    def test_whitespace_only_description_rejected(self, tmp_path: Path) -> None:
+        scenario = {
+            "title": "Valid",
+            "description": "\t\n ",
+            "roles": [{"name": "A", "role": "r"}],
+            "success_criteria": {"k": 1},
+            "max_rounds": 3,
+        }
+        f = tmp_path / "ws_desc.json"
+        f.write_text(json.dumps(scenario), encoding="utf-8")
+        proc = _run_cli("--scenario", str(f))
+        assert proc.returncode == 2
+        assert "[schema-error]" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Schema rejection: additional properties
+# ---------------------------------------------------------------------------
+
+class TestAdditionalPropertiesRejection:
+    """Verify additionalProperties: false blocks unknown keys."""
+
+    def test_extra_top_level_field_rejected(self) -> None:
+        proc = _run_cli("--scenario", str(FIXTURES / "extra_field.json"))
+        assert proc.returncode == 2
+        assert "[schema-error]" in proc.stderr
+        assert "unexpected_field" in proc.stderr.lower() or "additional" in proc.stderr.lower()
+
+    def test_extra_role_field_rejected(self, tmp_path: Path) -> None:
+        scenario = {
+            "title": "Valid",
+            "description": "Valid",
+            "roles": [{"name": "A", "role": "r", "bonus": True}],
+            "success_criteria": {"k": 1},
+            "max_rounds": 3,
+        }
+        f = tmp_path / "extra_role.json"
+        f.write_text(json.dumps(scenario), encoding="utf-8")
+        proc = _run_cli("--scenario", str(f))
+        assert proc.returncode == 2
+        assert "[schema-error]" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Input errors: write failures
+# ---------------------------------------------------------------------------
+
+class TestOutputWriteError:
+    """Verify graceful handling when the output path is not writable."""
+
+    def test_invalid_output_dir_returns_input_error(self, tmp_path: Path) -> None:
+        bad_output = tmp_path / "no_such_dir" / "deep" / "out.json"
+        proc = _run_cli(
+            "--scenario", str(EXAMPLE),
+            "--output", str(bad_output),
+            "--seed", "42",
+        )
+        assert proc.returncode == 2
+        assert "[input-error]" in proc.stderr
+        assert "cannot write output file" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Input errors: no arguments
+# ---------------------------------------------------------------------------
+
+class TestNoArguments:
+    """Verify the runner fails cleanly with no arguments."""
+
+    def test_no_args_returns_error(self) -> None:
+        proc = _run_cli()
+        assert proc.returncode == 2
+        assert "[input-error]" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Output format contract
+# ---------------------------------------------------------------------------
+
+class TestOutputFormatContract:
+    """Verify the exact output format produced by the runner."""
+
+    @pytest.fixture()
+    def result_file(self, tmp_path: Path) -> Path:
+        output = tmp_path / "result.json"
+        proc = _run_cli(
+            "--scenario", str(EXAMPLE),
+            "--output", str(output),
+            "--seed", "42",
+        )
+        assert proc.returncode == 0
+        return output
+
+    def test_output_has_trailing_newline(self, result_file: Path) -> None:
+        raw = result_file.read_bytes()
+        assert raw.endswith(b"\n")
+        assert not raw.endswith(b"\n\n")  # exactly one trailing newline
+
+    def test_output_is_valid_utf8(self, result_file: Path) -> None:
+        raw = result_file.read_bytes()
+        raw.decode("utf-8")  # raises UnicodeDecodeError if not valid
+
+    def test_output_keys_are_sorted(self, result_file: Path) -> None:
+        payload = json.loads(result_file.read_text(encoding="utf-8"))
+        assert list(payload.keys()) == sorted(payload.keys())
+
+    def test_output_file_is_byte_identical_across_runs(self, tmp_path: Path) -> None:
+        out_a = tmp_path / "a.json"
+        out_b = tmp_path / "b.json"
+
+        proc_a = _run_cli(
+            "--scenario", str(EXAMPLE),
+            "--output", str(out_a),
+            "--seed", "42",
+        )
+        proc_b = _run_cli(
+            "--scenario", str(EXAMPLE),
+            "--output", str(out_b),
+            "--seed", "42",
+        )
+        assert proc_a.returncode == 0
+        assert proc_b.returncode == 0
+        assert out_a.read_bytes() == out_b.read_bytes()


### PR DESCRIPTION
## Summary

Adds 11 regression tests covering gaps in the existing test suite, organized in 5 test classes that protect the runner contract end-to-end.

Closes #98.

## Coverage map

| Test class | What it guards | Origin |
|---|---|---|
| `TestWhitespaceRejection` (3 tests) | `pattern: ".*\\S.*"` on title, description, role name | PR #89 constraint |
| `TestAdditionalPropertiesRejection` (2 tests) | `additionalProperties: false` at top-level and role level | Schema contract |
| `TestOutputWriteError` (1 test) | `try/except OSError` on output write | PR #90 fix |
| `TestNoArguments` (1 test) | Clean `[input-error]` when no args provided | Edge case |
| `TestOutputFormatContract` (4 tests) | Trailing newline, UTF-8, sorted keys, byte-identical determinism | Output contract |

## Files changed

- **`tests/test_regression_runner.py`** — 11 new tests in 5 classes
- **`tests/fixtures/whitespace_title.json`** — fixture: whitespace-only title
- **`tests/fixtures/extra_field.json`** — fixture: unknown top-level property

## Before / After

| Metric | Before | After |
|---|---|---|
| Total tests | 7 | 18 |
| Whitespace rejection coverage | 0 | 3 tests |
| Output format coverage | 0 | 4 tests |
| Write-error coverage | 0 | 1 test |

## Verification

```
18 passed in 9.94s
```

All existing tests remain green. No changes to production code.</body>
</invoke>