### PR TITLE
docs: fix onboarding i18n links and language status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@
 
 **Integrity-first diplomatic simulation workflow for evaluation, preventive mediation, and systemic learning.**
 
-**Languages / Idiomas:** 
+**Languages / Idiomas:**
 
-> **Start here (Onboarding):**  
-> [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md) · [CA](docs/ca/00_start_here.md) · [FR](docs/fr/00_start_here.md) · [RU](docs/ru/00_start_here.md)
+> **Primary onboarding:** [EN](docs/00_start_here.md) · [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md)
+>
+> **Translation status:** CA / FR / RU = progressive translation (not language-faithful onboarding yet) · HE = stub / full translation pending · ZH = governance stub only
+>
+> Source of truth: [docs/context/STATUS.md](docs/context/STATUS.md)
 
 **Quick paths:**
-- 90 seconds: [EN](docs/00_start_here.md) · [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md) · [CA](docs/ca/00_start_here.md) · [FR](docs/fr/00_start_here.md) · [RU](docs/ru/00_start_here.md)
+- 90 seconds: [EN](docs/00_start_here.md) · [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md)
 - 20 minutes (canonical v1 ES): [v1_core/languages/es](v1_core/languages/es)
 - Hands-on: [Scenario Template](v1_core/workflow/04_scenario_template.md)
 
@@ -44,8 +47,9 @@ It is a tool for **better judgment**.
 
 ## Start in 60 seconds
 **New here?**
-- 🇬🇧 Start (EN): [docs/00_start_here.md](docs/00_start_here.md)
-- 🇪🇸 Empezar (ES): [docs/es/00_start_here.md](docs/es/00_start_here.md)
+- Start (EN): [docs/00_start_here.md](docs/00_start_here.md)
+- Empezar (ES): [docs/es/00_start_here.md](docs/es/00_start_here.md)
+- Start (DE): [docs/de/00_start_here.md](docs/de/00_start_here.md)
 
 **See it in practice (guided walkthrough):**
 - 🇬🇧 Try a scenario: [docs/03_try_a_scenario.md](docs/03_try_a_scenario.md)


### PR DESCRIPTION
## Scope
- README.md only
- Align public language navigation with docs/context/STATUS.md
- Keep EN / ES / DE as primary onboarding entries
- Present CA / FR / RU / HE / ZH as status, not false parity
- Add DE to "Start in 60 seconds"

## Out of scope
- Translating docs/*/00_start_here.md
- Editing docs/context/STATUS.md
- Runtime / CI / benchmarks / tests
- Any unrelated local changes already present in the worktree

## Validation
- python tools/check_mojibake.py README.md -> OK
- Verified linked paths exist
- Reviewed staged diff before commit
- Diff against origin/main limited to README.md

## Acceptance criteria
- EN / ES / DE remain the only primary onboarding links in root README
- CA / FR / RU / HE / ZH are shown as status, not as language-faithful onboarding
- README cites docs/context/STATUS.md as source of truth
- "Start in 60 seconds" includes DE
- Diff remains limited to README.md
