### PR TITLE
docs: add AI handoff protocol for ChatGPT/Codex sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md - HUB_Optimus
+
+You are Codex working on HUB_Optimus.
+
+## Source of Truth
+
+GitHub Issues, Pull Requests, Project board state, and repository docs are the only source of truth.
+Chat summaries are advisory unless reflected in GitHub or committed repo docs.
+
+## Operating Rules
+
+- No big rewrites.
+- No surprise architecture changes.
+- No roadmap edits without an approved RFC or issue.
+- One problem equals one small, reversible PR.
+- Prefer measurable increments.
+- Keep runtime behavior stable unless explicitly scoped.
+- Do not mix unrelated feature, refactor, docs, and cosmetic cleanup.
+- Do not touch runtime, CI, benchmarks, schemas, or kernel/governance contracts unless the issue explicitly asks for it.
+- If repeated mistakes appear, update this file with the stable rule instead of repeating the same correction in chat.
+
+## Required Reading
+
+Before changing files, read:
+
+1. `README.md`
+2. `docs/context/AI_HANDOFF.md`
+3. `docs/context/STATUS.md`, if present
+4. `docs/architecture/runtime_contract.md`, if present
+5. The relevant GitHub issue or Pull Request
+
+If a required file is missing, state that explicitly and continue with the smallest safe scope.
+
+## Default Output Format
+
+- Decision
+- Scope
+- Files changed
+- Acceptance criteria
+- Validation
+- Risks
+- AI_HANDOFF.md update
+- Next PR recommendation
+
+## Current Strategic Bias
+
+Prefer observability, benchmark clarity, CI visibility, and controlled drift detection.
+Do not introduce LLM-as-judge, dashboards, semantic scoring, roadmap changes, or runtime contract changes unless explicitly approved in GitHub.
+
+## Handoff Discipline
+
+After meaningful work, update `docs/context/AI_HANDOFF.md` with:
+
+- What changed
+- Which issue or PR justified it
+- What validation ran
+- What remains pending
+- What should not be done yet
+- The next recommended action

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -7,7 +7,7 @@ GitHub remains the source of truth; chat context only matters when it is reflect
 
 - Release: use GitHub Releases as source of truth.
 - Last merged PR: #1572, `docs: register scenario 005 in scenario catalog`.
-- Current branch: `docs/ai-handoff-protocol`.
+- Current branch: see active GitHub issue or PR; `main` is the source of truth after merge.
 - CI status: use GitHub Checks on the active PR as source of truth.
 - Active issue: #1577, `docs: add AI handoff protocol for ChatGPT/Codex sync`.
 - Current priority: add persistent AI handoff protocol without touching runtime, CI, benchmarks, or schemas.
@@ -55,7 +55,7 @@ GitHub remains the source of truth; chat context only matters when it is reflect
 Date: 2026-05-08
 Source: Codex execution for GitHub issue #1577
 Repo state: governance documentation update validated locally
-Branch: docs/ai-handoff-protocol
+Branch: see active GitHub issue or PR; `main` is the source of truth after merge
 Last merged PR: #1572
 Active issue: #1577
 Decision made: add persistent repo-level handoff protocol for ChatGPT/Codex sync
@@ -68,7 +68,7 @@ Validation:
 - `python tools/check_mojibake.py AGENTS.md docs/context/AI_HANDOFF.md` passed
 - `python -m pytest -q` passed, 42 tests
 Risks: low; documentation-only change
-Next action: prepare a small PR for issue #1577
+Next action: after merge, use this file as the AI handoff source for future Codex/ChatGPT sessions
 Out of scope:
 - runtime changes
 - CI changes

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -1,0 +1,79 @@
+# HUB_Optimus AI Handoff
+
+This file is the living bridge between ChatGPT PM/Tech Lead work and Codex repo execution.
+GitHub remains the source of truth; chat context only matters when it is reflected in issues, PRs, or repo docs.
+
+## Current System State
+
+- Release: use GitHub Releases as source of truth.
+- Last merged PR: #1572, `docs: register scenario 005 in scenario catalog`.
+- Current branch: `docs/ai-handoff-protocol`.
+- CI status: use GitHub Checks on the active PR as source of truth.
+- Active issue: #1577, `docs: add AI handoff protocol for ChatGPT/Codex sync`.
+- Current priority: add persistent AI handoff protocol without touching runtime, CI, benchmarks, or schemas.
+
+## Recent Decisions
+
+- Decision: synchronize ChatGPT and Codex through GitHub state, not through unsynchronized chat memory.
+- Reason: repository files, issues, and PRs are reviewable, durable, and reproducible.
+- Date: 2026-05-08.
+- Source: GitHub issue #1577 and ChatGPT PM handoff summary.
+
+## Current Constraints
+
+- No big rewrites.
+- No roadmap edits without RFC or approved issue.
+- Runtime contract must remain stable unless explicitly scoped.
+- Small PRs only.
+- Keep source-of-truth conflicts resolved by `docs/context/STATUS.md`.
+
+## Next Recommended Action
+
+- Issue: #1577.
+- Scope: add `AGENTS.md` and this handoff file only.
+- Acceptance criteria:
+  - `AGENTS.md` exists at repo root.
+  - `docs/context/AI_HANDOFF.md` exists.
+  - Both files state GitHub is the source of truth.
+  - Codex is instructed to update `AI_HANDOFF.md` after meaningful work.
+  - No runtime, CI, benchmark, or schema files are touched.
+- Validation command:
+  - `git diff --check`
+  - `python tools/check_mojibake.py AGENTS.md docs/context/AI_HANDOFF.md`
+  - `python -m pytest -q`
+
+## Do Not Do
+
+- Do not touch runtime unless an issue explicitly says so.
+- Do not add LLM-as-judge yet.
+- Do not replace byte-for-byte benchmark guard.
+- Do not add dashboards, semantic scoring, or new metrics without approved issue scope.
+- Do not treat chat-only decisions as roadmap changes.
+
+## AI Sync Block
+
+Date: 2026-05-08
+Source: Codex execution for GitHub issue #1577
+Repo state: governance documentation update validated locally
+Branch: docs/ai-handoff-protocol
+Last merged PR: #1572
+Active issue: #1577
+Decision made: add persistent repo-level handoff protocol for ChatGPT/Codex sync
+Reason: align AI work through GitHub state instead of fragile chat-memory synchronization
+Files changed:
+- AGENTS.md
+- docs/context/AI_HANDOFF.md
+Validation:
+- `git diff --check` passed
+- `python tools/check_mojibake.py AGENTS.md docs/context/AI_HANDOFF.md` passed
+- `python -m pytest -q` passed, 42 tests
+Risks: low; documentation-only change
+Next action: prepare a small PR for issue #1577
+Out of scope:
+- runtime changes
+- CI changes
+- benchmark changes
+- schema changes
+- roadmap changes
+- LLM-as-judge
+- dashboards


### PR DESCRIPTION
## Summary

Adds repo-level AI coordination protocol so ChatGPT and Codex operate from GitHub state instead of unsynchronized chat memory.

Closes #1577.

## Scope

Added:
- `AGENTS.md`
- `docs/context/AI_HANDOFF.md`

No runtime, CI, benchmark, schema, simulator, or dataset files changed.

## Validation

- `git diff --check`
- `python tools/check_mojibake.py AGENTS.md docs/context/AI_HANDOFF.md`
- `python -m pytest -q` (`42 passed`)

## Governance impact

- GitHub remains the single source of truth.
- Codex must read repo instructions before work.
- Codex must update `docs/context/AI_HANDOFF.md` after meaningful work.
- Chat summaries are advisory unless reflected in GitHub.

## Out of scope

- No runtime changes
- No CI changes
- No benchmark changes
- No schema changes
- No roadmap changes
- No geopolitical claim pack changes