### PR TITLE
scenarios: add scenario 005 for Spain diplomatic-war accusation

### DIFF
--- a/v1_core/workflow/scenario_005_spain_diplomatic_war_accusation.md
+++ b/v1_core/workflow/scenario_005_spain_diplomatic_war_accusation.md
@@ -1,0 +1,139 @@
+# Scenario 005 - Diplomatic Escalation via Accusation Against Spain
+
+## 0) Scenario identification
+- **Scenario ID:** SCN-005
+- **Domain:** geopolitical
+- **Date / version:** v0.1
+- **Evaluator(s):** HUB_Optimus (guided)
+- **Confidentiality level:** internal
+
+---
+
+## 1) Trigger
+On 2026-04-10, Benjamin Netanyahu publicly accused Spain of waging a
+"diplomatic war" against Israel, and Israeli authorities removed Spanish
+representatives from a Gaza/Kiryat Gat coordination context. On 2026-04-11,
+Israel also reprimanded Spain's top diplomatic representative in Tel Aviv over
+the burning of an effigy of Netanyahu in El Burgo.
+
+---
+
+## 2) Structural context
+- The accusation is public and declarative; no neutral verification channel is
+  defined.
+- Spain has publicly criticized Israeli actions in Gaza, Lebanon, and the
+  wider regional escalation.
+- Israel has escalated its response through coordination restrictions and
+  public diplomatic reprimand.
+- Media and social platforms amplify high-conflict framing faster than
+  institutional evidence review.
+- Domestic political incentives reward rhetorical escalation and symbolic
+  retaliation.
+- International audiences may conflate accusation, evidence, and legitimacy
+  under time pressure.
+
+---
+
+## 3) Incentive analysis (Layer 2)
+- **Rewarded behaviors:**
+  - rapid public escalation,
+  - narrative dominance,
+  - reputational signaling to domestic audiences.
+- **Punished behaviors:**
+  - evidentiary restraint,
+  - procedural clarification,
+  - delayed messaging pending verification.
+- **Escalation risk:**
+  - high, because symbolic retaliation can displace attention from verifiable
+    humanitarian and legal facts.
+- **Signal:** accusation-driven framing may outperform evidence-driven
+  assessment.
+
+**Output:**
+- Incentive map indicates optics > verification.
+- Risk of narrative diversion detected.
+
+---
+
+## 4) Human calibration (Layer 1)
+- Audiences are likely to over-weight conflict rhetoric and under-weight
+  evidentiary gaps.
+- Viral distribution increases certainty effects even when the underlying
+  accusation remains weakly substantiated.
+- Diplomatic polarization narrows the space for corrective framing.
+
+**Output:**
+- Priority: high
+- Framing guidance: separate verified facts from narrative inference.
+
+---
+
+## 5) Systemic evaluation (Layer 3)
+1. **Future risk reduction:** low
+2. **Medium/long-term stability:** negative
+3. **Immediate suffering reduction:** none
+4. **Incentive correction:** negative
+5. **Lock-in effects:** moderate to high (normalizes retaliatory narrative
+   escalation)
+
+**Outputs:**
+- Risk classification: high
+- Stability impact: negative
+- Correctability window: open but shrinking
+
+---
+
+## 6) Historical pattern check (Layer 5)
+- Pattern match: yes
+- Comparable episodes show that rhetorical interstate escalation can crowd out
+  evidence-focused accountability.
+- Recurrent failure mode: narrative conflict displacing institutional
+  verification.
+
+**Outputs:**
+- Recurrence warning level: medium-high
+
+---
+
+## 7) Kernel coherence check (Layer 0)
+- Weak alignment with medium/long-term stability.
+- Encourages declarative confrontation without independent verification.
+- Increases false-success risk for public discourse.
+
+**Decision:**
+- Rejected as stabilizing diplomatic posture.
+
+**Rationale:**
+The structure rewards escalation and attention capture rather than verifiable
+correction.
+
+---
+
+## 8) Preventive mediation options (Layer 4)
+- Re-center discussion on independently verifiable humanitarian and legal
+  facts.
+- Require documented evidence and neutral channels before escalating
+  diplomatic claims.
+- Reduce public rhetorical load while preserving formal accountability
+  pathways.
+
+---
+
+## 9) Final classification
+- **Outcome type:** destabilizing (narrative escalation)
+- **Primary risk vector:** declarative accusation without neutral verification
+- **Recommended posture:** document, decompose, and de-escalate rhetorically
+
+---
+
+## 10) Memory integration
+- Register pattern: "Attention-diversion via diplomatic accusation"
+- Reuse when public blame-shifting competes with evidence-led scrutiny.
+
+---
+
+## 11) Notes
+This scenario is about structural incentives and evidentiary weakness, not
+about adjudicating the broader underlying geopolitical dispute. The possible
+"attention diversion" effect is treated as systemic analysis, not as the base
+factual claim.


### PR DESCRIPTION
﻿## What changed
- add `v1_core/workflow/scenario_005_spain_diplomatic_war_accusation.md`
- model the April 2026 Spain-Israel diplomatic escalation as a declarative accusation scenario
- keep verification weakness inside structural context
- treat "attention diversion" as analytical/systemic inference, not as the base factual claim

## Scope
- one new scenario file only
- no runtime changes
- no schema changes
- no CI changes

## Validation
- `python tools/check_mojibake.py v1_core docs README.md CONTRIBUTING.md`
- `python -m pytest -q`

## Diff check
- `git diff --name-only main...HEAD`
  - `v1_core/workflow/scenario_005_spain_diplomatic_war_accusation.md`
