### PR TITLE
feat: add scenario-004 shared resource

### DIFF
--- a/docs/scenarios/catalog.md
+++ b/docs/scenarios/catalog.md
@@ -21,6 +21,7 @@ Scope notes:
 | [`scenario_001_partial_ceasefire`](../../v1_core/workflow/scenario_001_partial_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing an unverifiable ceasefire as destabilizing |
 | [`scenario_002_verified_ceasefire`](../../v1_core/workflow/scenario_002_verified_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing a verified ceasefire as stabilizing |
 | [`scenario_003_coalition_fracture`](../../v1_core/workflow/scenario_003_coalition_fracture.md) | Coalition Stability | experimental | External negotiation constrained by an internal coalition veto player |
+| [`scenario_004_shared_resource_drought`](../../v1_core/workflow/scenario_004_shared_resource_drought.md) | Shared Resource Conflict | experimental | Drought negotiation between upstream and downstream actors sharing a river basin |
 
 ---
 

--- a/v1_core/workflow/README.md
+++ b/v1_core/workflow/README.md
@@ -39,6 +39,7 @@ Reference scenarios:
 - [./scenario_001_partial_ceasefire.md](./scenario_001_partial_ceasefire.md)
 - [./scenario_002_verified_ceasefire.md](./scenario_002_verified_ceasefire.md)
 - [./scenario_003_coalition_fracture.md](./scenario_003_coalition_fracture.md)
+- [./scenario_004_shared_resource_drought.md](./scenario_004_shared_resource_drought.md)
 
 ### Step 2 - Iterate and compare
 Use the follow-up workflow:

--- a/v1_core/workflow/scenario_004_shared_resource_drought.md
+++ b/v1_core/workflow/scenario_004_shared_resource_drought.md
@@ -1,0 +1,58 @@
+# Scenario 004 - Shared Resource Drought Negotiation
+
+## Scenario family
+- Primary family: Shared Resource Conflict
+- Why this family is the best fit: The negotiation is driven primarily by
+  scarcity, allocation pressure, and the need for shared governance over a
+  resource that neither actor can control alone.
+- Optional secondary characteristics: Domestic Political Pressure,
+  Mediated Negotiation
+
+## Context
+A prolonged drought has sharply reduced water flow in a river basin shared by
+two neighboring states. The upstream actor wants to preserve domestic supply
+and agricultural output, while the downstream actor depends on stable flow to
+avoid economic disruption, public unrest, and infrastructure stress. Both
+sides recognize that unmanaged scarcity could escalate into a broader regional
+crisis, but both also face internal pressure against visible concessions.
+
+## Actors
+- Upstream state authority
+- Downstream state authority
+- Regional water management body
+- Optional international mediator
+
+## Core tension
+Water scarcity creates a zero-sum perception even when technical compromise is
+still possible. Any temporary allocation formula that stabilizes the basin will
+impose visible costs on at least one side, making it difficult for negotiators
+to defend cooperation at home.
+
+## Success criteria
+- Minimum acceptable outcome: The parties agree on a temporary drought
+  allocation formula with explicit flow-sharing rules.
+- Strong outcome (optional): The agreement includes monitoring, data-sharing,
+  and a review mechanism that makes compliance verifiable and politically
+  sustainable over multiple periods.
+
+## Failure mode
+Negotiations collapse because one or both actors reject reduced allocation,
+accuse the other side of manipulating flows, or abandon the talks after
+domestic backlash makes compromise politically costly.
+
+## Invariants
+- Scarcity must remain the primary negotiation constraint.
+- No actor can obtain full control of the shared resource.
+- Any durable agreement requires some form of shared governance, monitoring,
+  or verification.
+- Technical viability alone does not count as success unless both actors accept
+  the arrangement politically.
+
+## Benchmark plan
+- experimental
+
+## Notes
+This draft expands the corpus into the Shared Resource Conflict family and is
+intended as a narrative base for future refinement. A later issue may derive
+an executable simulator input from this scenario without changing the current
+schema.


### PR DESCRIPTION
## Summary
- Add scenario-004 shared resource drought scenario
- Update scenario catalog
- Update workflow documentation

## Why
This expands the scenario corpus with a shared-resource negotiation case and keeps documentation aligned.

## Scope
- `v1_core/workflow/scenario_004_shared_resource_drought.md` (new)
- `docs/scenarios/catalog.md` (updated)
- `v1_core/workflow/README.md` (updated)

## Non-goals
- No runtime changes
- No benchmark logic changes
- No architecture changes

## Validation
- Scenario is present and documented
- Catalog links remain consistent
- Workflow docs reflect the new scenario