### PR TITLE
chore: add issue forms and PR template v2 (fixes #99)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Report a bug in the simulator, runner, or tooling
+labels: [bug]
+body:
+  - type: input
+    id: component
+    attributes:
+      label: Affected component
+      description: Which part of the system is affected?
+      placeholder: "e.g. run_scenario.py, hub_optimus_simulator.py, CI workflow"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened, and what did you expect instead?
+      placeholder: |
+        **What happened:**
+        ...
+
+        **What I expected:**
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps to trigger the bug.
+      placeholder: |
+        1. Run `python run_scenario.py ...`
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, relevant details.
+      placeholder: |
+        - OS: Windows 11 / Ubuntu 24.04
+        - Python: 3.12.x
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output or logs
+      description: Paste any error messages or logs.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/Voxterrae/HUB_Optimus/blob/main/CONTRIBUTING.md
+    about: Read the contribution guidelines before opening an issue.

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,42 @@
+name: Documentation improvement
+description: Suggest a fix or improvement to documentation
+labels: [documentation]
+body:
+  - type: input
+    id: file
+    attributes:
+      label: Affected file(s)
+      description: Which document(s) need work?
+      placeholder: "e.g. docs/00_start_here.md, CONTRIBUTING.md"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Type of improvement
+      options:
+        - Broken link
+        - Typo / grammar
+        - Unclear or misleading content
+        - Missing information
+        - Translation issue
+        - Formatting
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong and what should change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+      description: If you already know the fix, describe or paste it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/rfc_governance.yml
+++ b/.github/ISSUE_TEMPLATE/rfc_governance.yml
@@ -1,0 +1,55 @@
+name: RFC / Governance proposal
+description: Propose a change to governance, Kernel, or project structure
+labels: [governance, needs-rfc]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Governance proposals are held to the highest standard.
+        Changes must be justified against Layer 0 principles and include impact analysis.
+        See [CHARTER](../../docs/governance/CHARTER.md) and [KERNEL](../../docs/governance/KERNEL.md).
+
+  - type: input
+    id: scope
+    attributes:
+      label: Scope
+      description: What area does this proposal affect?
+      placeholder: "e.g. Kernel Layer 0, CODEOWNERS policy, translation workflow"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the proposed change clearly and precisely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: Why is this change necessary? Reference Layer 0 principles where applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact analysis
+      description: What does this change affect? What could go wrong?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: integrity
+    attributes:
+      label: Integrity check
+      options:
+        - label: This proposal preserves Layer 0 principles
+          required: true
+        - label: This proposal does not introduce coercive mechanisms
+          required: true
+        - label: This proposal prioritizes medium/long-term stability over short-term optics
+          required: true

--- a/.github/ISSUE_TEMPLATE/scenario_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/scenario_contribution.yml
@@ -1,0 +1,64 @@
+name: Scenario contribution
+description: Propose a new diplomatic scenario for evaluation
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Scenarios must follow the [canonical template](../../v1_core/workflow/04_scenario_template.md).
+        Every scenario requires: trigger, structural context, incentive analysis,
+        systemic evaluation, historical contrast, Kernel coherence check,
+        final classification, and memory integration notes.
+
+  - type: input
+    id: title
+    attributes:
+      label: Scenario title
+      description: Short descriptive name for the scenario.
+      placeholder: "e.g. SCN-004 — Ceasefire verification under asymmetric intelligence"
+    validations:
+      required: true
+
+  - type: textarea
+    id: trigger
+    attributes:
+      label: Trigger and structural context
+      description: What event or condition triggers this scenario? What is the structural context?
+    validations:
+      required: true
+
+  - type: textarea
+    id: incentives
+    attributes:
+      label: Incentive analysis
+      description: What incentive structures are at play? Where are the misalignments?
+    validations:
+      required: true
+
+  - type: textarea
+    id: historical
+    attributes:
+      label: Historical contrast
+      description: Which historical patterns does this scenario echo or diverge from?
+    validations:
+      required: true
+
+  - type: textarea
+    id: coherence
+    attributes:
+      label: Kernel coherence check
+      description: Which Layer 0 principles are exercised? Any tensions?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: classification
+    attributes:
+      label: Preliminary classification
+      options:
+        - Structural success
+        - Fragile success
+        - Structural failure
+        - Undetermined
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,48 @@
 ## Summary
-What does this PR change?
+
+<!-- What does this PR change? One or two sentences. -->
+
+Fixes #
 
 ## Type of change
+
 - [ ] Documentation / formatting
 - [ ] New scenario
 - [ ] Meta-learning update
+- [ ] Tooling / CI
 - [ ] Kernel change (high scrutiny)
 
+## Scope check
+
+- [ ] This PR has a single objective
+- [ ] No unrelated formatting, refactoring, or structural changes
+
 ## Rationale
-Why is this change necessary?
+
+<!-- Why is this change necessary? -->
 
 ## Kernel coherence
+
 - [ ] Preserves Layer 0 principles
 - [ ] No narrative override of evaluation
 - [ ] No coercive mechanisms introduced
 - [ ] No personal scapegoating
 
 ## If scenario-related
+
 - [ ] Uses canonical template
 - [ ] Includes incentive analysis
 - [ ] Includes historical contrast
 - [ ] Includes final classification
 - [ ] Includes memory integration
 
+## Quality checklist
+
+- [ ] Tests pass (`pytest`)
+- [ ] Links are valid (no broken relative links)
+- [ ] No encoding issues (UTF-8, no mojibake)
+- [ ] Translations updated if Kernel files changed (`es` + `en` minimum)
+
 ## Risk
-What could go wrong? How is it mitigated?
+
+<!-- What could go wrong? How is it mitigated? -->


### PR DESCRIPTION
## Summary

Adds structured issue forms and updates the PR template to enforce contribution quality.

Fixes #99

## What's included

### Issue forms (4)
- **Bug report**  component, reproduction steps, environment, logs
- **Documentation improvement**  file, type dropdown, description
- **Scenario contribution**  structured fields matching the canonical template
- **RFC / Governance proposal**  impact analysis, integrity checkboxes

### Template chooser
- Blank issues disabled
- Link to CONTRIBUTING.md

### PR template v2
- Added `Fixes #` reference field
- Added **Scope check** (single objective enforcement)
- Added **Tooling / CI** change type
- Added **Quality checklist** (tests, links, encoding, translations)
- Converted prose prompts to HTML comments

## Rationale

With external contributors appearing (#95 assigned), the repo needs structured intake to prevent scope creep and ensure minimum quality on every contribution.