### PR TITLE
Fix broken relative links in onboarding documentation

### DIFF
--- a/docs/02_how_to_read_this_repo.md
+++ b/docs/02_how_to_read_this_repo.md
@@ -24,8 +24,8 @@ without reading the Kernel.
 
 Read:
 - [`docs/03_try_a_scenario.md`](03_try_a_scenario.md)
-- [`v1_core/workflow/scenario_001_partial_ceasefire.md`](v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [`v1_core/workflow/scenario_002_verified_ceasefire.md`](v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [`v1_core/workflow/scenario_001_partial_ceasefire.md`](../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`v1_core/workflow/scenario_002_verified_ceasefire.md`](../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 
 Focus on:
@@ -40,9 +40,9 @@ You can stop there and still understand the system.
 ## If you want the theoretical foundation (Kernel)
 
 Read in order:
-1. [v1_core/languages/en/01_base_declaracion.md](v1_core/languages/en/01_base_declaracion.md)
-2. [v1_core/languages/en/02_arquitectura_base.md](v1_core/languages/en/02_arquitectura_base.md)
-3. [v1_core/languages/en/03_flujo_operativo.md](v1_core/languages/en/03_flujo_operativo.md)
+1. [v1_core/languages/en/01_base_declaracion.md](../v1_core/languages/en/01_base_declaracion.md)
+2. [v1_core/languages/en/02_arquitectura_base.md](../v1_core/languages/en/02_arquitectura_base.md)
+3. [v1_core/languages/en/03_flujo_operativo.md](../v1_core/languages/en/03_flujo_operativo.md)
 
 These documents define the **immutable principles** of HUB_Optimus.
 They change rarely and intentionally.
@@ -52,7 +52,7 @@ They change rarely and intentionally.
 ## If you want to contribute
 
 Start with:
-- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 Important:
 - Kernel influence is integrity-gated
@@ -70,7 +70,7 @@ Do not start by changing principles.
 Focus on:
 - v1_core/workflow/
 - scenario classifications
-- learning logic in [05_meta_learning.md](v1_core/workflow/05_meta_learning.md)
+- learning logic in [05_meta_learning.md](../v1_core/workflow/05_meta_learning.md)
 
 Ask:
 - are incentives visible?

--- a/docs/ca/02_how_to_read_this_repo.md
+++ b/docs/ca/02_how_to_read_this_repo.md
@@ -25,8 +25,8 @@ without reading the Kernel.
 
 Read:
 - [`docs/03_try_a_scenario.md`](03_try_a_scenario.md)
-- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [`../../v1_core/workflow/scenario_002_verified_ceasefire.md`](../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`../../v1_core/workflow/scenario_002_verified_ceasefire.md`](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 
 Focus on:
@@ -41,9 +41,9 @@ You can stop there and still understand the system.
 ## If you want the theoretical foundation (Kernel)
 
 Read in order:
-1. [../../v1_core/languages/en/01_base_declaracion.md](../v1_core/languages/en/01_base_declaracion.md)
-2. [../../v1_core/languages/en/02_arquitectura_base.md](../v1_core/languages/en/02_arquitectura_base.md)
-3. [../../v1_core/languages/en/03_flujo_operativo.md](../v1_core/languages/en/03_flujo_operativo.md)
+1. [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+2. [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+3. [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 These documents define the **immutable principles** of HUB_Optimus.
 They change rarely and intentionally.
@@ -53,7 +53,7 @@ They change rarely and intentionally.
 ## If you want to contribute
 
 Start with:
-- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 Important:
 - Kernel influence is integrity-gated
@@ -71,7 +71,7 @@ Do not start by changing principles.
 Focus on:
 - ../../v1_core/workflow/
 - scenario classifications
-- learning logic in [05_meta_learning.md](../v1_core/workflow/05_meta_learning.md)
+- learning logic in [05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 Ask:
 - are incentives visible?

--- a/docs/de/03_try_a_scenario.md
+++ b/docs/de/03_try_a_scenario.md
@@ -11,7 +11,7 @@ Geschätzte Dauer: 10–15 Minuten.
 ## Schritt 1 — Öffne die Szenario-Vorlage
 
 Öffne:
-- [../v1_core/04_scenario_template.md](../v1_core/04_scenario_template.md)
+- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
 
 Achte nur auf die Struktur:
 - Kontext
@@ -25,7 +25,7 @@ Achte nur auf die Struktur:
 ## Schritt 2 — Szenario 001: Teilweiser Waffenstillstand (falscher Erfolg)
 
 ?ffne:
-- [../v1_core/workflow/scenario_001_partial_ceasefire.md](../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
 
 Fokussiere dich auf:
 - Was behauptet wird vs. was verifiziert wird
@@ -37,7 +37,7 @@ Fokussiere dich auf:
 ## Schritt 3 — Szenario 002: Verifizierter Waffenstillstand (struktureller Erfolg)
 
 Öffne:
-- [../v1_core/scenario_002_verified_ceasefire.md](../v1_core/scenario_002_verified_ceasefire.md)
+- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 Fokussiere dich auf:
 - Was sich im Vergleich zu Szenario 001 geändert hat
@@ -64,7 +64,7 @@ Es fragt:
 ## Schritt 5 — Learning Layer
 
 Lies:
-- [../v1_core/05_meta_learning.md](../v1_core/05_meta_learning.md)
+- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 Dort wird erklärt, wie Muster extrahiert und "gemerkt" werden.
 
@@ -83,9 +83,9 @@ Das ist der Kern von HUB_Optimus.
 
 Grundlagen:
 
-- [../v1_core/01_base_declaracion.md](../v1_core/01_base_declaracion.md)
-- [../v1_core/02_arquitectura_base.md](../v1_core/02_arquitectura_base.md)
-- [../v1_core/03_flujo_operativo.md](../v1_core/03_flujo_operativo.md)
+- [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+- [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+- [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 
 Mitmachen:

--- a/docs/fr/02_how_to_read_this_repo.md
+++ b/docs/fr/02_how_to_read_this_repo.md
@@ -25,8 +25,8 @@ without reading the Kernel.
 
 Read:
 - [`docs/03_try_a_scenario.md`](03_try_a_scenario.md)
-- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [`../../v1_core/workflow/scenario_002_verified_ceasefire.md`](../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`../../v1_core/workflow/scenario_002_verified_ceasefire.md`](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 
 Focus on:
@@ -41,9 +41,9 @@ You can stop there and still understand the system.
 ## If you want the theoretical foundation (Kernel)
 
 Read in order:
-1. [../../v1_core/languages/en/01_base_declaracion.md](../v1_core/languages/en/01_base_declaracion.md)
-2. [../../v1_core/languages/en/02_arquitectura_base.md](../v1_core/languages/en/02_arquitectura_base.md)
-3. [../../v1_core/languages/en/03_flujo_operativo.md](../v1_core/languages/en/03_flujo_operativo.md)
+1. [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+2. [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+3. [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 These documents define the **immutable principles** of HUB_Optimus.
 They change rarely and intentionally.
@@ -53,7 +53,7 @@ They change rarely and intentionally.
 ## If you want to contribute
 
 Start with:
-- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 Important:
 - Kernel influence is integrity-gated
@@ -71,7 +71,7 @@ Do not start by changing principles.
 Focus on:
 - ../../v1_core/workflow/
 - scenario classifications
-- learning logic in [05_meta_learning.md](../v1_core/workflow/05_meta_learning.md)
+- learning logic in [05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 Ask:
 - are incentives visible?

--- a/docs/ru/02_how_to_read_this_repo.md
+++ b/docs/ru/02_how_to_read_this_repo.md
@@ -25,8 +25,8 @@ without reading the Kernel.
 
 Read:
 - [`docs/03_try_a_scenario.md`](03_try_a_scenario.md)
-- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [`../../v1_core/workflow/scenario_002_verified_ceasefire.md`](../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- [`../../v1_core/workflow/scenario_001_partial_ceasefire.md`](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+- [`../../v1_core/workflow/scenario_002_verified_ceasefire.md`](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 
 Focus on:
@@ -41,9 +41,9 @@ You can stop there and still understand the system.
 ## If you want the theoretical foundation (Kernel)
 
 Read in order:
-1. [../../v1_core/languages/en/01_base_declaracion.md](../v1_core/languages/en/01_base_declaracion.md)
-2. [../../v1_core/languages/en/02_arquitectura_base.md](../v1_core/languages/en/02_arquitectura_base.md)
-3. [../../v1_core/languages/en/03_flujo_operativo.md](../v1_core/languages/en/03_flujo_operativo.md)
+1. [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
+2. [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
+3. [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
 
 These documents define the **immutable principles** of HUB_Optimus.
 They change rarely and intentionally.
@@ -53,7 +53,7 @@ They change rarely and intentionally.
 ## If you want to contribute
 
 Start with:
-- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 Important:
 - Kernel influence is integrity-gated
@@ -71,7 +71,7 @@ Do not start by changing principles.
 Focus on:
 - ../../v1_core/workflow/
 - scenario classifications
-- learning logic in [05_meta_learning.md](../v1_core/workflow/05_meta_learning.md)
+- learning logic in [05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 Ask:
 - are incentives visible?


### PR DESCRIPTION
Closes #95

Summary:
- Fixed broken relative links in onboarding docs
- Verified paths from file location
- Ran Lychee to confirm no broken links

Files updated:
- docs/02_how_to_read_this_repo.md
- docs/ca/02_how_to_read_this_repo.md
- docs/de/03_try_a_scenario.md
-  docs/fr/02_how_to_read_this_repo.md
-  docs/ru/02_how_to_read_this_repo.md