### PR TITLE
docs: add lightweight brand header to primary onboarding pages

### DIFF
--- a/docs/00_start_here.md
+++ b/docs/00_start_here.md
@@ -1,3 +1,11 @@
+<p align="center">
+  <img src="../assets/brand/logo/hub-optimus-logo-lockup.jpg" alt="HUB_Optimus" width="420" />
+</p>
+
+<p align="center">
+  <strong>Reality → Evidence → Inference → Narrative → Operational Signal</strong>
+</p>
+
 # Start Here — HUB_Optimus in 10 minutes
 
 > **Source-of-truth:** For HUB_Optimus v1, the canonical source is `v1_core/languages/es/`. English and other languages are reference or parity translations. If documentation conflicts, `docs/context/STATUS.md` is the authoritative governance record.
@@ -103,7 +111,6 @@ Next phases include:
 - multilingual synchronization,
 - quantitative evaluation model,
 - expanded scenario library.
-
 
 
 

--- a/docs/de/00_start_here.md
+++ b/docs/de/00_start_here.md
@@ -1,5 +1,13 @@
 > 🇬🇧 Englische Quelle: [docs/00_start_here.md](../00_start_here.md)
 
+<p align="center">
+  <img src="../../assets/brand/logo/hub-optimus-logo-lockup.jpg" alt="HUB_Optimus" width="420" />
+</p>
+
+<p align="center">
+  <strong>Realität → Evidenz → Schlussfolgerung → Narrativ → Operatives Signal</strong>
+</p>
+
 # HUB_Optimus — Start hier (DE)
 
 Schnelle diplomatische "Siege" zu erzielen ist leicht. **Verifizierbare Stabilität** mit **ausgerichteten Anreizen** aufzubauen, ist das Schwierige.  

--- a/docs/es/00_start_here.md
+++ b/docs/es/00_start_here.md
@@ -1,5 +1,13 @@
 > 🇬🇧 English version: [docs/00_start_here.md](../00_start_here.md)
 
+<p align="center">
+  <img src="../../assets/brand/logo/hub-optimus-logo-lockup.jpg" alt="HUB_Optimus" width="420" />
+</p>
+
+<p align="center">
+  <strong>Realidad → Evidencia → Inferencia → Narrativa → Señal operativa</strong>
+</p>
+
 # HUB_Optimus — Start Here (ES)
 
 Ganar "victorias" diplomáticas rápidas es fácil. Construir **estabilidad verificable** con **incentivos alineados** es lo difícil.  
@@ -107,7 +115,6 @@ Envía este enlace:
 - Examples: [Scenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 - Learning loop: [Meta Learning](../../v1_core/workflow/05_meta_learning.md)
 <!-- /HUB:TRACKS -->
-
 
 
 


### PR DESCRIPTION
Summary:
- Adds a lightweight HUB_Optimus lockup header to the EN, ES, and DE primary onboarding pages.
- Uses the existing repository asset `assets/brand/logo/hub-optimus-logo-lockup.jpg` with relative paths from each page.
- Adds localized signal-line text below the lockup.

Scope:
- Primary onboarding pages only.
- Existing brand asset only.
- Documentation-only visual onboarding support.

Out of scope:
- README changes.
- Full README hero usage in language docs.
- Motion assets.
- New files or new assets.
- Runtime, CI, benchmark, governance, roadmap, or capability-claim changes.

Validation:
- `git diff --cached --check`
- Verified all Markdown image paths resolve from each modified file.
- `python tools/check_mojibake.py docs/00_start_here.md docs/es/00_start_here.md docs/de/00_start_here.md`
- Changed files listed.

Risk:
- Main risk is visual overstatement.
- Mitigation: this uses a small lockup header, not the full README hero, and does not alter project claims.