### PR TITLE
feat: scenario telemetry, family dirs, and lab state

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -84,7 +84,7 @@ def main() -> int:
 
     scenarios = sorted(SCENARIOS_DIR.glob("*.json"))
     if include_generated and GENERATED_DIR.is_dir():
-        scenarios.extend(sorted(GENERATED_DIR.glob("*.json")))
+        scenarios.extend(sorted(GENERATED_DIR.rglob("*.json")))
     if name_filter:
         scenarios = [s for s in scenarios if name_filter in s.stem]
 

--- a/docs/lab_state.md
+++ b/docs/lab_state.md
@@ -1,0 +1,67 @@
+# Lab State
+
+Scientific memory for the HUB_Optimus exploration laboratory.
+
+This document captures what the system has learned from running
+synthetic scenarios — not code changes, but **behavioural observations**.
+
+Update this file when telemetry reveals a new pattern or when a
+previously observed pattern changes after a code modification.
+
+---
+
+## Current state
+
+| Metric | Value |
+|---|---|
+| Generator families | 3 (info_asymmetry, resource_scarcity, incentive_misalignment) |
+| Generated scenarios | 60 (seed 42) |
+| Passed runtime | 60 |
+| Runtime failures | 0 |
+| Schema violations | 0 |
+| Agreements reached | 55 |
+| No agreement | 5 |
+| Avg convergence round | 1.8 |
+
+### Per-family breakdown
+
+| Family | Scenarios | Agreements | Failures | Agreement rate |
+|---|---|---|---|---|
+| info_asymmetry | 20 | 20 | 0 | 100% |
+| incentive_misalignment | 20 | 19 | 1 | 95% |
+| resource_scarcity | 20 | 16 | 4 | 80% |
+
+## Observed patterns
+
+- **Resource scarcity scenarios are failure-prone by design.** Tight
+  round limits (1–3) combined with high thresholds (4–5) make agreement
+  unlikely under the default random-offer policy. 4 of 20 scenarios
+  fail to reach agreement — all with `max_rounds=1`.
+- **Information asymmetry scenarios always converge.** Moderate
+  thresholds (3–5) and more rounds (3–7) give the random policy enough
+  chances to hit the target. 20/20 reach agreement.
+- **Incentive misalignment scenarios have variable actor counts.**
+  The optional mediator role means some scenarios have 2 actors and
+  others have 5, creating a wider behavioural spread. 19/20 converge;
+  the one failure has only 2 rounds available.
+- **Convergence is fast.** Average convergence at round 1.8 means
+  most agreements happen in rounds 1–2, even in scenarios with 5+
+  rounds available. The random policy's uniform distribution over
+  [1, 5] makes a match probable early.
+
+## Questions to investigate
+
+- What is the agreement rate per family under seed 42?
+- Does adding a mediator role measurably change convergence speed?
+- At what `max_rounds` threshold does resource scarcity stop being
+  failure-dominant?
+- Do any scenarios produce the same negotiation history despite
+  different initial configurations? (structural equivalence)
+
+## Methodology notes
+
+- All generated scenarios use seed-controlled randomness (default: 42).
+- Telemetry is collected via `python tools/scenario_telemetry.py`.
+- Results are written to `scenarios/telemetry.json` (per-scenario)
+  and `scenarios/index.json` (aggregate).
+- Both files are gitignored — regenerate locally as needed.

--- a/scenarios/.gitignore
+++ b/scenarios/.gitignore
@@ -1,0 +1,4 @@
+# Telemetry and index are ephemeral — regenerate with:
+#   python tools/scenario_telemetry.py
+telemetry.json
+index.json

--- a/scenarios/generated/.gitignore
+++ b/scenarios/generated/.gitignore
@@ -1,4 +1,5 @@
-# Generated scenarios are ephemeral — regenerate with:
+# Generated scenarios and telemetry are ephemeral — regenerate with:
 #   python tools/scenario_generator/generate_scenarios.py
+#   python tools/scenario_telemetry.py
 *
 !.gitignore

--- a/tools/scenario_generator/generate_scenarios.py
+++ b/tools/scenario_generator/generate_scenarios.py
@@ -128,10 +128,10 @@ FAMILIES = [
 # ── Core generation logic ───────────────────────────────────
 
 
-def generate(count: int, seed: int) -> list[tuple[str, dict]]:
+def generate(count: int, seed: int) -> list[tuple[str, str, dict]]:
     """Generate *count* scenarios (evenly split across families).
 
-    Returns a list of (filename_stem, scenario_dict) pairs.
+    Returns a list of (filename_stem, family_name, scenario_dict) tuples.
     """
     rng = random.Random(seed)
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
@@ -140,7 +140,7 @@ def generate(count: int, seed: int) -> list[tuple[str, dict]]:
     per_family = count // len(FAMILIES)
     remainder = count % len(FAMILIES)
 
-    results: list[tuple[str, dict]] = []
+    results: list[tuple[str, str, dict]] = []
     global_index = 0
 
     for family_index, (family_name, factory) in enumerate(FAMILIES):
@@ -159,17 +159,22 @@ def generate(count: int, seed: int) -> list[tuple[str, dict]]:
                 continue
 
             stem = f"{family_name}_{global_index:03d}"
-            results.append((stem, scenario))
+            results.append((stem, family_name, scenario))
 
     return results
 
 
-def write_scenarios(scenarios: list[tuple[str, dict]], output_dir: Path) -> int:
-    """Write scenarios to JSON files.  Returns the number of files written."""
+def write_scenarios(scenarios: list[tuple[str, str, dict]], output_dir: Path) -> int:
+    """Write scenarios to JSON files organised by family subdirectory.
+
+    Returns the number of files written.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     written = 0
-    for stem, scenario in scenarios:
-        path = output_dir / f"{stem}.json"
+    for stem, family, scenario in scenarios:
+        family_dir = output_dir / family
+        family_dir.mkdir(parents=True, exist_ok=True)
+        path = family_dir / f"{stem}.json"
         path.write_text(
             json.dumps(scenario, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
             encoding="utf-8",

--- a/tools/scenario_telemetry.py
+++ b/tools/scenario_telemetry.py
@@ -1,0 +1,292 @@
+"""
+Scenario telemetry collector for HUB_Optimus.
+
+Runs every scenario in a target directory through the simulator, captures
+structured telemetry per execution, and writes:
+
+  scenarios/telemetry.json   — array of per-scenario records
+  scenarios/index.json       — aggregate statistics
+
+Each telemetry record captures:
+  scenario_id, family, actors, max_rounds, result_status,
+  rounds_used, convergence_round, schema_valid, runtime_error
+
+Usage:
+  python tools/scenario_telemetry.py                          # default dirs
+  python tools/scenario_telemetry.py --scenario-dir DIR       # custom input
+  python tools/scenario_telemetry.py --seed 99                # different seed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNNER = REPO_ROOT / "run_scenario.py"
+SCHEMA_PATH = REPO_ROOT / "scenario.schema.json"
+DEFAULT_SCENARIO_DIR = REPO_ROOT / "scenarios" / "generated"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "scenarios"
+SEED = "42"
+
+
+# ── Telemetry collection ───────────────────────────────────
+
+
+def _infer_family(path: Path) -> str:
+    """Infer the scenario family from its parent directory or filename."""
+    # If organized in family subdirectories, use the parent dir name
+    parent = path.parent.name
+    if parent != "generated":
+        return parent
+    # Fall back to filename prefix (e.g. info_asymmetry_001 → info_asymmetry)
+    parts = path.stem.rsplit("_", 1)
+    return parts[0] if len(parts) == 2 and parts[1].isdigit() else path.stem
+
+
+def _validate_schema(payload: Any) -> bool:
+    """Check if the scenario payload passes schema validation."""
+    import jsonschema
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    return not list(validator.iter_errors(payload))
+
+
+def collect_one(scenario_path: Path, seed: str) -> dict[str, Any]:
+    """Run one scenario and return a telemetry record."""
+    scenario_id = scenario_path.stem
+    family = _infer_family(scenario_path)
+
+    record: dict[str, Any] = {
+        "scenario_id": scenario_id,
+        "family": family,
+        "actors": 0,
+        "max_rounds": 0,
+        "result_status": "error",
+        "rounds_used": 0,
+        "convergence_round": None,
+        "schema_valid": False,
+        "runtime_error": True,
+    }
+
+    # Load and validate schema
+    try:
+        payload = json.loads(scenario_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return record
+
+    record["schema_valid"] = _validate_schema(payload)
+    record["actors"] = len(payload.get("roles", []))
+    record["max_rounds"] = payload.get("max_rounds", 0)
+
+    if not record["schema_valid"]:
+        return record
+
+    # Run through the simulator
+    actual = scenario_path.with_suffix(".telemetry_tmp.json")
+    try:
+        env = os.environ.copy()
+        env["PYTHONIOENCODING"] = "utf-8"
+        proc = subprocess.run(
+            [
+                sys.executable, str(RUNNER),
+                str(scenario_path),
+                "--output", str(actual),
+                "--seed", seed,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            env=env, check=False,
+        )
+
+        if proc.returncode != 0:
+            return record
+
+        record["runtime_error"] = False
+        result = json.loads(actual.read_text(encoding="utf-8"))
+        record["result_status"] = result.get("status", "unknown")
+        record["rounds_used"] = result.get("rounds", 0)
+
+        if result.get("status") == "success":
+            record["convergence_round"] = result.get("rounds")
+    except (json.JSONDecodeError, OSError):
+        pass
+    finally:
+        if actual.exists():
+            actual.unlink()
+
+    return record
+
+
+def collect_all(scenario_dir: Path, seed: str) -> list[dict[str, Any]]:
+    """Collect telemetry for all scenarios in a directory (recursive)."""
+    scenarios = sorted(scenario_dir.rglob("*.json"))
+    records: list[dict[str, Any]] = []
+
+    for path in scenarios:
+        record = collect_one(path, seed)
+        status_icon = {
+            "success": "\u2705", "failure": "\u274c", "error": "\U0001f6a8",
+        }.get(record["result_status"], "\u2753")
+        print(f"  {status_icon}  {record['scenario_id']}  "
+              f"[{record['family']}] "
+              f"rounds={record['rounds_used']}/{record['max_rounds']}")
+        records.append(record)
+
+    return records
+
+
+# ── Index generation ────────────────────────────────────────
+
+
+def build_index(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build aggregate statistics from telemetry records."""
+    total = len(records)
+    schema_invalid = sum(1 for r in records if not r["schema_valid"])
+    runtime_failures = sum(1 for r in records if r["runtime_error"])
+    passed = total - schema_invalid - runtime_failures
+
+    agreements = sum(1 for r in records if r["result_status"] == "success")
+    no_agreements = sum(1 for r in records if r["result_status"] == "failure")
+
+    convergence_rounds = [
+        r["convergence_round"] for r in records if r["convergence_round"] is not None
+    ]
+    avg_convergence = (
+        round(sum(convergence_rounds) / len(convergence_rounds), 2)
+        if convergence_rounds else None
+    )
+
+    # Per-family breakdown
+    families: dict[str, dict[str, Any]] = {}
+    for r in records:
+        fam = r["family"]
+        if fam not in families:
+            families[fam] = {"total": 0, "agreements": 0, "failures": 0, "errors": 0}
+        families[fam]["total"] += 1
+        if r["result_status"] == "success":
+            families[fam]["agreements"] += 1
+        elif r["result_status"] == "failure":
+            families[fam]["failures"] += 1
+        if r["runtime_error"]:
+            families[fam]["errors"] += 1
+
+    return {
+        "total": total,
+        "passed_runtime": passed,
+        "schema_invalid": schema_invalid,
+        "runtime_failures": runtime_failures,
+        "agreements": agreements,
+        "no_agreements": no_agreements,
+        "avg_convergence_round": avg_convergence,
+        "by_family": families,
+    }
+
+
+# ── Output ──────────────────────────────────────────────────
+
+
+def write_telemetry(records: list[dict[str, Any]], output_dir: Path) -> Path:
+    """Write per-scenario telemetry to output_dir/telemetry.json."""
+    path = output_dir / "telemetry.json"
+    path.write_text(
+        json.dumps(records, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_index(index: dict[str, Any], output_dir: Path) -> Path:
+    """Write aggregate index to output_dir/index.json."""
+    path = output_dir / "index.json"
+    path.write_text(
+        json.dumps(index, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def print_summary(index: dict[str, Any]) -> None:
+    """Print a human-readable summary to stdout."""
+    print(f"\n{'=' * 50}")
+    print("  Scenario Telemetry Summary")
+    print(f"{'=' * 50}")
+    print(f"  Total scenarios:       {index['total']}")
+    print(f"  Passed runtime:        {index['passed_runtime']}")
+    print(f"  Schema invalid:        {index['schema_invalid']}")
+    print(f"  Runtime failures:      {index['runtime_failures']}")
+    print(f"  Agreements reached:    {index['agreements']}")
+    print(f"  No agreement:          {index['no_agreements']}")
+    if index["avg_convergence_round"] is not None:
+        print(f"  Avg convergence round: {index['avg_convergence_round']}")
+    print()
+    print("  By family:")
+    for fam, stats in sorted(index["by_family"].items()):
+        agree_rate = (
+            f"{stats['agreements']}/{stats['total']}"
+            if stats["total"] > 0 else "-"
+        )
+        print(f"    {fam}: {stats['total']} scenarios, "
+              f"{agree_rate} agreements, "
+              f"{stats['errors']} errors")
+    print(f"{'=' * 50}")
+
+
+# ── CLI ─────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect execution telemetry for generated scenarios."
+    )
+    parser.add_argument(
+        "--scenario-dir", type=str, default=None,
+        help=f"Directory with scenario JSON files (default: {DEFAULT_SCENARIO_DIR}).",
+    )
+    parser.add_argument(
+        "--output-dir", type=str, default=None,
+        help=f"Where to write telemetry.json and index.json (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--seed", type=str, default=SEED,
+        help=f"Seed for reproducible runs (default: {SEED}).",
+    )
+    args = parser.parse_args()
+
+    scenario_dir = Path(args.scenario_dir) if args.scenario_dir else DEFAULT_SCENARIO_DIR
+    output_dir = Path(args.output_dir) if args.output_dir else DEFAULT_OUTPUT_DIR
+
+    if not scenario_dir.is_dir():
+        print(f"Scenario directory not found: {scenario_dir}", file=sys.stderr)
+        print("Run the generator first:\n"
+              "  python tools/scenario_generator/generate_scenarios.py",
+              file=sys.stderr)
+        return 1
+
+    print(f"Collecting telemetry from {scenario_dir} ...\n")
+    records = collect_all(scenario_dir, args.seed)
+
+    if not records:
+        print("No scenarios found.", file=sys.stderr)
+        return 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tel_path = write_telemetry(records, output_dir)
+    index = build_index(records)
+    idx_path = write_index(index, output_dir)
+
+    print_summary(index)
+    print(f"\n  telemetry → {tel_path}")
+    print(f"  index     → {idx_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Transforms the scenario exploration layer from flat file generation into **instrumented scientific infrastructure**. Three connected pieces:

### 1. Scenario Telemetry (`tools/scenario_telemetry.py`)

Runs every generated scenario through the simulator and captures structured records:

```json
{
  "scenario_id": "resource_scarcity_025",
  "family": "resource_scarcity",
  "actors": 3,
  "max_rounds": 1,
  "result_status": "failure",
  "rounds_used": 1,
  "convergence_round": null,
  "schema_valid": true,
  "runtime_error": false
}
```

Produces:
- `scenarios/telemetry.json` — per-scenario records (array)
- `scenarios/index.json` — aggregate statistics with per-family breakdown

### 2. Family Subdirectories

Generated scenarios now live in family-organized directories:

```
scenarios/generated/
    info_asymmetry/         (20 scenarios)
    resource_scarcity/      (20 scenarios)
    incentive_misalignment/ (20 scenarios)
```

Benchmark runner updated to use `rglob` for recursive discovery.

### 3. Lab State (`docs/lab_state.md`)

Scientific memory document seeded with real telemetry data:

| Family | Agreements | Rate |
|---|---|---|
| info_asymmetry | 20/20 | 100% |
| incentive_misalignment | 19/20 | 95% |
| resource_scarcity | 16/20 | 80% |

Key findings: avg convergence at round 1.8, all 5 failures have `max_rounds ≤ 2`, resource scarcity is the fragility vector.

## Usage

```bash
# Generate into family dirs
python tools/scenario_generator/generate_scenarios.py

# Collect telemetry
python tools/scenario_telemetry.py

# View results
cat scenarios/index.json
```

## Design decisions

- Telemetry and index are **gitignored** (ephemeral, regenerable)
- Lab state is **tracked** (scientific memory, manually updated)
- No new dependencies — uses only stdlib + jsonschema

## Test results

- 26/26 tests pass
- 60/60 generated scenarios pass runtime
- Benchmark `--include-generated` works with subdirectory layout (63 total: 60 RUN + 3 curated)

## Checklist

- [x] Changes preserve Kernel integrity
- [x] No weakening of evaluation standards
- [x] No introduction of coercive mechanisms
- [x] Language is clear and precise
- [x] Medium/long-term stability prioritized