### PR TITLE
chore: add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/kernel-guard.yml
+++ b/.github/workflows/kernel-guard.yml
@@ -9,6 +9,9 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -6,6 +6,9 @@ name: Link Check
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lychee:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-safety-check.yml
+++ b/.github/workflows/pr-safety-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   safety-label:
     name: Risk classification


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to all CI workflows that lacked it.

### Changes

| Workflow | Change |
|---|---|
| `ci.yml` | Added `permissions: contents: read` |
| `link-check.yml` | Added `permissions: contents: read` |
| `kernel-guard.yml` | Added `permissions: contents: read` |
| `pr-safety-check.yml` | Added `permissions: contents: read` |

`repo_maintenance_bot.yml` already had explicit permissions (`contents: write`, `pull-requests: write`) — no change needed.

### Rationale

By default, GitHub Actions tokens may have broader permissions than necessary. Adding explicit read-only permissions follows the principle of least privilege and prevents workflows from accidentally gaining write access to repository contents.

### Risk

**LOW** — no logic changes, only permission declarations added.

Related to #93