### PR TITLE
docs(fr): convert onboarding to honest stub

### DIFF
--- a/docs/fr/00_start_here.md
+++ b/docs/fr/00_start_here.md
@@ -1,144 +1,31 @@
-<!-- TODO: TRANSLATE -->
-# Start Here — HUB_Optimus in 10 minutes
+# HUB_Optimus — page de démarrage (FR)
 
-## What is HUB_Optimus?
-HUB_Optimus is an open, integrity-first framework that helps evaluate diplomatic and institutional decisions using:
-- systemic incentive analysis,
-- a stability-first evaluation lens,
-- a non-coercive prevention posture,
-- and structured scenario simulation.
+> **Statut de traduction :** l’onboarding français est en cours de préparation.  
+> Cette page est un stub honnête, pas une traduction complète et fidèle.
 
-It does not replace diplomats.  
-It improves how decisions are evaluated before escalation becomes irreversible.
+## Où aller maintenant
 
----
+Utilisez l’un des points d’entrée actuels :
 
-## What problem does it solve?
-Modern systems often repeat known failures because:
-- incentives reward short-term optics,
-- early correction mechanisms are weak,
-- narratives override evaluation,
-- historical patterns are ignored until it is too late.
+- English onboarding: [docs/00_start_here.md](../00_start_here.md)
+- Español onboarding: [docs/es/00_start_here.md](../es/00_start_here.md)
+- Deutsch onboarding: [docs/de/00_start_here.md](../de/00_start_here.md)
+- Main README: [README.md](../../README.md)
 
-HUB_Optimus exists to break that cycle.
+## Ce que signifie ce statut
 
----
+- Cette page n’est pas une spécification canonique.
+- Cette page ne prétend pas que la documentation française est terminée.
+- Le sens principal du projet doit être vérifié dans les documents d’entrée EN / ES / DE actuels.
+- Le contenu canonique v1 se trouve dans le noyau espagnol : [v1_core/languages/es](../../v1_core/languages/es)
 
-<!-- HUB:TRACKS -->
-## Choose your path
+## Pour contribuer
 
-**90 seconds (executive):**
-- What this is / isn't: [Kernel](governance/KERNEL.md)
-- How evaluation works: [Evaluation Standard](governance/EVALUATION_STANDARD.md)
-- How scenarios are defined: [Scenario Schema](governance/SCENARIO_SCHEMA.md)
+Si vous souhaitez aider à la traduction française, travaillez par petites PR vérifiables :
 
-**20 minutes (practitioner):**
-- Core spec (ES, canonical v1):  
-  [01_base_declaracion](../../v1_core/languages/es/01_base_declaracion.md)
-  [02_arquitectura_base](../../v1_core/languages/es/02_arquitectura_base.md)
-  [03_flujo_operativo](../../v1_core/languages/es/03_flujo_operativo.md)
-- English reference:  
-  [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)
+- un fichier à la fois ;
+- sans changement de sens ;
+- sans nouvelles fonctionnalités ;
+- sans modification du runtime, du schema, de la CI ou de la governance.
 
-**Try it (hands-on):**
-- Template: [Scenario Template](../../v1_core/workflow/04_scenario_template.md)
-- Examples: [Scenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- Learning loop: [Meta Learning](../../v1_core/workflow/05_meta_learning.md)
-<!-- /HUB:TRACKS -->
-
-## Governance
-- Charter: [governance/CHARTER.md](governance/CHARTER.md)
-- Kernel: [governance/KERNEL.md](governance/KERNEL.md)
-- Consensus Process: [governance/CONSENSUS_PROCESS.md](governance/CONSENSUS_PROCESS.md)
-- Custodianship: [governance/CUSTODIANSHIP.md](governance/CUSTODIANSHIP.md)
-- Name & Identity Use: [governance/TRADEMARKS.md](governance/TRADEMARKS.md)
-- Trust Layer (evidence & verification): [governance/TRUST_LAYER.md](governance/TRUST_LAYER.md)
-- Evaluation Standard: [governance/EVALUATION_STANDARD.md](governance/EVALUATION_STANDARD.md)
-- Scenario Schema: [governance/SCENARIO_SCHEMA.md](governance/SCENARIO_SCHEMA.md)
-- Legitimacy Model: [governance/LEGITIMACY_MODEL.md](governance/LEGITIMACY_MODEL.md)
-
-
-
----
-
-## What HUB_Optimus is NOT
-- Not a predictive oracle.
-- Not a decision authority.
-- Not propaganda.
-- Not a tribunal to assign personal blame.
-- Not a coercive enforcement tool.
-
----
-
-## How to explore this repository (recommended path)
-
-### If you only have 5 minutes
-1) Read the main README:
-- [README.md](../../README.md)
-
-2) Read the simulator overview:
-- [../../v1_core/workflow/README.md](../../v1_core/workflow/README.md)
-
-### If you have 15-30 minutes
-Read the Kernel (English reference):
-1) [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
-2) [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
-3) [../../v1_core/languages/en/03_flujo_operativo.md](../../v1_core/languages/en/03_flujo_operativo.md)
-
-Then try the simulator:
-- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
-- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
-
----
-
-## Try it (fast test)
-Compare these two scenarios:
-- SCN-001 (unverified ceasefire) → destabilizing masked "success"
-- SCN-002 (verified + incentives aligned) → stabilizing outcome
-
-Ask:
-- What incentives are rewarded?
-- What is verified vs declared?
-- Does the solution reduce future risk?
-- Does it increase medium/long-term stability?
-
----
-
-## If you want to contribute
-Start here:
-- [CONTRIBUTING.md](../../CONTRIBUTING.md)
-
-Contributions are welcome, but Kernel influence is integrity-gated.
-
----
-
-## Status
-This is an early but functional foundation:
-- Kernel baseline is defined
-- Scenario simulator is working
-- Governance for contributions is in place
-
-Next phases include:
-- multilingual synchronization,
-- quantitative evaluation model,
-- expanded scenario library.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+Voir les règles de contribution : [CONTRIBUTING.md](../../CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

Converts the French onboarding page into an honest translation-status stub.

Fixes #1562

## Scope

- docs/fr/00_start_here.md only
- Removes mixed-language onboarding content
- Redirects users to EN / ES / DE onboarding and README
- Preserves the FR entry point without claiming language-faithful completion

## Out of scope

- Full FR translation
- Runtime changes
- Schema changes
- CI changes
- Governance changes
- Other language files

## Validation

- GitHub checks
- Link check
- Mojibake guard