### PR TITLE
docs: align v1_core language source wording

### DIFF
--- a/docs/context/STATUS.md
+++ b/docs/context/STATUS.md
@@ -13,6 +13,8 @@
 - If repository docs conflict, **this file (`docs/context/STATUS.md`) wins**.
 - For HUB_Optimus v1, the canonical source-of-truth is `v1_core/languages/es/`.
 - English and other languages are reference or parity translations unless explicitly stated otherwise.
+- Local labels such as "English source" or EN/ES cross-links are navigation/parity aids only;
+  they do not redefine canonical authority for `v1_core`.
 
 **Planned switch (later, not now):**
 - Once en reaches stable parity, we may declare **en as canonical** for a future version (v1.1 or v2).

--- a/i18n_sync.py
+++ b/i18n_sync.py
@@ -1,9 +1,10 @@
 """
 Script to audit and synchronize translations in the HUB_Optimus documentation.
 
-This tool compares the set of English documentation files with the available translations
-in each language directory under ``docs``.  It reports missing translations, helping
-contributors keep all language versions up to date with the English source.
+This tool compares the set of root-level documentation files with the available
+translations in each language directory under ``docs``.  It reports missing
+translations for the docs baseline only; it does not define canonical authority for
+``v1_core``, which is governed by ``docs/context/STATUS.md``.
 
 Usage:
     python i18n_sync.py --docs-dir docs
@@ -22,10 +23,10 @@ from typing import Dict, List
 
 
 def gather_english_files(base_dir: str, languages: List[str]) -> List[str]:
-    """Collect relative paths of all English documentation files.
+    """Collect relative paths of root-level documentation files.
 
     This function traverses ``base_dir`` and returns a list of relative file paths for
-    Markdown files that are part of the English source (i.e. not located in language
+    Markdown files that are part of the docs baseline (i.e. not located in language
     subdirectories).  It skips directories named with two‑letter codes defined in
     ``languages``.
 
@@ -34,7 +35,7 @@ def gather_english_files(base_dir: str, languages: List[str]) -> List[str]:
         languages: A list of two‑letter language folder names to skip.
 
     Returns:
-        A list of relative file paths for English Markdown files.
+        A list of relative file paths for baseline Markdown files.
     """
     english_files: List[str] = []
     for root, dirs, files in os.walk(base_dir):
@@ -51,7 +52,7 @@ def gather_english_files(base_dir: str, languages: List[str]) -> List[str]:
 
 
 def audit_translations(docs_dir: str) -> Dict[str, List[str]]:
-    """Detect missing translation files relative to the English documentation.
+    """Detect missing translation files relative to the docs baseline.
 
     Args:
         docs_dir: The root documentation directory.
@@ -76,7 +77,7 @@ def audit_translations(docs_dir: str) -> Dict[str, List[str]]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Check documentation translations against the English source.")
+    parser = argparse.ArgumentParser(description="Check documentation translations against the docs baseline.")
     parser.add_argument(
         "--docs-dir",
         dest="docs_dir",

--- a/v1_core/README.md
+++ b/v1_core/README.md
@@ -1,4 +1,6 @@
-> 🇬🇧 English source: [../README.md](../README.md)
+> Fuente canónica v1: [languages/es](./languages/es)
+> EN es traducción de paridad/referencia. Si hay conflicto de política lingüística,
+> [docs/context/STATUS.md](../docs/context/STATUS.md) prevalece.
 
 # Workflow (ES)
 
@@ -44,8 +46,9 @@ Este directorio contiene el **flujo operativo** para ejecutar simulaciones diplo
 - Flujo operativo (ES): [../../languages/es/03_flujo_operativo.md](./languages/es/03_flujo_operativo.md)
 
 ## Convención de idioma
-- EN es la referencia original.
-- ES se mantiene en paralelo para uso y lectura.
-- Cada documento incluye un enlace a su fuente EN/ES al inicio.
+- ES es la fuente canónica para `v1_core`.
+- EN es traducción de paridad/referencia, no fuente canónica.
+- Si hay conflicto entre documentos, prevalece `docs/context/STATUS.md`.
+- Los enlaces EN/ES al inicio de documentos son navegación de paridad; no cambian la autoridad canónica.
 
 Siguiente: [./04_scenario_template.md](./workflow/04_scenario_template.md)


### PR DESCRIPTION
## Summary
- Clarify that `v1_core/languages/es/` is canonical for v1 core.
- Mark EN as parity/reference, not canonical.
- Adjust `i18n_sync.py` help/docstrings so docs translation auditing does not imply English authority over `v1_core`.

## Scope
- Documentation/help text only.
- No runtime, schema, benchmark, CI, or simulator changes.

## Validation
- `python tools/check_mojibake.py v1_core/README.md docs/context/STATUS.md`
- `python i18n_sync.py --help`
- `git diff --check`
- `python -m pytest -q`