### PR TITLE
docs: add coalition fracture scenario (workflow + ES mirror)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,8 @@ Start here:
 - [00_start_here.md](00_start_here.md)
 - [02_how_to_read_this_repo.md](02_how_to_read_this_repo.md)
 - [03_try_a_scenario.md](03_try_a_scenario.md)
+
+Scenario corpus:
+- [scenarios/scenario_taxonomy.md](scenarios/scenario_taxonomy.md)
+- [scenarios/scenario_template.md](scenarios/scenario_template.md)
+- [scenarios/catalog.md](scenarios/catalog.md)

--- a/docs/scenarios/catalog.md
+++ b/docs/scenarios/catalog.md
@@ -1,0 +1,39 @@
+# Scenario Catalog
+
+This index tracks the hand-maintained scenarios currently committed to the
+repository.
+
+Scope notes:
+
+- Include canonical scenarios and benchmarks committed to Git.
+- Exclude translated mirrors of the same scenario.
+- Exclude generated artifacts under `scenarios/generated/`,
+  `scenarios/mutations/`, and other derived outputs.
+
+---
+
+| Scenario | Family | Status | Description |
+|---|---|---|---|
+| [`example_scenario`](../../example_scenario.json) | Ceasefire Negotiation | example | Simple partial ceasefire input used to demonstrate the simulator CLI |
+| [`ceasefire_basic`](../../benchmarks/scenarios/ceasefire_basic.json) | Ceasefire Negotiation | benchmark | Simple bilateral ceasefire negotiation with compatible objectives |
+| [`ceasefire_fragile`](../../benchmarks/scenarios/ceasefire_fragile.json) | Ceasefire Negotiation | benchmark | Ceasefire with external mediation and limited rounds, used as a fragile convergence case |
+| [`ceasefire_failure`](../../benchmarks/scenarios/ceasefire_failure.json) | Ceasefire Negotiation | benchmark | Hardline negotiation breakdown with no feasible settlement space |
+| [`scenario_001_partial_ceasefire`](../../v1_core/workflow/scenario_001_partial_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing an unverifiable ceasefire as destabilizing |
+| [`scenario_002_verified_ceasefire`](../../v1_core/workflow/scenario_002_verified_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing a verified ceasefire as stabilizing |
+| [`scenario_003_coalition_fracture`](../../v1_core/workflow/scenario_003_coalition_fracture.md) | Coalition Stability | experimental | External negotiation constrained by an internal coalition veto player |
+
+---
+
+## How to extend this table
+
+When adding a new scenario:
+
+1. Add one row for the canonical scenario file.
+2. Reuse the primary family from
+   [scenario_taxonomy.md](scenario_taxonomy.md).
+3. Choose one status:
+   `example`, `benchmark`, `workflow reference`, or `experimental`.
+4. Keep the description to one sentence focused on the diplomatic dynamic.
+
+If a scenario evolves from experimental to benchmark status, update this table
+in the same pull request that freezes or promotes it.

--- a/docs/scenarios/scenario_taxonomy.md
+++ b/docs/scenarios/scenario_taxonomy.md
@@ -1,0 +1,101 @@
+# Scenario Taxonomy v0
+
+This document defines the first taxonomy for diplomatic scenarios in
+HUB_Optimus. Its purpose is to keep the scenario corpus structured as new
+contributions arrive.
+
+This taxonomy is conceptual only. It does not change runtime behavior, JSON
+schema, benchmark rules, or simulator features.
+
+---
+
+## Scope
+
+- Assign each scenario to one primary family.
+- Choose the family based on the main diplomatic bottleneck, not on file
+  format or writing style.
+- Use secondary notes only as modifiers. They do not create a second family.
+
+Example: a ceasefire that uses a mediator is still a `Ceasefire Negotiation`
+scenario if the core question is whether violence can be paused credibly.
+
+---
+
+## Family definitions
+
+| Family | Primary question | Typical actors involved | Common failure mode | Example scenario idea |
+|---|---|---|---|---|
+| Ceasefire Negotiation | Can parties pause or reduce violence under terms that can hold? | Armed factions, government forces, monitors, humanitarian coordinators | Symbolic agreement without credible verification or sequencing | Local ceasefire around a civilian corridor |
+| Mediated Negotiation | Can a third party make an agreement possible by sequencing, guarantees, or shuttle diplomacy? | Two disputing parties, mediator, guarantor state, observer mission | Mediator lacks leverage, neutrality, or enforcement capacity | External mediator brokers phased de-escalation steps |
+| Coalition Stability | Can one side keep its own coalition together long enough to negotiate externally? | Coalition partners, cabinet factions, military leadership, parliamentary blocs | Internal veto player defects after provisional concessions | Wartime unity government splits over negotiation terms |
+| Shared Resource Conflict | Can rivals agree on access, allocation, or governance of a scarce shared asset? | Neighboring states, local authorities, technical agencies, affected communities | Zero-sum framing blocks technical compromise | Cross-border river basin drought-sharing arrangement |
+| Spoiler Dynamics | Can negotiations survive actors who benefit from breakdown or escalation? | Formal negotiators, splinter militias, extremist factions, security services | Attack or provocation destroys trust before verification can stabilize it | Splinter group sabotages talks after a draft agreement |
+| Domestic Political Pressure | Can negotiators sustain an agreement under elections, protest cycles, or media pressure? | Executive branch, opposition, public opinion blocs, media, civil society | Leaders optimize for optics at home and abandon workable terms | Election-season prisoner exchange under nationalist pressure |
+| Asymmetric Negotiation | Can actors with sharply unequal power, legitimacy, or time horizons reach a durable bargain? | State and non-state actors, patron states, aid agencies, local power brokers | Dominant party imposes terms that look efficient but cannot be reciprocally enforced | Armed group seeks aid access under blockade conditions |
+
+---
+
+## Classification rule
+
+When a scenario could appear to fit more than one family, classify it by the
+single pressure that most strongly determines success or failure.
+
+Use this order of reasoning:
+
+1. What is the core agreement being attempted?
+2. What is the main reason that agreement could fail?
+3. Which family best captures that failure pressure?
+
+If the answer still looks ambiguous, prefer the family that is most useful for
+coverage accounting.
+
+---
+
+## Current repository coverage
+
+The current benchmark pack is concentrated in one family:
+
+- `Ceasefire Negotiation`
+
+That is acceptable for v0, but it means future benchmark contributions should
+expand coverage into the other families rather than only adding more ceasefire
+variants.
+
+The narrative workflow corpus now reaches a second family:
+
+- `Coalition Stability`
+
+This is useful exploratory coverage, but it is not yet benchmarked.
+
+### Classification of current benchmark scenarios
+
+| Scenario | Location | Primary family | Reason |
+|---|---|---|---|
+| `ceasefire_basic` | `benchmarks/scenarios/ceasefire_basic.json` | Ceasefire Negotiation | Bilateral ceasefire with compatible objectives and low convergence friction |
+| `ceasefire_fragile` | `benchmarks/scenarios/ceasefire_fragile.json` | Ceasefire Negotiation | The mediator is important, but the main evaluation target is still whether a fragile ceasefire can converge under tight rounds |
+| `ceasefire_failure` | `benchmarks/scenarios/ceasefire_failure.json` | Ceasefire Negotiation | Hardline bilateral ceasefire failure case with no feasible settlement space |
+
+### Classification of current workflow scenario references
+
+| Scenario | Location | Primary family | Reason |
+|---|---|---|---|
+| `scenario_001_partial_ceasefire` | `v1_core/workflow/scenario_001_partial_ceasefire.md` | Ceasefire Negotiation | Evaluates an unverifiable ceasefire as a destabilizing structure |
+| `scenario_002_verified_ceasefire` | `v1_core/workflow/scenario_002_verified_ceasefire.md` | Ceasefire Negotiation | Evaluates a verified ceasefire as a stabilizing structure |
+| `scenario_003_coalition_fracture` | `v1_core/workflow/scenario_003_coalition_fracture.md` | Coalition Stability | Evaluates how an internal veto player can collapse external diplomatic progress |
+
+---
+
+## Contribution guidance
+
+When proposing a new scenario:
+
+- start by selecting one primary family from this taxonomy,
+- explain why that family is the best fit,
+- avoid creating near-duplicates of existing scenarios unless the new scenario
+  tests a clearly different failure mode,
+- update the scenario catalog after the scenario is added.
+
+Related documents:
+
+- [scenario_template.md](scenario_template.md)
+- [catalog.md](catalog.md)

--- a/docs/scenarios/scenario_template.md
+++ b/docs/scenarios/scenario_template.md
@@ -1,0 +1,147 @@
+# Scenario Authoring Template
+
+Use this template when proposing a new diplomatic scenario for the repository.
+It is intentionally lightweight: the goal is to define a scenario clearly
+enough that maintainers can classify it, compare it, and decide whether it
+belongs in the benchmark corpus.
+
+This template complements the detailed workflow material in
+[`v1_core/workflow/04_scenario_template.md`](../../v1_core/workflow/04_scenario_template.md).
+It does not replace the runtime schema in
+[`scenario.schema.json`](../../scenario.schema.json).
+
+---
+
+## Author instructions
+
+- Pick one primary family from [scenario_taxonomy.md](scenario_taxonomy.md).
+- Keep the context short and concrete.
+- Describe failure as a structural breakdown, not as a personal judgment.
+- If you think the scenario should become a benchmark, write invariants that a
+  simulator run could check later.
+- Do not change runtime, schema, or CI as part of this document.
+
+---
+
+## Copy-paste template
+
+```markdown
+# Scenario title
+
+## Scenario family
+- Primary family:
+- Why this family is the best fit:
+- Optional secondary characteristics:
+
+## Context
+Short narrative description of the diplomatic situation.
+
+## Actors
+- Actor 1:
+- Actor 2:
+- Actor 3 (optional):
+
+## Tension
+What makes the negotiation difficult.
+
+## Success criteria
+- Minimum acceptable outcome:
+- Strong outcome (optional):
+
+## Failure mode
+Typical way the negotiation could break down.
+
+## Invariants
+- Property 1:
+- Property 2:
+- Property 3 (optional):
+
+## Benchmark plan
+- yes
+- experimental
+- undecided
+
+## Notes
+Anything maintainers should know about scope, novelty, or relation to existing scenarios.
+```
+
+---
+
+## Section guidance
+
+### Scenario title
+
+Use a short, descriptive name. Prefer stable names such as
+`coalition_fracture_budget_vote` over broad labels such as `hard case`.
+
+### Scenario family
+
+Choose the family that best captures the dominant negotiation constraint.
+If the scenario mixes several dynamics, explain which one is primary.
+
+### Context
+
+Keep this to a short paragraph. Include only facts needed to understand why the
+scenario exists.
+
+### Actors
+
+List roles, not biographies. Good examples:
+
+- governing coalition,
+- regional armed faction,
+- external mediator,
+- water authority.
+
+### Tension
+
+Name the force that makes agreement hard: lack of trust, domestic vetoes,
+verification gaps, time pressure, resource scarcity, spoilers, or power
+asymmetry.
+
+### Success criteria
+
+Write outcomes that can later be reviewed or simulated. Avoid vague targets
+such as "better relations."
+
+### Failure mode
+
+Describe the most likely structural breakdown:
+
+- agreement collapses after first implementation step,
+- coalition partner defects before ratification,
+- spoiler attack resets trust,
+- resource allocation formula becomes politically unacceptable.
+
+### Invariants
+
+These are expected properties of a valid run or review. Examples:
+
+- agreement should occur before `max_rounds`,
+- mediator must appear before final agreement,
+- no success result should be recorded if verification is absent,
+- failure should remain possible under adversarial seeds.
+
+### Benchmark plan
+
+Use one of these values:
+
+- `yes`: intended for stable, maintained benchmark coverage,
+- `experimental`: useful for exploration but not yet frozen,
+- `undecided`: worth discussing before committing to benchmark maintenance.
+
+---
+
+## Review checklist
+
+Before opening a PR, confirm that:
+
+- the scenario has one clear primary family,
+- the failure mode is distinct from existing catalog entries,
+- the scenario can be described without schema changes,
+- the benchmark plan is explicit.
+
+Related documents:
+
+- [scenario_taxonomy.md](scenario_taxonomy.md)
+- [catalog.md](catalog.md)

--- a/v1_core/workflow/README.md
+++ b/v1_core/workflow/README.md
@@ -1,7 +1,9 @@
-# HUB_Optimus — Scenario Simulator
+# HUB_Optimus - Scenario Simulator
 
 ## Purpose
-This simulator enables structured, non-coercive evaluation of diplomatic, geopolitical, economic, and institutional scenarios using the HUB_Optimus Kernel.
+This simulator enables structured, non-coercive evaluation of diplomatic,
+geopolitical, economic, and institutional scenarios using the HUB_Optimus
+Kernel.
 
 It is designed to:
 - detect systemic risk before escalation,
@@ -29,5 +31,15 @@ It evaluates structural soundness.
 
 ## How to use the simulator (canonical process)
 
-### Step 1 — Define a scenario
+### Step 1 - Define a scenario
 Create a new scenario file using the canonical template:
+- [./04_scenario_template.md](./04_scenario_template.md)
+
+Reference scenarios:
+- [./scenario_001_partial_ceasefire.md](./scenario_001_partial_ceasefire.md)
+- [./scenario_002_verified_ceasefire.md](./scenario_002_verified_ceasefire.md)
+- [./scenario_003_coalition_fracture.md](./scenario_003_coalition_fracture.md)
+
+### Step 2 - Iterate and compare
+Use the follow-up workflow:
+- [./05_meta_learning.md](./05_meta_learning.md)

--- a/v1_core/workflow/es/README.md
+++ b/v1_core/workflow/es/README.md
@@ -1,20 +1,24 @@
-> 🇬🇧 English source: [../README.md](../README.md)
+> English source: [../README.md](../README.md)
 
 # Workflow (ES)
 
-Este directorio contiene el **flujo operativo** para ejecutar simulaciones diplomáticas con estructura: roles, objetivos, rondas, criterios de verificación y una capa de aprendizaje (“meta-learning”) para iterar.
+Este directorio contiene el **flujo operativo** para ejecutar simulaciones
+diplomaticas con estructura: roles, objetivos, rondas, criterios de
+verificacion y una capa de aprendizaje ("meta-learning") para iterar.
 
-## Cómo empezar (rápido)
-1) Entrada en español: [../../../docs/es/00_start_here.md](../../../docs/es/00_start_here.md)
+## Como empezar (rapido)
+1) Entrada en espanol: [../../../docs/es/00_start_here.md](../../../docs/es/00_start_here.md)
 2) Prueba guiada: [../../../docs/es/03_try_a_scenario.md](../../../docs/es/03_try_a_scenario.md)
 3) Elige un escenario:
    - Escenario 001: [./scenario_001_partial_ceasefire.md](./scenario_001_partial_ceasefire.md)
    - Escenario 002: [./scenario_002_verified_ceasefire.md](./scenario_002_verified_ceasefire.md)
+   - Escenario 003: [./scenario_003_coalition_fracture.md](./scenario_003_coalition_fracture.md)
 
-## Qué hay aquí
+## Que hay aqui
 - **Escenarios**
   - [./scenario_001_partial_ceasefire.md](./scenario_001_partial_ceasefire.md) (alto el fuego parcial)
   - [./scenario_002_verified_ceasefire.md](./scenario_002_verified_ceasefire.md) (alto el fuego verificado)
+  - [./scenario_003_coalition_fracture.md](./scenario_003_coalition_fracture.md) (fractura de coalicion)
 
 - **Plantilla para crear escenarios**
   - [./04_scenario_template.md](./04_scenario_template.md)
@@ -22,28 +26,28 @@ Este directorio contiene el **flujo operativo** para ejecutar simulaciones diplo
 - **Aprendizaje iterativo (meta-learning)**
   - [./05_meta_learning.md](./05_meta_learning.md)
 
-## Cómo ejecutar una simulación (formato recomendado)
-**Preparación (2–5 min)**
+## Como ejecutar una simulacion (formato recomendado)
+**Preparacion (2-5 min)**
 - Define roles (Parte A, Parte B, mediador/observador).
-- Define “éxito mínimo” (qué condiciones hacen que la ronda sea útil).
-- Define límites (líneas rojas y zona negociable).
+- Define "exito minimo" (que condiciones hacen que la ronda sea util).
+- Define limites (lineas rojas y zona negociable).
 
-**Ejecución (3 rondas)**
-- Ronda 1: propuesta inicial ↔ respuesta
-- Ronda 2: ajustes (concesiones, verificación, secuencia)
+**Ejecucion (3 rondas)**
+- Ronda 1: propuesta inicial <-> respuesta
+- Ronda 2: ajustes (concesiones, verificacion, secuencia)
 - Ronda 3: cierre (borrador de acuerdo + puntos abiertos)
 
 **Cierre (5 min)**
-- Evalúa: claridad, verificabilidad, viabilidad.
+- Evalua: claridad, verificabilidad, viabilidad.
 - Registra: concesiones, riesgos, condiciones de seguimiento.
-- Decide: ¿qué se prueba distinto en la próxima iteración?
+- Decide: que se prueba distinto en la proxima iteracion?
 
 ## Base conceptual (si quieres profundizar)
-- Declaración base (ES): [../../languages/es/01_base_declaracion.md](../../languages/es/01_base_declaracion.md)
+- Declaracion base (ES): [../../languages/es/01_base_declaracion.md](../../languages/es/01_base_declaracion.md)
 - Arquitectura base (ES): [../../languages/es/02_arquitectura_base.md](../../languages/es/02_arquitectura_base.md)
 - Flujo operativo (ES): [../../languages/es/03_flujo_operativo.md](../../languages/es/03_flujo_operativo.md)
 
-## Convención de idioma
+## Convencion de idioma
 - EN es la referencia original.
 - ES se mantiene en paralelo para uso y lectura.
 - Cada documento incluye un enlace a su fuente EN/ES al inicio.

--- a/v1_core/workflow/es/scenario_003_coalition_fracture.md
+++ b/v1_core/workflow/es/scenario_003_coalition_fracture.md
@@ -1,0 +1,107 @@
+> English source: [../scenario_003_coalition_fracture.md](../scenario_003_coalition_fracture.md)
+
+# Escenario 003 - Fractura de coalicion durante negociacion externa
+
+## Familia del escenario
+Familia principal: Coalition Stability
+
+Este escenario explora negociaciones en las que el progreso diplomatico
+externo depende de la cohesion interna de una coalicion gobernante.
+
+Incluso si los negociadores alcanzan un acuerdo provisional en la mesa
+externa, los actores con poder de veto domestico todavia pueden bloquear
+la ratificacion.
+
+---
+
+## Contexto
+
+Una coalicion de gobierno intenta negociar un acuerdo de estabilizacion
+con una contraparte externa.
+
+Uno de los socios minoritarios de la coalicion representa a una base
+interna que se opone con fuerza a cualquier concesion.
+
+La direccion de la coalicion cree que un arreglo diplomatico es viable,
+pero el socio menor teme un costo electoral alto y la perdida de influencia
+politica.
+
+Por eso, cada concesion externa aumenta el riesgo politico interno.
+
+---
+
+## Actores
+
+- Liderazgo de la coalicion gobernante
+- Socio menor de la coalicion (actor con veto)
+- Contraparte negociadora externa
+- Opcional: mediador u observador internacional
+
+---
+
+## Tension central
+
+El avance de la negociacion externa exige concesiones que elevan
+el costo politico interno para la coalicion.
+
+El socio menor debe decidir si le conviene mas preservar la unidad
+del gobierno o diferenciarse bloqueando el acuerdo.
+
+---
+
+## Criterios de exito
+
+Resultado minimo aceptable:
+
+- Se alcanza un acuerdo externo
+- La coalicion permanece intacta el tiempo suficiente para ratificarlo
+
+Resultado reforzado:
+
+- El liderazgo mantiene cohesion interna
+- El acuerdo externo se vuelve politicamente sostenible en el plano domestico
+
+---
+
+## Modo de fallo
+
+El fallo estructural mas probable es una **ruptura de ratificacion interna**.
+
+Vias tipicas de colapso:
+
+- el socio menor bloquea la ratificacion tras un acuerdo provisional
+- el socio de coalicion abandona el gobierno
+- las concesiones externas activan una reaccion domestica que rompe la coalicion
+
+---
+
+## Invariantes
+
+Propiedades estructurales esperadas:
+
+- Un acuerdo externo no debe contar como estabilizador si falla la ratificacion interna
+- La defeccion de la coalicion tras las concesiones debe tratarse como fallo negociador
+- El anuncio publico del acuerdo, por si solo, no cuenta como exito
+- El poder de veto interno debe poder invalidar el arreglo externo
+
+---
+
+## Plan de benchmark
+
+experimental
+
+Este escenario esta pensado como expansion exploratoria del corpus.
+
+Si iteraciones posteriores muestran patrones estructurales consistentes,
+una version derivada podria proponerse mas adelante como benchmark.
+
+---
+
+## Notas
+
+Este escenario amplia el corpus mas alla de la dinamica de alto el fuego
+al introducir **actores domesticos con poder de veto como restriccion diplomatica**.
+
+Representa una estructura comun en negociaciones reales:
+
+diplomacia externa condicionada por la politica interna de coalicion.

--- a/v1_core/workflow/scenario_003_coalition_fracture.md
+++ b/v1_core/workflow/scenario_003_coalition_fracture.md
@@ -1,0 +1,103 @@
+# Scenario 003 - Coalition Fracture Negotiation
+
+## Scenario family
+Primary family: Coalition Stability
+
+This scenario explores negotiations where external diplomatic progress
+depends on the internal cohesion of a governing coalition.
+
+Even if negotiators reach provisional agreement externally,
+domestic veto players can still block ratification.
+
+---
+
+## Context
+
+A governing coalition is attempting to negotiate a stabilization agreement
+with an external counterpart.
+
+One junior coalition partner represents a domestic constituency that strongly
+opposes concessions.
+
+The coalition leadership believes a diplomatic settlement is achievable,
+but the junior partner fears electoral backlash and loss of political leverage.
+
+External concessions therefore increase internal political risk.
+
+---
+
+## Actors
+
+- Governing coalition leadership
+- Junior coalition partner (veto player)
+- External negotiating counterpart
+- Optional: mediator or international observer
+
+---
+
+## Core tension
+
+External negotiation progress requires concessions that
+increase internal political costs for the coalition.
+
+The junior partner must decide whether maintaining coalition unity
+is more valuable than opposing the agreement.
+
+---
+
+## Success criteria
+
+Minimum acceptable outcome:
+
+- External agreement is reached
+- Coalition remains intact long enough to ratify the agreement
+
+Stronger outcome:
+
+- Coalition leadership maintains internal cohesion
+- External agreement becomes politically sustainable domestically
+
+---
+
+## Failure mode
+
+The most likely structural breakdown is **internal ratification failure**.
+
+Typical pathways include:
+
+- junior coalition partner blocks ratification after provisional agreement
+- coalition partner defects from government
+- external concessions trigger domestic backlash that collapses the coalition
+
+---
+
+## Invariants
+
+Expected structural properties:
+
+- External agreement should not count as stabilizing if internal ratification fails
+- Coalition defection after concessions must be treated as negotiation failure
+- Public announcement of agreement alone does not count as success
+- Internal veto power must remain capable of invalidating external settlement
+
+---
+
+## Benchmark plan
+
+experimental
+
+This scenario is intended as exploratory corpus expansion.
+
+If repeated runs produce consistent structural patterns,
+a future issue may promote a derived version to benchmark status.
+
+---
+
+## Notes
+
+This scenario expands the corpus beyond ceasefire dynamics by introducing
+**domestic veto players as a diplomatic constraint**.
+
+It represents a common real-world negotiation structure:
+
+external diplomacy constrained by internal coalition politics.


### PR DESCRIPTION
## Summary
Adds the first non-ceasefire narrative scenario to the HUB_Optimus workflow corpus.

Scenario: Coalition Fracture Negotiation

This introduces the **Coalition Stability** family where external diplomacy
can fail due to internal coalition veto players.

## Changes
- Added scenario_003_coalition_fracture.md
- Added Spanish mirror in workflow/es/
- Updated workflow README navigation
- Added scenario taxonomy, template, and catalog
- Registered scenario in catalog

## Scope
Documentation and workflow corpus only.

No changes to:
- runtime
- schema
- CI
- benchmarks
- simulator logic

## Status
Scenario marked **experimental**.

Future work may promote a derived scenario to benchmark status if stable patterns appear.