### PR TITLE
docs: clarify multilingual onboarding and governance translation status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,21 @@
 
 This folder contains onboarding guides and multilingual entry points.
 
+## Multilingual entry points
+
+Canonical language policy is defined in [context/STATUS.md](context/STATUS.md). This table only summarizes onboarding and translation coverage; it does not change governance.
+
+| Language | Entry point | Status | Governance status |
+| --- | --- | --- | --- |
+| en | [00_start_here.md](00_start_here.md) | reference/default docs | canonical governance in [governance/](governance/) |
+| es | [es/00_start_here.md](es/00_start_here.md) | priority onboarding | translation in progress; some governance files may still be English mirrors |
+| de | [de/00_start_here.md](de/00_start_here.md) | priority onboarding | translation in progress; some governance files may still be English mirrors |
+| ca | [ca/00_start_here.md](ca/00_start_here.md) | progressive | not in the priority governance translation batch |
+| fr | [fr/00_start_here.md](fr/00_start_here.md) | progressive | not in the priority governance translation batch |
+| ru | [ru/00_start_here.md](ru/00_start_here.md) | progressive | not in the priority governance translation batch |
+| zh | [zh/governance/](zh/governance/) | stub | governance mirror/stub only; full translation pending |
+| he | [he/00_start_here.md](he/00_start_here.md) | stub | governance mirror/stub only; full translation pending |
+
 Start here:
 - [00_start_here.md](00_start_here.md)
 - [02_how_to_read_this_repo.md](02_how_to_read_this_repo.md)

--- a/docs/de/00_start_here.md
+++ b/docs/de/00_start_here.md
@@ -8,6 +8,11 @@ HUB_Optimus hilft dabei, Szenarien und Vereinbarungen zu bewerten, **bevor** sie
 ---
 
 ## Governance
+> Uebersetzungsstatus:
+> Diese Onboarding-Seite ist lokalisiert. Einige unten verlinkte Governance-Dokumente koennen weiterhin englische Mirrors sein.
+> Die kanonische Governance bleibt `docs/governance/`.
+> Jede Uebersetzung muss Bedeutung und normative Kraft erhalten.
+
 - Gründungsurkunde: [governance/CHARTER.md](governance/CHARTER.md)
 - Kernel (unveränderliche Prinzipien): [governance/KERNEL.md](governance/KERNEL.md)
 - Konsensprozess: [governance/CONSENSUS_PROCESS.md](governance/CONSENSUS_PROCESS.md)

--- a/docs/es/00_start_here.md
+++ b/docs/es/00_start_here.md
@@ -8,6 +8,11 @@ HUB_Optimus existe para ayudar a evaluar escenarios y acuerdos **antes** de que 
 ---
 
 ## Gobernanza
+> Estado de traduccion:
+> Esta pagina de onboarding esta localizada. Algunos documentos de gobernanza enlazados abajo pueden seguir siendo espejos en ingles.
+> La gobernanza canonica sigue estando en `docs/governance/`.
+> Toda traduccion debe preservar significado y fuerza normativa.
+
 - Carta Fundacional: [governance/CHARTER.md](governance/CHARTER.md)
 - Kernel (principios inmutables): [governance/KERNEL.md](governance/KERNEL.md)
 - Proceso de Consenso: [governance/CONSENSUS_PROCESS.md](governance/CONSENSUS_PROCESS.md)
@@ -107,7 +112,6 @@ Envía este enlace:
 - Examples: [Scenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Scenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 - Learning loop: [Meta Learning](../../v1_core/workflow/05_meta_learning.md)
 <!-- /HUB:TRACKS -->
-
 
 
 


### PR DESCRIPTION
﻿## Summary

Clarifies multilingual onboarding status and governance translation coverage.

This PR adds:
- a language/status matrix in `docs/README.md`
- translation-status notices in:
  - `docs/es/00_start_here.md`
  - `docs/de/00_start_here.md`

## Why

The repository already defines ES/DE/EN as priority onboarding languages, with CA/FR/RU as progressive translations and ZH/HE as stubs. This PR makes that status visible from onboarding so contributors do not assume every localized path is already complete.

## Scope

Touched files:
- `docs/README.md`
- `docs/es/00_start_here.md`
- `docs/de/00_start_here.md`

## Out of scope

- No governance translation work.
- No changes to `docs/context/STATUS.md`.
- No changes to canonical source-of-truth hierarchy.
- No runtime, schema, benchmark, CI, or architecture changes.
- No cleanup of unrelated mojibake debt.

## Validation

Passed:

```bash
python tools/check_mojibake.py docs/README.md docs/es/00_start_here.md docs/de/00_start_here.md
lychee docs/README.md docs/es/00_start_here.md docs/de/00_start_here.md
git diff --check -- docs/README.md docs/es/00_start_here.md docs/de/00_start_here.md
python tools/check_mojibake.py docs README.md CONTRIBUTING.md
```

Pre-PR scope check:

```bash
git diff --name-only origin/main
```

returned only:

```text
docs/README.md
docs/de/00_start_here.md
docs/es/00_start_here.md
```

## Acceptance criteria

- ES/DE are visible as priority onboarding languages.
- CA/FR/RU are visible as progressive translations.
- ZH/HE are visible as stubs.
- Governance canonical source remains `docs/governance/`.
- Localized onboarding no longer implies full localized governance coverage.

Related to i18n onboarding/governance translation coverage.
