### PR TITLE
feat: add benchmark pack v0 with 3 canonical scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ __pycache__/
 site/
 out_pr41/
 .pytest_cache/
+
+# Benchmark runner temporary outputs
+*.actual.json

--- a/benchmarks/expected/ceasefire_basic.json
+++ b/benchmarks/expected/ceasefire_basic.json
@@ -1,0 +1,23 @@
+{
+  "detail": "Success criteria met at round 2",
+  "history": [
+    {
+      "Faction_A": {
+        "offer": 1
+      },
+      "Faction_B": {
+        "offer": 2
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 4
+      },
+      "Faction_B": {
+        "offer": 5
+      }
+    }
+  ],
+  "rounds": 2,
+  "status": "success"
+}

--- a/benchmarks/expected/ceasefire_failure.json
+++ b/benchmarks/expected/ceasefire_failure.json
@@ -1,0 +1,31 @@
+{
+  "detail": "Max rounds reached without meeting success criteria",
+  "history": [
+    {
+      "Faction_A": {
+        "offer": 1
+      },
+      "Faction_B": {
+        "offer": 2
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 4
+      },
+      "Faction_B": {
+        "offer": 5
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 3
+      },
+      "Faction_B": {
+        "offer": 2
+      }
+    }
+  ],
+  "rounds": 3,
+  "status": "failure"
+}

--- a/benchmarks/expected/ceasefire_fragile.json
+++ b/benchmarks/expected/ceasefire_fragile.json
@@ -1,0 +1,29 @@
+{
+  "detail": "Success criteria met at round 2",
+  "history": [
+    {
+      "Faction_A": {
+        "offer": 1
+      },
+      "Faction_B": {
+        "offer": 2
+      },
+      "Mediator": {
+        "offer": 4
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 5
+      },
+      "Faction_B": {
+        "offer": 3
+      },
+      "Mediator": {
+        "offer": 2
+      }
+    }
+  ],
+  "rounds": 2,
+  "status": "success"
+}

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,0 +1,105 @@
+"""
+Benchmark runner for HUB_Optimus.
+
+Executes every scenario in benchmarks/scenarios/ through run_scenario.py
+with seed 42 and compares the output byte-for-byte against the
+corresponding file in benchmarks/expected/.
+
+Exit codes:
+  0  all benchmarks match
+  1  at least one mismatch or missing expected file
+
+Usage:
+  python benchmarks/run_benchmarks.py          # run all
+  python benchmarks/run_benchmarks.py basic     # run only scenarios containing "basic"
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+BENCHMARKS_DIR = Path(__file__).resolve().parent
+SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
+EXPECTED_DIR = BENCHMARKS_DIR / "expected"
+REPO_ROOT = BENCHMARKS_DIR.parent
+RUNNER = REPO_ROOT / "run_scenario.py"
+SEED = "42"
+
+
+def run_benchmark(scenario: Path, actual_output: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            str(scenario),
+            "--output",
+            str(actual_output),
+            "--seed",
+            SEED,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+
+def main() -> int:
+    name_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    scenarios = sorted(SCENARIOS_DIR.glob("*.json"))
+    if name_filter:
+        scenarios = [s for s in scenarios if name_filter in s.stem]
+
+    if not scenarios:
+        print("No scenarios found.", file=sys.stderr)
+        return 1
+
+    passed = 0
+    failed = 0
+
+    for scenario in scenarios:
+        label = scenario.stem
+        expected = EXPECTED_DIR / scenario.name
+
+        if not expected.is_file():
+            print(f"  SKIP  {label}  (no expected file)")
+            failed += 1
+            continue
+
+        actual = scenario.with_suffix(".actual.json")
+        try:
+            proc = run_benchmark(scenario, actual)
+            if proc.returncode != 0:
+                print(f"  FAIL  {label}  runner exited {proc.returncode}")
+                print(f"        stderr: {proc.stderr.strip()}")
+                failed += 1
+                continue
+
+            expected_bytes = expected.read_bytes()
+            actual_bytes = actual.read_bytes()
+
+            if actual_bytes == expected_bytes:
+                print(f"  PASS  {label}")
+                passed += 1
+            else:
+                print(f"  FAIL  {label}  output differs from expected")
+                failed += 1
+        finally:
+            if actual.exists():
+                actual.unlink()
+
+    print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/scenarios/ceasefire_basic.json
+++ b/benchmarks/scenarios/ceasefire_basic.json
@@ -1,0 +1,10 @@
+{
+  "title": "Basic ceasefire negotiation",
+  "description": "Two factions negotiate a straightforward ceasefire with compatible objectives. Low conflict intensity, high convergence potential.",
+  "roles": [
+    {"name": "Faction_A", "role": "negotiator"},
+    {"name": "Faction_B", "role": "negotiator"}
+  ],
+  "success_criteria": {"offer": 5},
+  "max_rounds": 5
+}

--- a/benchmarks/scenarios/ceasefire_failure.json
+++ b/benchmarks/scenarios/ceasefire_failure.json
@@ -1,0 +1,10 @@
+{
+  "title": "Irreconcilable territorial dispute",
+  "description": "Two factions with mutually exclusive demands over full territorial control. No feasible agreement exists under current constraints.",
+  "roles": [
+    {"name": "Faction_A", "role": "hardliner"},
+    {"name": "Faction_B", "role": "hardliner"}
+  ],
+  "success_criteria": {"offer": 99},
+  "max_rounds": 3
+}

--- a/benchmarks/scenarios/ceasefire_fragile.json
+++ b/benchmarks/scenarios/ceasefire_fragile.json
@@ -1,0 +1,11 @@
+{
+  "title": "Fragile ceasefire under pressure",
+  "description": "Two factions with partially conflicting objectives attempt a ceasefire under external mediation. A third-party mediator increases complexity but limited rounds constrain convergence.",
+  "roles": [
+    {"name": "Faction_A", "role": "negotiator"},
+    {"name": "Faction_B", "role": "negotiator"},
+    {"name": "Mediator", "role": "mediator"}
+  ],
+  "success_criteria": {"offer": 5},
+  "max_rounds": 3
+}


### PR DESCRIPTION
## Summary

Introduces the first reproducible benchmark pack for HUB_Optimus: three canonical scenarios with versioned expected outputs and a runner script for byte-level comparison.

## Structure

```
benchmarks/
  scenarios/           # input scenarios (schema-valid JSON)
    ceasefire_basic.json
    ceasefire_fragile.json
    ceasefire_failure.json
  expected/            # frozen expected outputs (seed 42)
    ceasefire_basic.json
    ceasefire_fragile.json
    ceasefire_failure.json
  run_benchmarks.py    # runner: scenario → runner → compare with expected
```

## The 3 canonical scenarios

| Scenario | Actors | success_criteria | max_rounds | Outcome | Meaning |
|---|---|---|---|---|---|
| **basic** | 2 negotiators | `offer: 5` | 5 | success at round 2 | Stable convergence with margin |
| **fragile** | 2 negotiators + mediator | `offer: 5` | 3 | success at round 2 | Convergence under complexity pressure |
| **failure** | 2 hardliners | `offer: 99` | 3 | failure (3/3) | Structurally impossible criterion |

## Design rationale

- **Seed 42** for all scenarios — deterministic, reproducible, byte-identical across runs
- **`offer: 99`** in failure scenario is unreachable by the default policy (range 1-5), guaranteeing structural failure
- **3 actors** in fragile scenario changes the RNG path, producing distinct outputs from basic
- Expected outputs are version-controlled — any simulator change that alters output will be immediately visible via diff

## Runner usage

```bash
python benchmarks/run_benchmarks.py           # run all
python benchmarks/run_benchmarks.py basic      # filter by name
```

Output:
```
  PASS  ceasefire_basic
  PASS  ceasefire_failure
  PASS  ceasefire_fragile

3 passed, 0 failed, 3 total
```

## Files changed

- **`benchmarks/scenarios/*.json`** — 3 scenario definitions
- **`benchmarks/expected/*.json`** — 3 frozen expected outputs
- **`benchmarks/run_benchmarks.py`** — benchmark runner (byte comparison)
- **`.gitignore`** — added `*.actual.json` to ignore temporary benchmark artifacts

## Verification

- 3/3 benchmarks pass
- 18/18 existing tests remain green
- No production code changes