### PR TITLE
policy: add BiasedRandomPolicy and --policy CLI flag

### DIFF
--- a/hub_optimus_simulator.py
+++ b/hub_optimus_simulator.py
@@ -15,6 +15,58 @@ import random
 from typing import Any, Callable, Dict, List, Optional
 
 
+# ── Negotiation policies ────────────────────────────────────
+
+
+class NegotiationPolicy:
+    """Base class for negotiation policies."""
+
+    name: str = "base"
+
+    def propose(self, actor_role: str, state: Dict[str, Any], rng: random.Random) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class UniformRandomPolicy(NegotiationPolicy):
+    """Original default: uniform random offer in [1, 5]."""
+
+    name = "uniform"
+
+    def propose(self, actor_role: str, state: Dict[str, Any], rng: random.Random) -> Dict[str, Any]:
+        return {"offer": rng.randint(1, 5)}
+
+
+class BiasedRandomPolicy(NegotiationPolicy):
+    """Role-aware policy: offer range depends on actor role.
+
+    - hardliner: biased toward high offers (3–5)
+    - mediator:  biased toward middle offers (2–4)
+    - all others (negotiator, etc.): uniform [1, 5]
+    """
+
+    name = "biased"
+
+    def propose(self, actor_role: str, state: Dict[str, Any], rng: random.Random) -> Dict[str, Any]:
+        if actor_role == "hardliner":
+            return {"offer": rng.randint(3, 5)}
+        if actor_role == "mediator":
+            return {"offer": rng.randint(2, 4)}
+        return {"offer": rng.randint(1, 5)}
+
+
+POLICIES: Dict[str, NegotiationPolicy] = {
+    "uniform": UniformRandomPolicy(),
+    "biased": BiasedRandomPolicy(),
+}
+
+
+def get_policy(name: str) -> NegotiationPolicy:
+    """Look up a policy by name."""
+    if name not in POLICIES:
+        raise ValueError(f"Unknown policy: {name!r}. Available: {sorted(POLICIES)}")
+    return POLICIES[name]
+
+
 class Scenario:
     """Data container for a negotiation scenario.
 
@@ -73,6 +125,7 @@ class Actor:
         self.name = name
         self.role_type = role_type
         self.policy = policy or self.default_policy
+        self._negotiation_policy: Optional[NegotiationPolicy] = None
 
     def default_policy(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """Default policy for actors.
@@ -84,6 +137,9 @@ class Actor:
 
     def act(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """Return an action for the given negotiation state by calling the actor's policy."""
+        if self._negotiation_policy is not None:
+            rng = random.Random(random.random())
+            return self._negotiation_policy.propose(self.role_type, state, rng)
         return self.policy(state)
 
 
@@ -95,11 +151,15 @@ class Simulator:
     more complex negotiation logic, richer histories and evaluation metrics.
     """
 
-    def __init__(self, scenario: Scenario) -> None:
+    def __init__(self, scenario: Scenario, policy_name: Optional[str] = None) -> None:
         self.scenario = scenario
         # Instantiate actors based on scenario roles
         self.actors: List[Actor] = [Actor(role["name"], role.get("role", "")) for role in scenario.roles]
         self.history: List[Dict[str, Dict[str, Any]]] = []
+        if policy_name is not None:
+            neg_policy = get_policy(policy_name)
+            for actor in self.actors:
+                actor._negotiation_policy = neg_policy
 
     def assign_policy(
         self, actor_name: str, policy: Callable[[Dict[str, Any]], Dict[str, Any]]

--- a/run_scenario.py
+++ b/run_scenario.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import jsonschema
 
-from hub_optimus_simulator import Scenario, Simulator
+from hub_optimus_simulator import POLICIES, Scenario, Simulator
 
 
 SCHEMA_PATH = Path(__file__).parent / "scenario.schema.json"
@@ -92,6 +92,12 @@ def main() -> int:
             " enabling reproducible runs."
         ),
     )
+    parser.add_argument(
+        "--policy",
+        choices=sorted(POLICIES),
+        default=None,
+        help="Negotiation policy for all actors (default: uniform random).",
+    )
     args = parser.parse_args()
 
     scenario_path_value = args.scenario_path_opt or args.scenario_path_pos
@@ -111,7 +117,7 @@ def main() -> int:
         print(f"[schema-error] {exc}", file=sys.stderr)
         return INPUT_ERROR_EXIT_CODE
 
-    simulator = Simulator(scenario)
+    simulator = Simulator(scenario, policy_name=args.policy)
     result = simulator.run(seed=args.seed)
     output_path = Path(args.output) if args.output else scenario_path.with_suffix(".result.json")
     try:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,113 @@
+"""Tests for the negotiation policy system."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCENARIO = REPO_ROOT / "run_scenario.py"
+EXAMPLE = REPO_ROOT / "example_scenario.json"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [sys.executable, str(RUN_SCENARIO), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+
+def _mixed_role_scenario(tmp_path: Path) -> Path:
+    """Create a scenario with hardliner + mediator roles."""
+    scenario = {
+        "title": "Policy divergence test",
+        "description": "Scenario with mixed roles to test biased policy.",
+        "roles": [
+            {"name": "Alpha", "role": "hardliner"},
+            {"name": "Beta", "role": "mediator"},
+            {"name": "Gamma", "role": "negotiator"},
+        ],
+        "success_criteria": {"offer": 5},
+        "max_rounds": 10,
+    }
+    path = tmp_path / "mixed_roles.json"
+    path.write_text(json.dumps(scenario, indent=2), encoding="utf-8")
+    return path
+
+
+def test_uniform_policy_runs() -> None:
+    proc = _run_cli("--scenario", str(EXAMPLE), "--seed", "42", "--policy", "uniform")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] in {"success", "failure"}
+
+
+def test_biased_policy_runs() -> None:
+    proc = _run_cli("--scenario", str(EXAMPLE), "--seed", "42", "--policy", "biased")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] in {"success", "failure"}
+
+
+def test_no_policy_flag_backward_compatible() -> None:
+    proc = _run_cli("--scenario", str(EXAMPLE), "--seed", "42")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["status"] in {"success", "failure"}
+
+
+def test_policy_changes_convergence_profile(tmp_path: Path) -> None:
+    """Same seed + different policy + mixed roles → different offer history."""
+    scenario_path = _mixed_role_scenario(tmp_path)
+    proc_uniform = _run_cli(
+        "--scenario", str(scenario_path), "--seed", "42", "--policy", "uniform",
+    )
+    proc_biased = _run_cli(
+        "--scenario", str(scenario_path), "--seed", "42", "--policy", "biased",
+    )
+    assert proc_uniform.returncode == 0, proc_uniform.stderr
+    assert proc_biased.returncode == 0, proc_biased.stderr
+
+    payload_u = json.loads(proc_uniform.stdout)
+    payload_b = json.loads(proc_biased.stdout)
+
+    # At least one of: different history, different rounds, different status
+    differs = (
+        payload_u["history"] != payload_b["history"]
+        or payload_u["rounds"] != payload_b["rounds"]
+        or payload_u["status"] != payload_b["status"]
+    )
+    assert differs, (
+        "Uniform and biased policies should produce different convergence profiles "
+        "under the same seed when roles include hardliner/mediator"
+    )
+
+
+def test_each_policy_is_deterministic() -> None:
+    """Same seed + same policy run twice → identical output."""
+    for policy in ("uniform", "biased"):
+        proc_a = _run_cli(
+            "--scenario", str(EXAMPLE), "--seed", "99", "--policy", policy,
+        )
+        proc_b = _run_cli(
+            "--scenario", str(EXAMPLE), "--seed", "99", "--policy", policy,
+        )
+        assert proc_a.returncode == 0, proc_a.stderr
+        assert proc_b.returncode == 0, proc_b.stderr
+
+        payload_a = json.loads(proc_a.stdout)
+        payload_b = json.loads(proc_b.stdout)
+        assert payload_a == payload_b, (
+            f"Policy {policy!r} is not deterministic under seed 99"
+        )

--- a/tools/scenario_boundary_search.py
+++ b/tools/scenario_boundary_search.py
@@ -50,6 +50,9 @@ EXTRA_ACTORS = [
     {"name": "Faction_I", "role": "negotiator"},
 ]
 
+# Active policy for probes (None = simulator default).
+ACTIVE_POLICY: str | None = None
+
 
 # ── Probe ───────────────────────────────────────────────────
 
@@ -66,15 +69,19 @@ def probe(scenario: dict, seed: str) -> bool:
             encoding="utf-8",
         )
 
+        cmd = [
+            sys.executable, str(RUNNER),
+            str(scenario_path),
+            "--output", str(result_path),
+            "--seed", seed,
+        ]
+        if ACTIVE_POLICY is not None:
+            cmd.extend(["--policy", ACTIVE_POLICY])
+
         env = os.environ.copy()
         env["PYTHONIOENCODING"] = "utf-8"
         proc = subprocess.run(
-            [
-                sys.executable, str(RUNNER),
-                str(scenario_path),
-                "--output", str(result_path),
-                "--seed", seed,
-            ],
+            cmd,
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
@@ -106,15 +113,19 @@ def probe_detail(scenario: dict, seed: str) -> dict:
             encoding="utf-8",
         )
 
+        cmd = [
+            sys.executable, str(RUNNER),
+            str(scenario_path),
+            "--output", str(result_path),
+            "--seed", seed,
+        ]
+        if ACTIVE_POLICY is not None:
+            cmd.extend(["--policy", ACTIVE_POLICY])
+
         env = os.environ.copy()
         env["PYTHONIOENCODING"] = "utf-8"
         proc = subprocess.run(
-            [
-                sys.executable, str(RUNNER),
-                str(scenario_path),
-                "--output", str(result_path),
-                "--seed", seed,
-            ],
+            cmd,
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
@@ -517,7 +528,14 @@ def main() -> int:
         "--gradient", action="store_true",
         help="Measure convergence round at each parameter value (convergence curves).",
     )
+    parser.add_argument(
+        "--policy", type=str, default=None,
+        help="Negotiation policy name (e.g. uniform, biased).",
+    )
     args = parser.parse_args()
+
+    global ACTIVE_POLICY  # noqa: PLW0603
+    ACTIVE_POLICY = args.policy
 
     bases = pick_base_scenarios()
     if not bases:

--- a/tools/scenario_frontier.py
+++ b/tools/scenario_frontier.py
@@ -29,6 +29,7 @@ import json
 import sys
 from pathlib import Path
 
+import scenario_boundary_search
 from scenario_boundary_search import (
     EXTRA_ACTORS,
     OUTPUT_DIR,
@@ -267,7 +268,13 @@ def main() -> int:
         choices=list(PLANES.keys()),
         help="Map a specific plane only (default: both).",
     )
+    parser.add_argument(
+        "--policy", type=str, default=None,
+        help="Negotiation policy name (e.g. uniform, biased).",
+    )
     args = parser.parse_args()
+
+    scenario_boundary_search.ACTIVE_POLICY = args.policy
 
     bases = pick_base_scenarios()
     if not bases:


### PR DESCRIPTION
## Summary

Implements a pluggable negotiation policy system and adds a second baseline policy (`BiasedRandomPolicy`) for comparative frontier analysis.

### Changes

**Simulator kernel** (`hub_optimus_simulator.py`):
- `NegotiationPolicy` base class with `propose(actor_role, state, rng)` interface
- `UniformRandomPolicy` (name=`uniform`): `rng.randint(1, 5)` — formalizes existing default
- `BiasedRandomPolicy` (name=`biased`): hardliner→3–5, mediator→2–4, others→1–5
- `POLICIES` registry dict and `get_policy()` lookup
- `Actor._negotiation_policy` field; `Simulator` accepts optional `policy_name`
- All backward-compatible: `None` default preserves existing behavior

**CLI** (`run_scenario.py`):
- `--policy` argument with `choices=sorted(POLICIES)`

**Lab tools**:
- `scenario_boundary_search.py`: `ACTIVE_POLICY` module variable, threaded through `probe()` and `probe_detail()` subprocess calls
- `scenario_frontier.py`: `--policy` CLI argument, sets `scenario_boundary_search.ACTIVE_POLICY`

**Tests** (`tests/test_policy.py` — 5 new tests):
- `test_uniform_policy_runs` — uniform policy produces valid output
- `test_biased_policy_runs` — biased policy produces valid output
- `test_no_policy_flag_backward_compatible` — no flag preserves existing behavior
- `test_policy_changes_convergence_profile` — same seed + different policy + mixed roles → different convergence
- `test_each_policy_is_deterministic` — same seed + same policy → identical output across runs

### Design decisions

1. **Module-level `ACTIVE_POLICY` instead of parameter threading**: The lab tools call `run_scenario.py` as a subprocess, so policy must be passed on the command line. Rather than threading `policy=None` through ~15 function signatures, a module-level variable set from CLI keeps the diff minimal and the architecture clean.

2. **Role-aware divergence**: The biased policy only differs from uniform when actors have `hardliner` or `mediator` roles — the test uses a purpose-built mixed-role scenario to verify divergence.

Closes #576