### PR TITLE
data: add NorthStone Putin/Kremlin screenshots as unverified geopolitical claim pack

### DIFF
--- a/datasets/geopolitical_claim_packs/README.md
+++ b/datasets/geopolitical_claim_packs/README.md
@@ -1,0 +1,20 @@
+# Geopolitical Claim Packs
+
+This lane stores high-risk geopolitical screenshot or post material as structured
+claims, not as evidence and not as factual findings.
+
+Operator rules:
+- Treat every record as an attributed social media assertion.
+- Do not mark any claim true or false without external primary evidence.
+- Split observable claims from inference, intelligence, or psychological-state claims.
+- Preserve the evidence gap and the source context in every claim.
+- Use benchmark behavior to test decomposition and epistemic restraint, not factual judgment.
+
+Current limitation:
+- Screenshot assets are not stored in this directory. Records are operator-supplied
+  structured transcriptions intended for review and stress testing.
+
+Files:
+- `claim_pack.schema.json`: machine-validatable schema for geopolitical claim packs.
+- `northstone_putin_security_2026_pack_001.json`: unverified NorthStone / TikTok
+  claim pack anchored to GitHub issue #1574.

--- a/datasets/geopolitical_claim_packs/claim_pack.schema.json
+++ b/datasets/geopolitical_claim_packs/claim_pack.schema.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "geopolitical_claim_pack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "claim_pack_id",
+    "github_issue",
+    "source_type",
+    "source_platform",
+    "source_handle_visible",
+    "publisher_label_visible",
+    "ingested_on",
+    "verification_status",
+    "evidence_tier",
+    "overall_risk",
+    "source_assets",
+    "claims",
+    "recommended_use",
+    "not_recommended_use",
+    "benchmark"
+  ],
+  "properties": {
+    "claim_pack_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "github_issue": {
+      "type": "string",
+      "pattern": "^https://github.com/.+/issues/[0-9]+$"
+    },
+    "source_type": {
+      "type": "string",
+      "enum": ["social_media_screenshot"]
+    },
+    "source_platform": {
+      "type": "string",
+      "enum": ["tiktok"]
+    },
+    "source_handle_visible": {
+      "type": "string",
+      "pattern": ".*\\S.*"
+    },
+    "publisher_label_visible": {
+      "type": "string",
+      "pattern": ".*\\S.*"
+    },
+    "ingested_on": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "verification_status": {
+      "type": "string",
+      "enum": ["unverified"]
+    },
+    "evidence_tier": {
+      "type": "string",
+      "enum": ["low", "very_low"]
+    },
+    "overall_risk": {
+      "type": "string",
+      "enum": ["medium_high", "high", "very_high"]
+    },
+    "source_assets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": ".*\\S.*"
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "claim_id",
+          "source_label",
+          "source_type",
+          "claim_text",
+          "domain",
+          "claim_type",
+          "verification_status",
+          "evidence_tier",
+          "risk_level",
+          "primary_evidence_needed",
+          "notes",
+          "subclaims"
+        ],
+        "properties": {
+          "claim_id": {
+            "type": "string",
+            "pattern": "^ns_[a-z0-9_]+_[0-9]{3}$"
+          },
+          "source_label": {
+            "type": "string",
+            "pattern": ".*\\S.*"
+          },
+          "source_type": {
+            "type": "string",
+            "enum": ["social_media_screenshot"]
+          },
+          "claim_text": {
+            "type": "string",
+            "pattern": "^A social media post claims.*\\S.*"
+          },
+          "domain": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": ".*\\S.*"
+            }
+          },
+          "claim_type": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": ".*\\S.*"
+            }
+          },
+          "verification_status": {
+            "type": "string",
+            "enum": ["unverified"]
+          },
+          "evidence_tier": {
+            "type": "string",
+            "enum": ["low", "very_low"]
+          },
+          "risk_level": {
+            "type": "string",
+            "enum": ["medium_high", "high", "very_high"]
+          },
+          "primary_evidence_needed": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": ".*\\S.*"
+            }
+          },
+          "notes": {
+            "type": "string",
+            "pattern": ".*\\S.*"
+          },
+          "subclaims": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["text", "type", "verification_notes"],
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "pattern": ".*\\S.*"
+                },
+                "type": {
+                  "type": "string",
+                  "pattern": ".*\\S.*"
+                },
+                "verification_notes": {
+                  "type": "string",
+                  "pattern": ".*\\S.*"
+                }
+              }
+            }
+          },
+          "inference_chain": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": ".*\\S.*"
+            }
+          },
+          "red_flags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": ".*\\S.*"
+            }
+          }
+        }
+      }
+    },
+    "recommended_use": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": ".*\\S.*"
+      }
+    },
+    "not_recommended_use": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": ".*\\S.*"
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenario", "expected_behavior"],
+      "properties": {
+        "scenario": {
+          "type": "string",
+          "const": "social_media_geopolitical_claim_pack"
+        },
+        "expected_behavior": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": ".*\\S.*"
+          }
+        }
+      }
+    }
+  }
+}

--- a/datasets/geopolitical_claim_packs/northstone_putin_security_2026_pack_001.json
+++ b/datasets/geopolitical_claim_packs/northstone_putin_security_2026_pack_001.json
@@ -1,0 +1,344 @@
+{
+  "claim_pack_id": "northstone_putin_security_2026_pack_001",
+  "github_issue": "https://github.com/Voxterrae/HUB_Optimus/issues/1574",
+  "source_type": "social_media_screenshot",
+  "source_platform": "tiktok",
+  "source_handle_visible": "@cotedelamer",
+  "publisher_label_visible": "NorthStone",
+  "ingested_on": "2026-05-08",
+  "verification_status": "unverified",
+  "evidence_tier": "low",
+  "overall_risk": "high",
+  "source_assets": [],
+  "claims": [
+    {
+      "claim_id": "ns_putin_victory_day_2026_001",
+      "source_label": "NorthStone / TikTok screenshot",
+      "source_type": "social_media_screenshot",
+      "claim_text": "A social media post claims that on May 9 Victory Day in Moscow there were no tanks, no missiles, and no heavy equipment, and that videos released by the Kremlin were pre-recorded.",
+      "domain": [
+        "geopolitics",
+        "russian_domestic_politics",
+        "information_integrity"
+      ],
+      "claim_type": [
+        "event_claim",
+        "media_authenticity_claim"
+      ],
+      "verification_status": "unverified",
+      "evidence_tier": "low",
+      "risk_level": "high",
+      "primary_evidence_needed": [
+        "official Victory Day parade footage",
+        "independent media footage from Moscow on May 9",
+        "satellite imagery or OSINT imagery",
+        "Kremlin release metadata",
+        "reports from credible news agencies"
+      ],
+      "notes": "The claim combines an observable event claim with a stronger media manipulation claim. These should be evaluated separately. The May 9 reference is retained as screenshot wording and is not treated as a verified chronology.",
+      "subclaims": [
+        {
+          "text": "No tanks, missiles, or heavy equipment appeared at the Moscow Victory Day event.",
+          "type": "observable_event_claim",
+          "verification_notes": "Check official footage, independent media, and geolocated OSINT imagery."
+        },
+        {
+          "text": "Kremlin videos of the event were pre-recorded.",
+          "type": "media_authenticity_claim",
+          "verification_notes": "Check metadata, visual geolocation, timestamp consistency, and release provenance."
+        },
+        {
+          "text": "Convoy tracking indicates a location outside Moscow.",
+          "type": "location_intelligence_claim",
+          "verification_notes": "Requires the underlying tracking data and a method that links convoy movement to protected-person location."
+        },
+        {
+          "text": "Putin was not in Moscow.",
+          "type": "location_claim",
+          "verification_notes": "High evidence burden; cannot be inferred from the screenshot alone."
+        }
+      ]
+    },
+    {
+      "claim_id": "ns_putin_location_2026_002",
+      "source_label": "NorthStone / TikTok screenshot",
+      "source_type": "social_media_screenshot",
+      "claim_text": "A social media post claims that Kremlin convoy tracking shows Putin has been in a bunker in Krasnodar region for weeks and is not in Moscow.",
+      "domain": [
+        "geopolitics",
+        "osint",
+        "russian_domestic_politics"
+      ],
+      "claim_type": [
+        "location_claim",
+        "intelligence_claim",
+        "inference_claim"
+      ],
+      "verification_status": "unverified",
+      "evidence_tier": "very_low",
+      "risk_level": "very_high",
+      "primary_evidence_needed": [
+        "convoy tracking dataset",
+        "methodology for linking convoy movement to person location",
+        "independent corroboration",
+        "geolocated imagery",
+        "credible reporting"
+      ],
+      "notes": "This is a weak evidentiary claim unless convoy tracking data and methodology are provided. Movement of official convoys does not automatically prove personal location.",
+      "subclaims": [
+        {
+          "text": "Kremlin convoy tracking data exists and is available to the source.",
+          "type": "source_methodology_claim",
+          "verification_notes": "Requires the raw or auditable tracking dataset."
+        },
+        {
+          "text": "The convoy movement can be linked to Putin personally.",
+          "type": "inference_claim",
+          "verification_notes": "Requires methodology and independent corroboration."
+        },
+        {
+          "text": "Putin has been in a bunker in Krasnodar region for weeks.",
+          "type": "location_claim",
+          "verification_notes": "Requires geolocated imagery, credible reporting, or comparable primary evidence."
+        },
+        {
+          "text": "Putin is not in Moscow.",
+          "type": "absence_location_claim",
+          "verification_notes": "Requires positive evidence of alternate location or reliable contemporaneous absence evidence."
+        }
+      ],
+      "inference_chain": [
+        "convoy movement",
+        "presumed protected-person movement",
+        "bunker location",
+        "absence from Moscow"
+      ]
+    },
+    {
+      "claim_id": "ns_kremlin_security_2026_003",
+      "source_label": "NorthStone / TikTok screenshot",
+      "source_type": "social_media_screenshot",
+      "claim_text": "A social media post claims that internal Kremlin security measures changed, including surveillance in homes of close staff, restrictions on cooks and bodyguards, no internet near Putin, double body searches, and FSB wiretapping redirected toward government officials.",
+      "domain": [
+        "russian_domestic_politics",
+        "security_services",
+        "information_integrity"
+      ],
+      "claim_type": [
+        "institutional_claim",
+        "security_procedure_claim",
+        "intelligence_claim"
+      ],
+      "verification_status": "unverified",
+      "evidence_tier": "very_low",
+      "risk_level": "high",
+      "primary_evidence_needed": [
+        "named source",
+        "leaked directive or document",
+        "corroborating investigative reporting",
+        "testimony from identifiable insiders",
+        "court records or procurement records if surveillance equipment is involved"
+      ],
+      "notes": "The post presents several specific operational claims without visible sourcing. Each item should be split into an independent claim before any evaluation.",
+      "subclaims": [
+        {
+          "text": "Surveillance was installed in homes of close staff.",
+          "type": "security_procedure_claim",
+          "verification_notes": "Severe claim; requires documentary evidence or named corroboration."
+        },
+        {
+          "text": "Cooks and bodyguards were banned from public transport.",
+          "type": "security_procedure_claim",
+          "verification_notes": "Possible but unsupported without directives or insider testimony."
+        },
+        {
+          "text": "Phones near Putin have no internet access.",
+          "type": "security_procedure_claim",
+          "verification_notes": "Plausible as a security practice, still unverified."
+        },
+        {
+          "text": "Two full body searches are required before entering rooms.",
+          "type": "security_procedure_claim",
+          "verification_notes": "Plausible but unsourced."
+        },
+        {
+          "text": "FSB wiretapping was redirected toward government officials.",
+          "type": "intelligence_claim",
+          "verification_notes": "Major intelligence claim requiring high-burden evidence."
+        }
+      ]
+    },
+    {
+      "claim_id": "ns_putin_military_visits_2026_004",
+      "source_label": "NorthStone / TikTok screenshot",
+      "source_type": "social_media_screenshot",
+      "claim_text": "A social media post claims that Putin has not visited a single military facility in 2026, and that this is confirmed by movement tracking of official Kremlin convoys.",
+      "domain": [
+        "geopolitics",
+        "russian_domestic_politics",
+        "osint"
+      ],
+      "claim_type": [
+        "absence_claim",
+        "movement_tracking_claim"
+      ],
+      "verification_status": "unverified",
+      "evidence_tier": "low",
+      "risk_level": "medium_high",
+      "primary_evidence_needed": [
+        "public schedule archive",
+        "Kremlin official visit logs",
+        "independent media reports",
+        "OSINT tracking logs",
+        "methodology defining what counts as a military facility"
+      ],
+      "notes": "This is more testable than the bunker claim because public visit records may be checked. However, an absence claim requires careful scope definition: no evidence of a visit is not the same as confirmed no visit.",
+      "subclaims": [
+        {
+          "text": "There are no public records of Putin visiting a military facility in 2026.",
+          "type": "absence_claim",
+          "verification_notes": "Check official schedule archives and credible reporting."
+        },
+        {
+          "text": "Movement tracking of official Kremlin convoys confirms no such visit.",
+          "type": "movement_tracking_claim",
+          "verification_notes": "Requires the tracking logs and a method defining coverage and false negatives."
+        }
+      ],
+      "inference_chain": [
+        "no observed public visit",
+        "movement tracking coverage is assumed complete",
+        "confirmed absence from all military facilities"
+      ]
+    },
+    {
+      "claim_id": "ns_eu_intel_assassination_fear_2026_005",
+      "source_label": "NorthStone / TikTok screenshot",
+      "source_type": "social_media_screenshot",
+      "claim_text": "A social media post claims that a European intelligence agency released or leaked a classified report stating that Putin fears assassination by his own political elite, specifically by drone.",
+      "domain": [
+        "geopolitics",
+        "intelligence",
+        "russian_domestic_politics"
+      ],
+      "claim_type": [
+        "classified_report_claim",
+        "threat_assessment_claim",
+        "psychological_state_claim"
+      ],
+      "verification_status": "unverified",
+      "evidence_tier": "very_low",
+      "risk_level": "very_high",
+      "primary_evidence_needed": [
+        "name of the intelligence agency",
+        "text or excerpt of the alleged report",
+        "provenance of leak",
+        "corroboration by reputable outlets",
+        "official denial or confirmation if available"
+      ],
+      "notes": "This is a high-risk claim because it invokes anonymous intelligence authority and asserts internal psychological state and assassination threat without visible evidence.",
+      "subclaims": [
+        {
+          "text": "A European intelligence agency produced a classified report.",
+          "type": "classified_report_claim",
+          "verification_notes": "Requires agency identity, report text, or credible reporting on the leak."
+        },
+        {
+          "text": "The report was released or leaked.",
+          "type": "provenance_claim",
+          "verification_notes": "Requires leak provenance and source chain."
+        },
+        {
+          "text": "The report states Putin fears assassination by his own political elite.",
+          "type": "psychological_state_claim",
+          "verification_notes": "Requires direct report text or credible attributed reporting."
+        },
+        {
+          "text": "The feared assassination method is specifically drone-based.",
+          "type": "threat_assessment_claim",
+          "verification_notes": "Requires the alleged report text or independently corroborated detail."
+        }
+      ],
+      "red_flags": [
+        "European intelligence agency",
+        "classified report",
+        "not meant to be public",
+        "specifically by drone"
+      ]
+    },
+    {
+      "claim_id": "ns_shoigu_coup_risk_2026_006",
+      "source_label": "NorthStone / TikTok screenshot",
+      "source_type": "social_media_screenshot",
+      "claim_text": "A social media post claims that Sergei Shoigu was identified as a coup risk, that his deputy was arrested on March 5, 2026, and that intelligence sources interpret this as breaking an unspoken agreement among Russian elites not to arrest each other.",
+      "domain": [
+        "russian_domestic_politics",
+        "elite_politics",
+        "security_services"
+      ],
+      "claim_type": [
+        "political_risk_claim",
+        "arrest_claim",
+        "elite_dynamics_inference"
+      ],
+      "verification_status": "unverified",
+      "evidence_tier": "low",
+      "risk_level": "high",
+      "primary_evidence_needed": [
+        "confirmed identity of the deputy",
+        "official arrest record",
+        "court filing",
+        "reputable media confirmation",
+        "evidence supporting coup risk designation",
+        "source for alleged elite agreement"
+      ],
+      "notes": "This contains one potentially verifiable factual claim about an arrest and several interpretive claims about elite politics.",
+      "subclaims": [
+        {
+          "text": "A Shoigu deputy was arrested on March 5, 2026.",
+          "type": "arrest_claim",
+          "verification_notes": "Check identity, official records, court filings, and reputable media confirmation."
+        },
+        {
+          "text": "Shoigu was identified as a coup risk.",
+          "type": "political_risk_claim",
+          "verification_notes": "Hard to verify without attributed intelligence or documentary evidence."
+        },
+        {
+          "text": "The arrest broke an unspoken elite agreement not to arrest each other.",
+          "type": "elite_dynamics_inference",
+          "verification_notes": "Political analysis or inference unless sourced by credible evidence."
+        },
+        {
+          "text": "Russian elites operate under an unattributed quote equivalent to 'we do not arrest each other'.",
+          "type": "unattributed_quote_claim",
+          "verification_notes": "High risk unless source and context are provided."
+        }
+      ]
+    }
+  ],
+  "recommended_use": [
+    "claim_extraction",
+    "narrative_risk_analysis",
+    "evidence_gap_detection",
+    "osint_methodology_stress_test"
+  ],
+  "not_recommended_use": [
+    "factual_assertion",
+    "truth_label_without_sources",
+    "public_report_without_verification"
+  ],
+  "benchmark": {
+    "scenario": "social_media_geopolitical_claim_pack",
+    "expected_behavior": [
+      "does_not_assert_truth",
+      "extracts_subclaims",
+      "marks_evidence_insufficient",
+      "identifies_unsupported_inference_chains",
+      "requests_primary_sources",
+      "separates_observable_from_intelligence_claims",
+      "preserves_social_media_source_context",
+      "keeps_absence_claims_scope_limited"
+    ]
+  }
+}

--- a/tests/test_geopolitical_claim_packs.py
+++ b/tests/test_geopolitical_claim_packs.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATASET_DIR = REPO_ROOT / "datasets" / "geopolitical_claim_packs"
+SCHEMA_PATH = DATASET_DIR / "claim_pack.schema.json"
+NORTHSTONE_PACK = DATASET_DIR / "northstone_putin_security_2026_pack_001.json"
+
+
+def _load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_geopolitical_claim_packs_validate_against_schema() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    validator = jsonschema.Draft202012Validator(schema)
+
+    pack_files = sorted(
+        path for path in DATASET_DIR.glob("*.json") if path.name != "claim_pack.schema.json"
+    )
+    assert pack_files
+
+    for pack_file in pack_files:
+        payload = _load_json(pack_file)
+        errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
+        assert errors == [], [error.message for error in errors]
+
+
+def test_northstone_pack_keeps_screenshot_claims_unverified() -> None:
+    pack = _load_json(NORTHSTONE_PACK)
+    assert isinstance(pack, dict)
+
+    assert pack["source_type"] == "social_media_screenshot"
+    assert pack["verification_status"] == "unverified"
+    assert pack["evidence_tier"] == "low"
+    assert pack["overall_risk"] == "high"
+    assert len(pack["claims"]) >= 5
+
+    for claim in pack["claims"]:
+        assert claim["source_type"] == "social_media_screenshot"
+        assert claim["verification_status"] == "unverified"
+        assert claim["evidence_tier"] in {"low", "very_low"}
+        assert claim["risk_level"] in {"medium_high", "high", "very_high"}
+        assert claim["claim_text"].startswith("A social media post claims")
+        assert claim["primary_evidence_needed"]
+        assert "truth_status" not in claim
+        assert "true" not in claim
+        assert "false" not in claim
+
+
+def test_northstone_pack_marks_high_burden_inference_claims() -> None:
+    pack = _load_json(NORTHSTONE_PACK)
+    assert isinstance(pack, dict)
+    claims = {claim["claim_id"]: claim for claim in pack["claims"]}
+
+    location_claim = claims["ns_putin_location_2026_002"]
+    assert location_claim["evidence_tier"] == "very_low"
+    assert location_claim["risk_level"] == "very_high"
+    assert location_claim["inference_chain"] == [
+        "convoy movement",
+        "presumed protected-person movement",
+        "bunker location",
+        "absence from Moscow",
+    ]
+
+    classified_report_claim = claims["ns_eu_intel_assassination_fear_2026_005"]
+    assert classified_report_claim["evidence_tier"] == "very_low"
+    assert classified_report_claim["risk_level"] == "very_high"
+    assert {
+        "European intelligence agency",
+        "classified report",
+        "not meant to be public",
+        "specifically by drone",
+    }.issubset(set(classified_report_claim["red_flags"]))
+
+
+def test_northstone_benchmark_expected_behavior_preserves_epistemic_restraint() -> None:
+    pack = _load_json(NORTHSTONE_PACK)
+    assert isinstance(pack, dict)
+    benchmark = pack["benchmark"]
+
+    assert benchmark["scenario"] == "social_media_geopolitical_claim_pack"
+    assert {
+        "does_not_assert_truth",
+        "extracts_subclaims",
+        "marks_evidence_insufficient",
+        "identifies_unsupported_inference_chains",
+        "requests_primary_sources",
+        "separates_observable_from_intelligence_claims",
+        "preserves_social_media_source_context",
+        "keeps_absence_claims_scope_limited",
+    }.issubset(set(benchmark["expected_behavior"]))


### PR DESCRIPTION
## Summary

Closes #1574.

Implements #1574 as an isolated geopolitical claim pack dataset.

This adds a structured, unverified social media claim pack derived from NorthStone / TikTok screenshots. The pack is explicitly treated as dataset material, not as factual evidence.

## Files changed

- `datasets/geopolitical_claim_packs/README.md`
- `datasets/geopolitical_claim_packs/claim_pack.schema.json`
- `datasets/geopolitical_claim_packs/northstone_putin_security_2026_pack_001.json`
- `tests/test_geopolitical_claim_packs.py`

## Acceptance criteria

- Adds 6 structured claims.
- Uses `source_type: social_media_screenshot`.
- Uses `verification_status: unverified`.
- Uses low / very_low evidence tiers.
- Uses medium_high / high / very_high risk levels.
- Frames claims as social media assertions, not facts.
- Separates observable claims from inference/intelligence claims.
- Marks inference chains explicitly.
- Adds deterministic tests preventing factual conversion of unverified claims.

## Validation

- `python -m pytest tests/test_geopolitical_claim_packs.py -q` -> 4 passed
- `python tools/check_mojibake.py datasets/geopolitical_claim_packs` -> passed
- `python -m pytest -q` -> 46 passed

Known unrelated issue:

- `python tools/check_mojibake.py v1_core docs README.md CONTRIBUTING.md` fails due to preexisting mojibake in `docs/context/TRACEABILITY_SNAPSHOT.md`.
- This is outside the scope of this PR and is tracked separately in #1575.

## Out of scope

- No factual verification of the claims.
- No binary screenshot ingestion.
- No runtime/kernel changes.
- No changes to existing `ai_risk_narratives` schema.