### PR TITLE
docs: add Spanish README navigation

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,0 +1,15 @@
+> English source: [../README.md](../README.md)
+
+# docs/
+
+El directorio `docs/` contiene guias de incorporacion y puntos de entrada multilingues.
+
+Empieza aqui:
+- [00_start_here.md](00_start_here.md)
+- [02_how_to_read_this_repo.md](02_how_to_read_this_repo.md)
+- [03_try_a_scenario.md](03_try_a_scenario.md)
+
+Corpus de escenarios:
+- [../scenarios/scenario_taxonomy.md](../scenarios/scenario_taxonomy.md)
+- [../scenarios/scenario_template.md](../scenarios/scenario_template.md)
+- [../scenarios/catalog.md](../scenarios/catalog.md)


### PR DESCRIPTION
Summary:
- Adds `docs/es/README.md` as the Spanish navigation counterpart for `docs/README.md`.
- Preserves the source README without modification.

Scope:
- Spanish README navigation batch only.
- Source file: `docs/README.md`.

Out of scope:
- Source README changes.
- Runtime changes.
- CI changes.
- Benchmarks.
- Governance.
- Roadmap.
- Brand/media changes.
- Other README files.

Validation:
- `git diff --name-only origin/main...HEAD` returned only `docs/es/README.md`.
- `git diff --check` passed.
- `git diff --check origin/main...HEAD` passed.
- `python tools/check_mojibake.py docs/es/README.md` passed.
- Link target existence check passed from the `docs/es/` context.

Risk:
- Low. This is a short navigation translation.
- Main risk is link-path drift from the deeper `docs/es/` context; mitigated by checking every local Markdown link target.