### PR TITLE
docs: register scenario 005 in scenario catalog

### DIFF
--- a/docs/context/hub_optimus_checkpoint.md
+++ b/docs/context/hub_optimus_checkpoint.md
@@ -17,7 +17,7 @@
 - PR #109 merged
 - Benchmark summary visible in CI
 - `runtime_contract.md` published
-- Scenario corpus: 001–004 integrated
+- Scenario corpus: 001–005 integrated
 
 ## Scenario corpus
 
@@ -27,12 +27,14 @@
 | 002 | Verified Ceasefire        | Ceasefire Negotiation    |
 | 003 | Coalition Fracture        | Coalition Stability      |
 | 004 | Shared Resource Drought   | Shared Resource Conflict |
+| 005 | Spain Diplomatic War Accusation | Domestic Political Pressure |
 
 ## Active taxonomy families
 
 - Ceasefire Negotiation
 - Coalition Stability
 - Shared Resource Conflict
+- Domestic Political Pressure
 
 ## Documentary infrastructure
 

--- a/docs/scenarios/catalog.md
+++ b/docs/scenarios/catalog.md
@@ -22,6 +22,7 @@ Scope notes:
 | [`scenario_002_verified_ceasefire`](../../v1_core/workflow/scenario_002_verified_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing a verified ceasefire as stabilizing |
 | [`scenario_003_coalition_fracture`](../../v1_core/workflow/scenario_003_coalition_fracture.md) | Coalition Stability | experimental | External negotiation constrained by an internal coalition veto player |
 | [`scenario_004_shared_resource_drought`](../../v1_core/workflow/scenario_004_shared_resource_drought.md) | Shared Resource Conflict | experimental | Drought negotiation between upstream and downstream actors sharing a river basin |
+| [`scenario_005_spain_diplomatic_war_accusation`](../../v1_core/workflow/scenario_005_spain_diplomatic_war_accusation.md) | Domestic Political Pressure | experimental | Accusation-driven diplomatic escalation where public framing can displace verification. |
 
 ---
 

--- a/v1_core/workflow/README.md
+++ b/v1_core/workflow/README.md
@@ -40,6 +40,7 @@ Reference scenarios:
 - [./scenario_002_verified_ceasefire.md](./scenario_002_verified_ceasefire.md)
 - [./scenario_003_coalition_fracture.md](./scenario_003_coalition_fracture.md)
 - [./scenario_004_shared_resource_drought.md](./scenario_004_shared_resource_drought.md)
+- [./scenario_005_spain_diplomatic_war_accusation.md](./scenario_005_spain_diplomatic_war_accusation.md)
 
 ### Step 2 - Iterate and compare
 Use the follow-up workflow:


### PR DESCRIPTION
## Summary

- Register `scenario_005_spain_diplomatic_war_accusation` in the scenario catalog
- Add scenario 005 to the workflow README reference list
- Update the systemic checkpoint from corpus `001–004` to `001–005`
- Add `Domestic Political Pressure` to active taxonomy families

## Why

`scenario_005_spain_diplomatic_war_accusation.md` already exists in the workflow corpus, but it was not yet discoverable through the scenario catalog, workflow README, or checkpoint.

This PR closes that integration gap without touching runtime behavior.

## Scope

- `docs/scenarios/catalog.md`
- `v1_core/workflow/README.md`
- `docs/context/hub_optimus_checkpoint.md`

## Out of scope

- No runtime changes
- No schema changes
- No benchmark changes
- No CI changes
- No new scenario family
- No cleanup of unrelated generated/context artifacts

## Validation

- `python -m pytest -q`
  - `42 passed`
- `python tools/check_mojibake.py docs/scenarios/catalog.md v1_core/workflow/README.md docs/context/hub_optimus_checkpoint.md`
  - passed
- `git diff --check`
  - passed
- `git diff --name-only main`
  - only the 3 expected files

## Known unrelated issue

The broader guard:

```bash
python tools/check_mojibake.py v1_core docs README.md CONTRIBUTING.md
```

currently fails on pre-existing mojibake in:

```text
docs/context/TRACEABILITY_SNAPSHOT.md
```

affected lines:

```text
630, 635, 640, 645, 650, 655, 660, 675
```

This PR does not touch that file because it is outside the scenario registration scope.