### PR TITLE
docs: add zh onboarding stub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Canonical language policy is defined in [context/STATUS.md](context/STATUS.md). 
 | ca | [ca/00_start_here.md](ca/00_start_here.md) | progressive | not in the priority governance translation batch |
 | fr | [fr/00_start_here.md](fr/00_start_here.md) | progressive | not in the priority governance translation batch |
 | ru | [ru/00_start_here.md](ru/00_start_here.md) | progressive | not in the priority governance translation batch |
-| zh | [zh/governance/](zh/governance/) | stub | governance mirror/stub only; full translation pending |
+| zh | [zh/00_start_here.md](zh/00_start_here.md) | stub | onboarding stub only; governance mirror/stub only; full translation pending |
 | he | [he/00_start_here.md](he/00_start_here.md) | stub | governance mirror/stub only; full translation pending |
 
 Start here:

--- a/docs/zh/00_start_here.md
+++ b/docs/zh/00_start_here.md
@@ -1,0 +1,15 @@
+# HUB_Optimus — Start Here (ZH)
+
+> Translation status:
+> Chinese onboarding is currently a stub.
+> Full Chinese translation is pending.
+
+For complete onboarding, use one of the current entry points:
+
+- [English](../00_start_here.md)
+- [Español](../es/00_start_here.md)
+- [Deutsch](../de/00_start_here.md)
+
+Governance mirrors/stubs may exist under `docs/zh/governance/`, but they are not a full Chinese governance translation.
+
+Canonical governance remains `docs/governance/`.


### PR DESCRIPTION
## Summary
- Adds `docs/zh/00_start_here.md` as an honest Chinese onboarding stub.
- Updates `docs/README.md` so the `zh` row points to the onboarding stub instead of `zh/governance/`.

## Scope
- Touched only `docs/README.md` and `docs/zh/00_start_here.md`.
- Keeps the multilingual entry point table actionable for `zh`.

## Out of scope
- No governance translation added.
- No canonical governance or language policy changed.
- No changes to `docs/context/STATUS.md`, runtime, CI, benchmarks, schemas, or translation policy.

## Validation
- `python tools/check_mojibake.py docs/README.md docs/zh/00_start_here.md` — passed.
- `lychee docs/README.md docs/zh/00_start_here.md` — passed, 18 links OK, 0 errors.
- `git diff --check -- docs/README.md docs/zh/00_start_here.md` — passed.
- `git diff --name-only origin/main` — returned only:
  - `docs/README.md`
  - `docs/zh/00_start_here.md`

## Acceptance criteria
- `docs/README.md` links every listed language to an onboarding entry point.
- `zh` has a minimal honest onboarding stub.
- No governance translation is added.
- No canonical policy is changed.
- The diff against `origin/main` contains only `docs/README.md` and `docs/zh/00_start_here.md`.