### PR TITLE
feat: add mobile_review CLI for raw claim inspection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,19 @@ jobs:
       - name: Run tests
         run: python -m pytest -q
 
+      - name: Traceability Snapshot
+        if: always()
+        run: python tools/trace_repo.py --output-md out/traceability/trace.md --output-json out/traceability/trace.json
+
+      - name: Upload traceability artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: traceability
+          path: |
+            out/traceability/trace.md
+            out/traceability/trace.json
+
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Read Order
+1. `AGENTS.md`
+2. `docs/context/hub_optimus_checkpoint.md`
+3. `docs/context/AI_CONTEXT.md`
+4. `docs/context/STATUS.md`
+5. `docs/context/PROJECT_OVERVIEW.md`
+6. `docs/context/TRACEABILITY.md`
+
+## Non-Negotiables
+- Ship small, reversible PRs with one objective each.
+- GitHub Issues and PRs are the source of truth for roadmap and task state.
+- If repository docs conflict, `docs/context/STATUS.md` wins.
+- Do not change runtime, CI, contracts, or governance without explicit approval.
+- Preserve backward compatibility unless an approved RFC says otherwise.
+
+## Validation Commands
+- `python tools/check_mojibake.py v1_core docs README.md CONTRIBUTING.md`
+- `python -m pytest -q`
+- `python run_scenario.py example_scenario.json --output out/example.result.json`
+
+## Traceability Rule
+- If `tools/trace_repo.py` exists, run:
+  `python tools/trace_repo.py --output-md docs/context/TRACEABILITY_SNAPSHOT.md --output-json docs/context/TRACEABILITY_SNAPSHOT.json`
+- Otherwise use:
+  `powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1`
+- Read `docs/context/TRACEABILITY_SNAPSHOT.md` before merge or deploy guidance.
+
+## Working Mode
+- Use repo evidence, current git state, and reproducible checks.
+- If scope grows, split it into a follow-up issue or PR.
+- Keep docs and comments minimal, concrete, and traceable.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@
 - 90 seconds: [EN](docs/00_start_here.md) · [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md) · [CA](docs/ca/00_start_here.md) · [FR](docs/fr/00_start_here.md) · [RU](docs/ru/00_start_here.md)
 - 20 minutes (canonical v1 ES): [v1_core/languages/es](v1_core/languages/es)
 - Hands-on: [Scenario Template](v1_core/workflow/04_scenario_template.md)
+- AI / Codex bootstrap: [AGENTS.md](AGENTS.md) -> [docs/context/hub_optimus_checkpoint.md](docs/context/hub_optimus_checkpoint.md) -> [docs/context/AI_CONTEXT.md](docs/context/AI_CONTEXT.md) -> [docs/context/STATUS.md](docs/context/STATUS.md)
+
+### Traceability Snapshot
+
+Generate repository traceability snapshot:
+
+```bash
+python tools/trace_repo.py
+```
+
+Custom output:
+
+```bash
+python tools/trace_repo.py --output-md out/trace.md --output-json out/trace.json
+```
 
 
 

--- a/docs/context/AI_CONTEXT.md
+++ b/docs/context/AI_CONTEXT.md
@@ -12,6 +12,15 @@ Eres el copiloto técnico del repositorio. Tu trabajo es:
 - Prioriza coherencia: si hay conflicto entre docs, STATUS.md manda.
 - Cuando propongas cambios, incluye impacto, riesgo y plan de rollback.
 
+## Orden de arranque
+1) [docs/context/hub_optimus_checkpoint.md](hub_optimus_checkpoint.md)
+2) [docs/context/AI_CONTEXT.md](AI_CONTEXT.md)
+3) [docs/context/STATUS.md](STATUS.md)
+4) [docs/context/PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md)
+5) [docs/context/WORKFLOWS.md](WORKFLOWS.md)
+6) [docs/context/GLOSSARY.md](GLOSSARY.md)
+7) [docs/context/TRACEABILITY.md](TRACEABILITY.md)
+
 ## Fuente de verdad
 1) [docs/context/STATUS.md](STATUS.md)
 2) [docs/context/PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md)
@@ -25,6 +34,8 @@ Eres el copiloto técnico del repositorio. Tu trabajo es:
 - Explicaciones "jerga popular" cuando se pida (sin humo).
 
 ## Protocolo de trazabilidad
-- Para poner el repo al día, ejecutar:
+- Para poner el repo al día, ejecutar preferentemente:
+  `python tools/trace_repo.py`
+- Si la herramienta portable no está disponible, usar:
   `powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1`
 - Leer `docs/context/TRACEABILITY_SNAPSHOT.md` antes de responder sobre cambios, merges o deploys.

--- a/docs/context/TRACEABILITY.md
+++ b/docs/context/TRACEABILITY.md
@@ -5,11 +5,15 @@ Provide a single command that captures the repo state and automation surface
 area before any analysis, merge, or deploy decision.
 
 ## Command
-- Run: `powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1`
-- Output: `docs/context/TRACEABILITY_SNAPSHOT.md`
+- Preferred: `python tools/trace_repo.py`
+- Custom outputs: `python tools/trace_repo.py --output-md PATH --output-json PATH`
+- Fallback: `powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1`
+- Default outputs:
+  - `docs/context/TRACEABILITY_SNAPSHOT.md`
+  - `docs/context/TRACEABILITY_SNAPSHOT.json`
 
 ## What the snapshot includes
-- Timestamp and repo root path.
+- UTC timestamp and repo root path.
 - Git branch, HEAD, remotes, recent commits.
 - Working tree status and diff stats (staged and unstaged).
 - Full contents of `.github/workflows` files.

--- a/docs/context/hub_optimus_checkpoint.md
+++ b/docs/context/hub_optimus_checkpoint.md
@@ -54,7 +54,7 @@ Phase 4 — behavioral diagnostics      ← current
 
 ## Next task
 
-Task 24 — structural drift analysis for benchmarks
+Bootstrap and operational state alignment for assistant entry points
 
 ## Next action
 

--- a/docs/lab_state.md
+++ b/docs/lab_state.md
@@ -31,6 +31,20 @@ previously observed pattern changes after a code modification.
 | incentive_misalignment | 20 | 19 | 1 | 95% |
 | resource_scarcity | 20 | 16 | 4 | 80% |
 
+### Mobile Ingest (Termux)
+
+Capture a claim from a mobile terminal and append it to the dataset:
+
+```bash
+python tools/mobile_ingest.py "AI regulation in Europe is accelerating"
+```
+
+Or via stdin:
+
+```bash
+echo "AI regulation in Europe is accelerating" | python tools/mobile_ingest.py
+```
+
 ## Observed patterns
 
 - **Resource scarcity scenarios are failure-prone by design.** Tight

--- a/tests/test_trace_repo.py
+++ b/tests/test_trace_repo.py
@@ -1,0 +1,102 @@
+"""Tests for the portable traceability snapshot CLI."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parent.parent / "tools" / "trace_repo.py"
+
+
+def run_tool(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TOOL), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / ".github" / "workflows" / "ci.yml").write_text(
+        "name: CI\non: push\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("# Temp repo\n", encoding="utf-8")
+
+    git(repo, "init")
+    git(repo, "checkout", "-b", "main")
+    git(repo, "config", "user.email", "trace@example.com")
+    git(repo, "config", "user.name", "Trace Tester")
+    git(repo, "remote", "add", "origin", "https://example.com/org/repo.git")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "initial commit")
+    return repo
+
+
+def test_trace_repo_writes_markdown_and_json_with_custom_paths(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    (repo / "README.md").write_text("# Temp repo\nupdated\n", encoding="utf-8")
+    (repo / "staged.txt").write_text("staged change\n", encoding="utf-8")
+    git(repo, "add", "staged.txt")
+
+    md_path = repo / "out" / "trace.md"
+    json_path = repo / "out" / "trace.json"
+
+    result = run_tool("--output-md", str(md_path), "--output-json", str(json_path), cwd=repo)
+
+    assert result.returncode == 0, result.stderr
+    assert md_path.is_file()
+    assert json_path.is_file()
+
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "# TRACEABILITY SNAPSHOT" in markdown
+    assert "## Git status" in markdown
+    assert "## Diff stats (staged)" in markdown
+    assert "## .github/workflows" in markdown
+    assert "### ci.yml" in markdown
+    assert "staged.txt" in markdown
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["repo_root"] == str(repo.resolve())
+    assert payload["current_branch"] == "main"
+    assert len(payload["head"]) == 40
+    assert any("origin" in line for line in payload["remotes"])
+    assert payload["recent_commits"]
+    assert "staged.txt" in payload["diff_stats"]["staged"]
+    assert "README.md" in payload["diff_stats"]["unstaged"]
+    assert payload["workflows"][0]["name"] == "ci.yml"
+    assert payload["workflows"][0]["content"] == "name: CI\non: push"
+    assert any(item["name"] == ".github/" for item in payload["top_level_inventory"])
+
+
+def test_trace_repo_uses_default_docs_context_outputs(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+
+    result = run_tool(cwd=repo)
+
+    assert result.returncode == 0, result.stderr
+    assert (repo / "docs" / "context" / "TRACEABILITY_SNAPSHOT.md").is_file()
+    assert (repo / "docs" / "context" / "TRACEABILITY_SNAPSHOT.json").is_file()
+
+
+def test_trace_repo_fails_outside_git_repo(tmp_path: Path) -> None:
+    result = run_tool(cwd=tmp_path)
+
+    assert result.returncode != 0
+    assert "not inside a git repository" in result.stderr.lower()

--- a/tools/mobile_ingest.py
+++ b/tools/mobile_ingest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "mobile_ingest.jsonl"
+ERROR_EXIT_CODE = 1
+
+
+def _read_claim(argv_claim: list[str]) -> str:
+    if argv_claim:
+        return " ".join(argv_claim).strip()
+    if not sys.stdin.isatty():
+        return sys.stdin.read().strip()
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Append a raw mobile claim to mobile_ingest.jsonl."
+    )
+    parser.add_argument("claim", nargs="*", help="Claim text to ingest.")
+    args = parser.parse_args()
+
+    claim = _read_claim(args.claim)
+    if not claim:
+        print("[mobile_ingest:error] no input provided", file=sys.stderr)
+        return ERROR_EXIT_CODE
+
+    record = {
+        "claim": claim,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source": "mobile_termux",
+        "status": "raw",
+    }
+
+    try:
+        with OUTPUT_PATH.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        print(f"[mobile_ingest:error] {exc}", file=sys.stderr)
+        return ERROR_EXIT_CODE
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mobile_review.py
+++ b/tools/mobile_review.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_INPUT_PATH = Path(__file__).resolve().parent.parent / "mobile_ingest.jsonl"
+ERROR_PREFIX = "[mobile_review:error]"
+SHORT_CLAIM_THRESHOLD = 10
+
+WORD_RE = re.compile(r"[^\W_]+(?:['-][^\W_]+)?", re.UNICODE)
+
+VAGUE_MARKERS = {
+    ".",
+    "..",
+    "...",
+    "\u2026",
+    "lo que detectes",
+    "lo que veas interesante",
+    "claim que quieras guardar",
+}
+
+SHORT_MEANINGFUL_TERMS = {
+    "eeuu",
+    "gaza",
+    "iran",
+    "israel",
+    "trump",
+    "tiktok",
+}
+
+STOPWORDS = {
+    "a",
+    "al",
+    "algo",
+    "an",
+    "and",
+    "ante",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "con",
+    "como",
+    "cu\u00e1l",
+    "cual",
+    "de",
+    "del",
+    "desde",
+    "donde",
+    "el",
+    "ella",
+    "en",
+    "es",
+    "esa",
+    "ese",
+    "eso",
+    "esta",
+    "este",
+    "esto",
+    "for",
+    "from",
+    "hay",
+    "in",
+    "is",
+    "la",
+    "las",
+    "le",
+    "lo",
+    "los",
+    "m\u00e1s",
+    "mas",
+    "mi",
+    "mis",
+    "no",
+    "of",
+    "on",
+    "or",
+    "para",
+    "pero",
+    "por",
+    "que",
+    "qu\u00e9",
+    "se",
+    "si",
+    "sin",
+    "sobre",
+    "su",
+    "sus",
+    "te",
+    "that",
+    "the",
+    "this",
+    "to",
+    "tu",
+    "un",
+    "una",
+    "uno",
+    "with",
+    "y",
+    "ya",
+}
+
+TOPIC_PATTERNS = {
+    "espa\u00f1a": (r"\bespana\b", r"\bspain\b"),
+    "ia / deepfake": (
+        r"\bai\b",
+        r"\bia\b",
+        r"\bdeepfake\b",
+        r"\bdeepfakes\b",
+        r"\bartificial intelligence\b",
+        r"\binteligencia artificial\b",
+    ),
+    "iran": (r"\biran\b", r"\biranian\b"),
+    "israel": (r"\bisrael\b", r"\bisraeli\b"),
+    "netanyahu": (r"\bnetanyahu\b",),
+    "tel aviv": (r"\btel aviv\b",),
+    "tiktok": (r"\btiktok\b",),
+    "trump": (r"\btrump\b",),
+    "x": (
+        r"\bpost viral en x\b",
+        r"\bpost en x\b",
+        r"\bx\.com\b",
+        r"\btwitter\b",
+    ),
+}
+
+TOPIC_REGEXES = {
+    topic: tuple(re.compile(pattern) for pattern in patterns)
+    for topic, patterns in TOPIC_PATTERNS.items()
+}
+
+
+class MobileReviewError(Exception):
+    """Raised for deterministic user-facing review errors."""
+
+
+class MobileReviewArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self.exit(2, f"{ERROR_PREFIX} {message}\n")
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    line_number: int
+    claim: str
+    timestamp: str
+    source: str
+    status: str
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def build_parser() -> MobileReviewArgumentParser:
+    parser = MobileReviewArgumentParser(
+        description="Review raw mobile claims stored in mobile_ingest.jsonl."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT_PATH),
+        help="Path to the mobile_ingest.jsonl dataset.",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Show total claims and dataset time range.",
+    )
+    parser.add_argument(
+        "--latest",
+        type=_positive_int,
+        metavar="N",
+        help="Show the latest N claims in readable form.",
+    )
+    parser.add_argument(
+        "--duplicates",
+        action="store_true",
+        help="Show exact duplicate claim texts with counts.",
+    )
+    parser.add_argument(
+        "--flag-vague",
+        action="store_true",
+        help="Show vague or underspecified claims.",
+    )
+    parser.add_argument(
+        "--keywords",
+        action="store_true",
+        help="Show keyword frequency over claim text.",
+    )
+    parser.add_argument(
+        "--topics",
+        action="store_true",
+        help="Show simple topic-family counts.",
+    )
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    return parser.parse_args(argv)
+
+
+def _has_selected_action(args: argparse.Namespace) -> bool:
+    return any(
+        (
+            args.summary,
+            args.latest is not None,
+            args.duplicates,
+            args.flag_vague,
+            args.keywords,
+            args.topics,
+        )
+    )
+
+
+def _coerce_text(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def load_records(path: Path) -> list[ClaimRecord]:
+    if not path.exists() or not path.is_file():
+        raise MobileReviewError(f"input file not found: {path}")
+
+    records: list[ClaimRecord] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                if not raw_line.strip():
+                    continue
+                try:
+                    payload = json.loads(raw_line)
+                except json.JSONDecodeError as exc:
+                    raise MobileReviewError(
+                        f"invalid JSON on line {line_number}: {exc.msg}"
+                    ) from exc
+                if not isinstance(payload, dict):
+                    raise MobileReviewError(
+                        f"line {line_number} must contain a JSON object"
+                    )
+                records.append(
+                    ClaimRecord(
+                        line_number=line_number,
+                        claim=_coerce_text(payload.get("claim")),
+                        timestamp=_coerce_text(payload.get("timestamp")),
+                        source=_coerce_text(payload.get("source")),
+                        status=_coerce_text(payload.get("status")),
+                    )
+                )
+    except OSError as exc:
+        raise MobileReviewError(str(exc)) from exc
+
+    return records
+
+
+def summarize_records(records: list[ClaimRecord]) -> list[str]:
+    first_timestamp = records[0].timestamp if records else "-"
+    last_timestamp = records[-1].timestamp if records else "-"
+    return [
+        "Summary",
+        f"- Total claims: {len(records)}",
+        f"- First timestamp: {first_timestamp or '-'}",
+        f"- Last timestamp: {last_timestamp or '-'}",
+    ]
+
+
+def select_latest_records(records: list[ClaimRecord], limit: int) -> list[ClaimRecord]:
+    return list(reversed(records[-limit:]))
+
+
+def format_latest_records(records: list[ClaimRecord], limit: int) -> list[str]:
+    selected = select_latest_records(records, limit)
+    lines = [f"Latest {limit} Claims"]
+    if not selected:
+        lines.append("(no claims found)")
+        return lines
+
+    for index, record in enumerate(selected, start=1):
+        metadata = " | ".join(
+            part
+            for part in (
+                f"line {record.line_number}",
+                record.timestamp or "-",
+                record.source or "-",
+                record.status or "-",
+            )
+        )
+        lines.append(f"{index}. {metadata}")
+        lines.append(f"   {record.claim or '(empty claim)'}")
+    return lines
+
+
+def find_duplicate_claims(records: list[ClaimRecord]) -> list[tuple[str, int]]:
+    counts = Counter(record.claim for record in records)
+    duplicates = [
+        (claim, count)
+        for claim, count in counts.items()
+        if count > 1
+    ]
+    return sorted(duplicates, key=lambda item: (-item[1], item[0].casefold(), item[0]))
+
+
+def format_duplicate_claims(records: list[ClaimRecord]) -> list[str]:
+    duplicates = find_duplicate_claims(records)
+    lines = ["Duplicate Claims"]
+    if not duplicates:
+        lines.append("(no exact duplicates found)")
+        return lines
+    for claim, count in duplicates:
+        lines.append(f"- {count}x | {claim or '(empty claim)'}")
+    return lines
+
+
+def _normalize_text(text: str) -> str:
+    return " ".join(text.casefold().split())
+
+
+def _fold_text(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text.casefold())
+    return "".join(char for char in normalized if not unicodedata.combining(char))
+
+
+def _looks_meaningful_short_claim(normalized_text: str) -> bool:
+    tokens = WORD_RE.findall(normalized_text)
+    if not tokens:
+        return False
+    if any(token.isdigit() for token in tokens):
+        return True
+    if len(tokens) >= 2:
+        return True
+    return tokens[0] in SHORT_MEANINGFUL_TERMS
+
+
+def classify_vague_claim(record: ClaimRecord) -> str | None:
+    normalized = _normalize_text(record.claim)
+    if not normalized:
+        return "empty claim"
+    if normalized in VAGUE_MARKERS:
+        return "generic marker"
+    if not re.search(r"\w", normalized, re.UNICODE):
+        return "punctuation only"
+
+    compact = normalized.replace(" ", "")
+    if len(compact) < SHORT_CLAIM_THRESHOLD and not _looks_meaningful_short_claim(normalized):
+        return f"short claim (<{SHORT_CLAIM_THRESHOLD} chars)"
+    return None
+
+
+def find_vague_claims(records: list[ClaimRecord]) -> list[tuple[ClaimRecord, str]]:
+    flagged: list[tuple[ClaimRecord, str]] = []
+    for record in records:
+        reason = classify_vague_claim(record)
+        if reason:
+            flagged.append((record, reason))
+    return flagged
+
+
+def format_vague_claims(records: list[ClaimRecord]) -> list[str]:
+    flagged = find_vague_claims(records)
+    lines = ["Vague Claims"]
+    if not flagged:
+        lines.append("(no vague claims found)")
+        return lines
+    for record, reason in flagged:
+        lines.append(
+            f"- line {record.line_number} | {reason} | {record.claim or '(empty claim)'}"
+        )
+    return lines
+
+
+def tokenize_claim_text(text: str) -> list[str]:
+    tokens = WORD_RE.findall(_fold_text(text))
+    kept: list[str] = []
+    for token in tokens:
+        if token.isdigit():
+            continue
+        if len(token) == 1 and token != "x":
+            continue
+        if token in STOPWORDS:
+            continue
+        kept.append(token)
+    return kept
+
+
+def count_keywords(records: list[ClaimRecord]) -> list[tuple[str, int]]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        counts.update(tokenize_claim_text(record.claim))
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+
+
+def format_keywords(records: list[ClaimRecord]) -> list[str]:
+    keywords = count_keywords(records)
+    lines = ["Keyword Frequency"]
+    if not keywords:
+        lines.append("(no keywords found)")
+        return lines
+    for keyword, count in keywords:
+        lines.append(f"- {keyword}: {count}")
+    return lines
+
+
+def count_topic_families(records: list[ClaimRecord]) -> list[tuple[str, int]]:
+    counts = {topic: 0 for topic in TOPIC_PATTERNS}
+    for record in records:
+        folded = _fold_text(record.claim)
+        for topic, regexes in TOPIC_REGEXES.items():
+            if any(regex.search(folded) for regex in regexes):
+                counts[topic] += 1
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+
+
+def format_topic_families(records: list[ClaimRecord]) -> list[str]:
+    topics = count_topic_families(records)
+    lines = ["Topic Families"]
+    for topic, count in topics:
+        lines.append(f"- {topic}: {count}")
+    return lines
+
+
+def _print_sections(sections: list[list[str]]) -> None:
+    for index, lines in enumerate(sections):
+        if index:
+            print()
+        for line in lines:
+            print(line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not _has_selected_action(args):
+        parser.print_help()
+        return 0
+
+    try:
+        records = load_records(Path(args.input))
+    except MobileReviewError as exc:
+        print(f"{ERROR_PREFIX} {exc}", file=sys.stderr)
+        return 1
+
+    sections: list[list[str]] = []
+    if args.summary:
+        sections.append(summarize_records(records))
+    if args.latest is not None:
+        sections.append(format_latest_records(records, args.latest))
+    if args.duplicates:
+        sections.append(format_duplicate_claims(records))
+    if args.flag_vague:
+        sections.append(format_vague_claims(records))
+    if args.keywords:
+        sections.append(format_keywords(records))
+    if args.topics:
+        sections.append(format_topic_families(records))
+
+    _print_sections(sections)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/trace_repo.py
+++ b/tools/trace_repo.py
@@ -1,0 +1,242 @@
+"""Portable repo snapshot generator for HUB_Optimus."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MD_OUTPUT = Path("docs/context/TRACEABILITY_SNAPSHOT.md")
+DEFAULT_JSON_OUTPUT = Path("docs/context/TRACEABILITY_SNAPSHOT.json")
+RECENT_COMMIT_LIMIT = 20
+
+
+def run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def detect_repo_root(cwd: Path) -> Path:
+    try:
+        result = run_git(["rev-parse", "--show-toplevel"], cwd)
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable not found") from exc
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        message = "not inside a git repository"
+        if detail:
+            message = f"{message}: {detail}"
+        raise RuntimeError(message)
+
+    root = result.stdout.strip().splitlines()[0].strip()
+    return Path(root).resolve()
+
+
+def git_text(
+    repo_root: Path,
+    args: list[str],
+    empty_fallback: str,
+) -> str:
+    result = run_git(args, repo_root)
+    text = result.stdout.strip()
+    if result.returncode != 0:
+        error_text = (result.stderr or text).strip()
+        return f"ERROR: {error_text or 'git command failed'}"
+    if not text:
+        return empty_fallback
+    return text
+
+
+def git_lines(
+    repo_root: Path,
+    args: list[str],
+    empty_fallback: str,
+) -> list[str]:
+    return git_text(repo_root, args, empty_fallback).splitlines()
+
+
+def collect_workflows(repo_root: Path) -> list[dict[str, str]]:
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+
+    files = sorted(
+        path for path in workflows_dir.iterdir()
+        if path.is_file() and path.suffix.lower() in {".yml", ".yaml"}
+    )
+    workflows: list[dict[str, str]] = []
+    for path in files:
+        workflows.append(
+            {
+                "name": path.name,
+                "path": str(path.relative_to(repo_root)).replace("\\", "/"),
+                "content": path.read_text(encoding="utf-8", errors="replace").rstrip(),
+            }
+        )
+    return workflows
+
+
+def collect_inventory(repo_root: Path) -> list[dict[str, str]]:
+    inventory: list[dict[str, str]] = []
+    for path in sorted(repo_root.iterdir(), key=lambda item: item.name.lower()):
+        if path.name == ".git":
+            continue
+        kind = "dir" if path.is_dir() else "file"
+        name = f"{path.name}/" if path.is_dir() else path.name
+        inventory.append({"kind": kind, "name": name})
+    return inventory
+
+
+def collect_snapshot(repo_root: Path) -> dict[str, Any]:
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    branch = git_text(repo_root, ["branch", "--show-current"], "(detached HEAD)")
+    if branch == "(detached HEAD)":
+        branch = git_text(repo_root, ["rev-parse", "--abbrev-ref", "HEAD"], "(detached HEAD)")
+
+    return {
+        "timestamp_utc": timestamp,
+        "repo_root": str(repo_root),
+        "current_branch": branch,
+        "head": git_text(repo_root, ["rev-parse", "HEAD"], "UNKNOWN"),
+        "remotes": git_lines(repo_root, ["remote", "-v"], "(no remotes configured)"),
+        "recent_commits": git_lines(
+            repo_root,
+            ["log", "--oneline", "--decorate", "-n", str(RECENT_COMMIT_LIMIT)],
+            "(no commits found)",
+        ),
+        "git_status": git_text(repo_root, ["status", "-sb"], "(no status output)"),
+        "diff_stats": {
+            "unstaged": git_text(repo_root, ["diff", "--stat"], "(no unstaged changes)"),
+            "staged": git_text(repo_root, ["diff", "--staged", "--stat"], "(no staged changes)"),
+        },
+        "workflows": collect_workflows(repo_root),
+        "top_level_inventory": collect_inventory(repo_root),
+    }
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    lines: list[str] = [
+        "# TRACEABILITY SNAPSHOT",
+        "",
+        f"- Timestamp: **{snapshot['timestamp_utc']}**",
+        f"- Repo root: {snapshot['repo_root']}",
+        f"- Branch: **{snapshot['current_branch']}**",
+        f"- HEAD: {snapshot['head']}",
+        "",
+        "## Git status",
+        "~~~text",
+        snapshot["git_status"],
+        "~~~",
+        "",
+        "## Diff stats (unstaged)",
+        "~~~text",
+        snapshot["diff_stats"]["unstaged"],
+        "~~~",
+        "",
+        "## Diff stats (staged)",
+        "~~~text",
+        snapshot["diff_stats"]["staged"],
+        "~~~",
+        "",
+        f"## Recent commits (last {RECENT_COMMIT_LIMIT})",
+        "~~~text",
+        "\n".join(snapshot["recent_commits"]),
+        "~~~",
+        "",
+        "## Remotes",
+        "~~~text",
+        "\n".join(snapshot["remotes"]),
+        "~~~",
+        "",
+        "## Top-level inventory",
+    ]
+
+    for item in snapshot["top_level_inventory"]:
+        lines.append(f"- {item['kind']} {item['name']}")
+
+    lines.extend(["", "## .github/workflows"])
+
+    workflows = snapshot["workflows"]
+    if not workflows:
+        lines.append("(no workflow files found)")
+    else:
+        for workflow in workflows:
+            lines.extend(
+                [
+                    "",
+                    f"### {workflow['name']}",
+                    "~~~yaml",
+                    workflow["content"],
+                    "~~~",
+                ]
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def write_text_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+
+
+def write_json_file(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=None,
+        help="Write the markdown snapshot to PATH.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Write the JSON snapshot to PATH.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    try:
+        repo_root = detect_repo_root(Path.cwd())
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    snapshot = collect_snapshot(repo_root)
+    markdown = render_markdown(snapshot)
+
+    md_path = args.output_md or (repo_root / DEFAULT_MD_OUTPUT)
+    json_path = args.output_json or (repo_root / DEFAULT_JSON_OUTPUT)
+
+    write_text_file(md_path, markdown)
+    write_json_file(json_path, snapshot)
+
+    print(f"OK: wrote {md_path}")
+    print(f"OK: wrote {json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope
- Add `tools/mobile_review.py` as a stdlib-only CLI for reviewing raw mobile claims
- Read `mobile_ingest.jsonl` by default, with optional `--input`

## Features
- `--summary`
- `--latest N`
- `--duplicates`
- `--flag-vague`
- `--keywords`
- `--topics`

## Behavior
- Stable terminal output
- User-facing errors with `[mobile_review:error]`
- Ignores blank lines in JSONL
- Topic family `x` restricted to explicit patterns (`post en X`, `post viral en X`, `x.com`, `twitter`)

## Validation
- Manual CLI validation completed for:
  - help / no flags
  - missing file
  - malformed JSON
  - summary
  - latest
  - duplicates
  - vague claims
  - keywords
  - topics
- `python -m py_compile tools/mobile_review.py` passed

## Out of scope
- No runtime/scenario changes
- No CI integration
- No tests
- No semantic deduplication or clustering
