### PR TITLE
feat: add mobile_ingest CLI + docs usage example

### DIFF
--- a/docs/lab_state.md
+++ b/docs/lab_state.md
@@ -31,6 +31,20 @@ previously observed pattern changes after a code modification.
 | incentive_misalignment | 20 | 19 | 1 | 95% |
 | resource_scarcity | 20 | 16 | 4 | 80% |
 
+### Mobile Ingest (Termux)
+
+Capture a claim from a mobile terminal and append it to the dataset:
+
+```bash
+python tools/mobile_ingest.py "AI regulation in Europe is accelerating"
+```
+
+Or via stdin:
+
+```bash
+echo "AI regulation in Europe is accelerating" | python tools/mobile_ingest.py
+```
+
 ## Observed patterns
 
 - **Resource scarcity scenarios are failure-prone by design.** Tight

--- a/tools/mobile_ingest.py
+++ b/tools/mobile_ingest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "mobile_ingest.jsonl"
+ERROR_EXIT_CODE = 1
+
+
+def _read_claim(argv_claim: list[str]) -> str:
+    if argv_claim:
+        return " ".join(argv_claim).strip()
+    if not sys.stdin.isatty():
+        return sys.stdin.read().strip()
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Append a raw mobile claim to mobile_ingest.jsonl."
+    )
+    parser.add_argument("claim", nargs="*", help="Claim text to ingest.")
+    args = parser.parse_args()
+
+    claim = _read_claim(args.claim)
+    if not claim:
+        print("[mobile_ingest:error] no input provided", file=sys.stderr)
+        return ERROR_EXIT_CODE
+
+    record = {
+        "claim": claim,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source": "mobile_termux",
+        "status": "raw",
+    }
+
+    try:
+        with OUTPUT_PATH.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        print(f"[mobile_ingest:error] {exc}", file=sys.stderr)
+        return ERROR_EXIT_CODE
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Scope
- Add tools/mobile_ingest.py (CLI ingestion tool)
- Add usage example to docs/lab_state.md

## Behavior
- Accepts claim via argv or stdin
- Appends JSONL record to mobile_ingest.jsonl
- Stdlib-only, no runtime/CI impact

## Validation
- Manual smoke tests (argv, stdin, error case)
- Mojibake check passed for docs

## Out of scope
- No runtime changes
- No CI integration
- No dataset processing

## Notes
Docs commit stacked on top of tool commit to maintain consistency.
