### PR TITLE
fix: stop maintenance bot feedback loop

### DIFF
--- a/.github/workflows/repo_maintenance_bot.yml
+++ b/.github/workflows/repo_maintenance_bot.yml
@@ -17,13 +17,7 @@ name: Repo maintenance bot
         type: choice
         options: ["false", "true"]
   schedule:
-    - cron: "15 6 * * *"
-  pull_request:
-    paths:
-      - "docs/**"
-      - "v1_core/**"
-      - ".github/workflows/**"
-      - "tools/**"
+    - cron: "15 6 * * 1"
 
 permissions:
   contents: write


### PR DESCRIPTION
## URGENT: Stop maintenance bot feedback loop

The maintenance bot has a `pull_request` trigger that fires when `docs/**`, `v1_core/**`, `.github/workflows/**`, or `tools/**` are changed. Since the bot itself creates PRs that modify files in those paths, it triggers itself in an infinite loop.

**Evidence:** 1,388+ `chore/maintenance-*` PRs created, with new ones appearing every few seconds.

### Changes

- **Removed** the `pull_request` trigger from `repo_maintenance_bot.yml`
- **Changed** schedule from daily (`"15 6 * * *"`) to weekly (`"15 6 * * 1"` — Mondays at 06:15 UTC)
- `workflow_dispatch` trigger preserved for manual runs

### Why this is safe

The bot's useful work (i18n sync, hygiene checks) doesn't need to run on every PR — scheduled weekly + manual dispatch is sufficient. The `pull_request` trigger was the direct cause of the runaway loop.

### After merge

The existing `chore/maintenance-*` branches and PRs should be bulk-closed and deleted.

Related to #93