### PR TITLE
docs: consolidate frontier mapping in canonical documentation

### DIFF
--- a/SIMULATION_README.md
+++ b/SIMULATION_README.md
@@ -90,6 +90,22 @@ El núcleo es intencionadamente minimalista.  Algunas direcciones de ampliación
 3. **Índice de Integridad**: implementar el cálculo automático del índice definido en `INTEGRITY_SCORING_SYSTEM.md` y añadirlo al informe de salida.
 4. **Interfaz gráfica o web**: crear una CLI más amigable o un panel web para seleccionar escenarios, actores y parámetros sin necesidad de modificar archivos a mano.
 
+## 4b. Instrumentos del laboratorio experimental
+
+Además del núcleo base, el repositorio incluye un conjunto de herramientas de análisis
+que permiten mapear el espacio de estabilidad del simulador. Todos los resultados son
+efímeros (gitignored) y se regeneran localmente.
+
+| Herramienta | Comando | Propósito |
+|---|---|---|
+| Generador | `python tools/scenario_generator/generate_scenarios.py` | Genera escenarios sintéticos por familia |
+| Telemetría | `python tools/scenario_telemetry.py` | Métricas agregadas de convergencia |
+| Mutador | `python tools/scenario_mutator.py` | Barrido de estabilidad variando un eje |
+| Búsqueda de frontera | `python tools/scenario_boundary_search.py` | Frontera de estabilidad por eje (búsqueda binaria) |
+| Frontera 2D | `python tools/scenario_frontier.py` | Mapas de estabilidad en planos de dos ejes |
+
+La memoria científica del laboratorio se mantiene en `docs/lab_state.md`.
+
 ## 5. Sincronización de traducciones (opcional)
 
 El script `i18n_sync.py` ayuda a mantener sincronizada la documentación multilingüe.  Comprueba que todos los archivos en `docs/` que están en inglés tienen traducciones correspondientes en los subdirectorios de idiomas (`es`, `de`, `fr`, `ca`, `ru`).  Para ejecutarlo, coloca el script en la raíz del proyecto (o especifica la ruta `--docs_dir`) y ejecuta:

--- a/docs/context/PROJECT_OVERVIEW.md
+++ b/docs/context/PROJECT_OVERVIEW.md
@@ -26,7 +26,10 @@ It compares declared commitments against verifiable structure: incentives, seque
 - `run_scenario.py` and `hub_optimus_simulator.py`: scenario execution loop.
 - `v1_core/`: active kernel language specs and workflow scenarios.
 - `docs/`: onboarding and governance documentation.
-- `.github/workflows/` and `tools/`: CI checks and maintenance automation.
+- `docs/lab_state.md`: scientific memory — behavioural observations and stability maps.
+- `tools/`: CI checks, maintenance automation, and experimental lab instruments
+  (scenario generator, mutator, boundary search, 2D frontier mapping).
+- `.github/workflows/`: CI checks.
 
 ## Success metrics (MVP)
 - `pytest` passes on every `pull_request` and `push` to `main`.

--- a/docs/lab_state.md
+++ b/docs/lab_state.md
@@ -421,6 +421,10 @@ resource_scarcity:
   unused.
 - Does the "more actors hurts convergence" phenomenon emerge under
   adversarial seeds or different scenario families?
+- **How does the stability frontier change under a different
+  negotiation policy?** This is the next structural question —
+  compare stable area, minimum actors×rounds curve, seed sensitivity,
+  and convergence gradient across policies.
 - ~~Can multi-axis boundary search (varying 2+ parameters simultaneously)
   decouple the axis coupling observed with seed 1?~~ Answered: yes.
   2D actors×rounds maps show the coupling was threshold-mediated.


### PR DESCRIPTION
## Summary

Consolidates PR #538 (two-axis stability frontier mapping) findings into the canonical documentation files that users consult first.

### Changes

- **SIMULATION_README.md**: Add section 4b  lab instrument inventory table listing all 5 experimental tools (generator, telemetry, mutator, boundary search, 2D frontier) with commands and purposes
- **docs/context/PROJECT_OVERVIEW.md**: Update architecture section to reference lab tools and \docs/lab_state.md\ as scientific memory
- **docs/lab_state.md**: Add the next structural question (policy comparative frontier) to the open questions list

### Context

The lab now has a complete instrument chain. This consolidation ensures someone reading the canonical docs can discover the full tool set without having to know about \lab_state.md\ first.