### PR TITLE
chore: normalize line endings to avoid CRLF benchmark drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+* text=auto
 *.md text eol=lf
-benchmarks/expected/*.json text eol=lf
+*.py text eol=lf
+*.json text eol=lf


### PR DESCRIPTION
## Summary

Expands `.gitattributes` to normalize line endings across all text files, eliminating CRLF-induced benchmark byte mismatches on Windows.

## Changes

```
* text=auto
*.md text eol=lf
*.py text eol=lf
*.json text eol=lf
```

Supersedes the previous rule that only covered `benchmarks/expected/*.json`.

## Why

Windows checkouts produce CRLF line endings, causing byte-level mismatches against LF-normalized expected benchmark files. This makes all 3 curated benchmarks FAIL on Windows even though the JSON is structurally identical. Enforcing LF globally eliminates this class of false negatives.

## Checklist

- [x] Changes preserve Kernel integrity
- [x] No weakening of evaluation standards
- [x] Medium/long-term stability prioritized