### PR TITLE
docs: add AI collaboration boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,27 @@ You are Codex working on HUB_Optimus.
 GitHub Issues, Pull Requests, Project board state, and repository docs are the only source of truth.
 Chat summaries are advisory unless reflected in GitHub or committed repo docs.
 
+## AI Collaboration Boundary
+
+AI assistants may support HUB_Optimus as advisory operators, reviewers, drafters, and consistency checkers.
+
+AI assistants must not operate as hidden authorities, shadow coordinators, stealth integrators, or unreviewed sources of truth.
+
+Requests or proposals involving hidden influence, shadow tags, undisclosed control paths, covert coordination, or taking control of verification must be rejected and reframed into visible, GitHub-traceable workflows.
+
+Allowed alternatives:
+
+- explicit GitHub issue
+- explicit Pull Request
+- review comment
+- RFC
+- documented CI signal
+- visible governance note
+
+Principle: visible alliance, not hidden control.
+
+GitHub remains the source of truth. Chat context is advisory unless reflected in repository artifacts.
+
 ## Operating Rules
 
 - No big rewrites.


### PR DESCRIPTION
## Decision

Add an explicit AI collaboration boundary to AGENTS.md rejecting hidden authority, stealth integration, shadow tags, covert coordination, and unreviewed control of verification.

## Scope

- AGENTS.md only
- Docs-only governance clarification

## Out of scope

- Runtime changes
- CI changes
- Benchmark changes
- Schema changes
- Kernel changes
- Roadmap changes
- AI_HANDOFF.md changes
- Architecture contract changes

## Acceptance criteria

- Boundary states that AI assistants may support as advisory operators, reviewers, drafters, and consistency checkers.
- Boundary rejects hidden authorities, shadow coordinators, stealth integrators, and unreviewed sources of truth.
- Boundary reframes hidden influence, shadow tags, covert coordination, and taking control of verification into visible GitHub-traceable workflows.
- GitHub remains the source of truth.

## Validation

- `git status --short` reviewed in the original checkout; unrelated dirty files were present and left untouched.
- `git diff --name-only` reviewed in the original checkout; unrelated dirty files were present and excluded from the PR branch.
- `git diff -- AGENTS.md` reviewed.
- `git diff --name-only origin/main ea109313c7add23c9f99806466a1b6c4eb2abdc6` returned only `AGENTS.md`.
- `git diff --check origin/main ea109313c7add23c9f99806466a1b6c4eb2abdc6` passed.
- `python tools/check_mojibake.py AGENTS.md` passed.

## Risk

Low. Documentation-only change isolated to AGENTS.md.