### PR TITLE
governance: add CODEOWNERS and contributor safe zones (fixes #100)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS — HUB_Optimus
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# ───── Protected zones (require maintainer review) ─────
+
+# Kernel (canonical + parity)
+v1_core/languages/          @Voxterrae
+v1_core/languages/es/       @Voxterrae
+v1_core/languages/en/       @Voxterrae
+
+# Governance documents
+docs/governance/            @Voxterrae
+
+# CI and repo infrastructure
+.github/                    @Voxterrae
+
+# Project root configs
+CONTRIBUTING.md             @Voxterrae
+README.md                   @Voxterrae
+scenario.schema.json        @Voxterrae
+
+# ───── Reviewed zones (maintainer notified) ─────
+
+# Simulator core
+hub_optimus_simulator.py    @Voxterrae
+run_scenario.py             @Voxterrae
+hub_optimus/                @Voxterrae
+
+# Benchmarks (deterministic contract)
+benchmarks/                 @Voxterrae
+
+# ───── Open zones (contributors welcome) ─────
+# No CODEOWNERS entry = no mandatory review gate.
+# Open zones: docs/ (non-governance), tools/, tests/, examples/, legacy/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,39 @@ The active Kernel and simulator.
 
 ---
 
+## 2.1) Contributor zones
+
+### Open zones (contributors welcome, no mandatory review gate)
+
+| Path | What lives here |
+|---|---|
+| `docs/` (non-governance) | Onboarding guides, reading paths, translations |
+| `tools/` | Maintenance scripts, auditing utilities |
+| `tests/` | Regression tests, smoke tests |
+| `examples/` | Example scenarios and usage samples |
+| `legacy/` | Historical v0 materials (read-only — see above) |
+
+### Protected zones (require maintainer review via CODEOWNERS)
+
+| Path | Why it's protected |
+|---|---|
+| `v1_core/languages/` | Kernel specs — canonical (`es`) and parity (`en`) |
+| `docs/governance/` | Charter, consensus process, trust layer |
+| `.github/` | CI, issue forms, PR template, CODEOWNERS |
+| `scenario.schema.json` | Runtime contract — changes break benchmarks |
+| `run_scenario.py`, `hub_optimus_simulator.py` | Simulator core |
+| `benchmarks/` | Deterministic output contract |
+
+### How to pick up an issue
+
+1. Find an issue labelled `good first issue` or in an open zone.
+2. Comment on the issue to signal intent.
+3. Wait for informal assignment (to avoid duplicate work).
+4. Create a branch: `feat/<short-name>` or `chore/<short-name>`.
+5. Open a focused PR linked to the issue (`Fixes #N`).
+
+---
+
 ## 3) Contribution types
 
 ### A) Documentation improvements (low risk)


### PR DESCRIPTION
## Summary

Adds CODEOWNERS file and documents contributor safe zones in CONTRIBUTING.md.

Fixes #100

## What's included

### CODEOWNERS
- **Protected zones** (require @Voxterrae review): Kernel languages, governance docs, CI infra, schema, simulator core, benchmarks
- **Open zones** (no mandatory review gate): docs (non-governance), tools, tests, examples, legacy

### CONTRIBUTING.md update
- New section 2.1 with safe/protected zone tables
- Issue pickup guide (find  comment  branch  PR)

## Rationale

With external contributors now active (#95 assigned), the repo needs clear boundaries. CODEOWNERS enforces review gates on protected paths. The zone documentation lets contributors self-serve without touching sensitive areas.