### PR TITLE
i18n/es: translate priority governance batch A

### DIFF
--- a/docs/es/governance/CHARTER.md
+++ b/docs/es/governance/CHARTER.md
@@ -1,53 +1,53 @@
-# HUB_Optimus — Charter
+# HUB_Optimus — Carta
 
-## Nature of the System
-HUB_Optimus is an international, non-sovereign, non-corporate system for the structured evaluation of diplomatic scenarios, agreements, and decisions.
+## Naturaleza del sistema
+HUB_Optimus es un sistema internacional, no soberano y no corporativo para la evaluación estructurada de escenarios, acuerdos y decisiones diplomáticas.
 
-It is designed to improve how decisions are evaluated **before escalation becomes irreversible**.
+Está diseñado para mejorar cómo se evalúan las decisiones **antes de que la escalada se vuelva irreversible**.
 
-## Mission
-To provide a verifiable, incentive-aligned framework that:
-- makes assumptions explicit,
-- distinguishes verifiable commitments from non-verifiable claims,
-- surfaces escalation and lock-in risks early,
-- and preserves a neutral record of reasoning.
+## Misión
+Proporcionar un marco verificable y alineado con incentivos que:
+- haga explícitos los supuestos,
+- distinga los compromisos verificables de las afirmaciones no verificables,
+- exponga temprano los riesgos de escalada y bloqueo irreversible,
+- y preserve un registro neutral del razonamiento.
 
-## What HUB_Optimus is
-- A structured evaluation framework.
-- A shared "language" for scenario definition and analysis.
-- A method to reduce uncertainty and manipulation by making verification explicit.
+## Qué es HUB_Optimus
+- Un marco de evaluación estructurada.
+- Un "lenguaje" compartido para la definición y el análisis de escenarios.
+- Un método para reducir la incertidumbre y la manipulación haciendo explícita la verificación.
 
-## What HUB_Optimus is NOT
-- Not a predictive oracle.
-- Not a decision authority.
-- Not propaganda.
-- Not a tribunal assigning personal blame.
-- Not a coercive enforcement tool.
+## Qué NO es HUB_Optimus
+- No es un oráculo predictivo.
+- No es una autoridad de decisión.
+- No es propaganda.
+- No es un tribunal que asigna culpa personal.
+- No es una herramienta de ejecución coercitiva.
 
-## Core Governance Documents
-This Charter is implemented through:
+## Documentos centrales de gobernanza
+Esta Carta se implementa mediante:
 - Kernel: [KERNEL.md](KERNEL.md)
-- Consensus Process: [CONSENSUS_PROCESS.md](CONSENSUS_PROCESS.md)
-- Custodianship: [CUSTODIANSHIP.md](CUSTODIANSHIP.md)
-- Trust Layer: [TRUST_LAYER.md](TRUST_LAYER.md)
-- Evaluation Standard: [EVALUATION_STANDARD.md](EVALUATION_STANDARD.md)
-- Scenario Schema: [SCENARIO_SCHEMA.md](SCENARIO_SCHEMA.md)
-- Name & Identity Use: [TRADEMARKS.md](TRADEMARKS.md)
+- Proceso de consenso: [CONSENSUS_PROCESS.md](CONSENSUS_PROCESS.md)
+- Custodia: [CUSTODIANSHIP.md](CUSTODIANSHIP.md)
+- Capa de confianza: [TRUST_LAYER.md](TRUST_LAYER.md)
+- Estándar de evaluación: [EVALUATION_STANDARD.md](EVALUATION_STANDARD.md)
+- Esquema de escenarios: [SCENARIO_SCHEMA.md](SCENARIO_SCHEMA.md)
+- Uso del nombre y la identidad: [TRADEMARKS.md](TRADEMARKS.md)
 
-## Neutrality and Non-Enforcement
-HUB_Optimus does not enforce outcomes.
-It improves decision quality by exposing structural risks, incentive misalignments, and verification limits.
+## Neutralidad y no imposición
+HUB_Optimus no impone resultados.
+Mejora la calidad de decisión al exponer riesgos estructurales, desalineaciones de incentivos y límites de verificación.
 
-## Anti-Capture Principle
-No individual, organization, or state may claim unilateral authority over HUB_Optimus.
-Legitimacy comes from transparent process, recorded reasoning, and consensus rules.
+## Principio anti-captura
+Ningún individuo, organización o Estado puede reclamar autoridad unilateral sobre HUB_Optimus.
+La legitimidad proviene del proceso transparente, el razonamiento registrado y las reglas de consenso.
 
-## Versioning and Integrity
-Changes must be:
-- proposed openly,
-- reviewed through the consensus process,
-- recorded with traceability,
-- and consistent with the Kernel.
+## Versionado e integridad
+Los cambios deben ser:
+- propuestos abiertamente,
+- revisados mediante el proceso de consenso,
+- registrados con trazabilidad,
+- y coherentes con el Kernel.
 
-## Scope and Adoption
-HUB_Optimus is intended for international diplomatic use, and may later be adapted to other domains (institutions, companies, multi-party disputes) without changing its non-coercive nature.
+## Alcance y adopción
+HUB_Optimus está destinado al uso diplomático internacional y puede adaptarse más adelante a otros dominios (instituciones, empresas, disputas multipartes) sin cambiar su naturaleza no coercitiva.

--- a/docs/es/governance/CONSENSUS_PROCESS.md
+++ b/docs/es/governance/CONSENSUS_PROCESS.md
@@ -1,64 +1,64 @@
-# HUB_Optimus — Consensus Process
+# HUB_Optimus — Proceso de consenso
 
-## Purpose
-This document defines how changes to HUB_Optimus documents are proposed, reviewed, and adopted.
+## Propósito
+Este documento define cómo se proponen, revisan y adoptan los cambios a los documentos de HUB_Optimus.
 
-Consensus is used to prevent unilateral capture and to preserve system legitimacy through traceable agreement.
+El consenso se usa para impedir la captura unilateral y para preservar la legitimidad del sistema mediante acuerdo trazable.
 
-## Definitions
-- **Proposal**: a documented change request (text + rationale).
-- **Objection**: a reasoned statement that a proposal violates the Kernel, reduces neutrality, weakens verifiability, or introduces capture risk.
-- **Sustained objection**: an objection that remains unresolved after good-faith revision attempts.
-- **Consensus**: adoption after review when no sustained objections remain.
+## Definiciones
+- **Propuesta**: una solicitud de cambio documentada (texto + justificación).
+- **Objeción**: una declaración razonada de que una propuesta viola el Kernel, reduce la neutralidad, debilita la verificabilidad o introduce riesgo de captura.
+- **Objeción sostenida**: una objeción que permanece sin resolver tras intentos de revisión de buena fe.
+- **Consenso**: adopción tras revisión cuando no quedan objeciones sostenidas.
 
-## Process Overview
+## Resumen del proceso
 
-### Step 1 — Draft
-A proposal is submitted with:
-- a clear description of changes,
-- rationale and expected impact,
-- references to affected sections,
-- compatibility statement with the Kernel.
+### Paso 1 — Borrador
+Una propuesta se presenta con:
+- una descripción clara de los cambios,
+- justificación e impacto esperado,
+- referencias a las secciones afectadas,
+- declaración de compatibilidad con el Kernel.
 
-### Step 2 — Review Window
-A defined review window is opened (timeboxed).
-Participants may:
-- ask clarifying questions,
-- suggest improvements,
-- raise objections (must be reasoned).
+### Paso 2 — Ventana de revisión
+Se abre una ventana de revisión definida (con límite temporal).
+Los participantes pueden:
+- hacer preguntas aclaratorias,
+- sugerir mejoras,
+- plantear objeciones (deben ser razonadas).
 
-### Step 3 — Objection Handling (Good Faith)
-If objections are raised, the proposer must:
-- address the objection directly,
-- revise the proposal, or
-- document why the objection is out of scope.
+### Paso 3 — Gestión de objeciones (buena fe)
+Si se plantean objeciones, el proponente debe:
+- abordar la objeción directamente,
+- revisar la propuesta, o
+- documentar por qué la objeción está fuera de alcance.
 
-Objections must reference:
-- Kernel principles, or
-- verifiability/trust issues, or
-- anti-capture/neutrality risks.
+Las objeciones deben referenciar:
+- principios del Kernel, o
+- problemas de verificabilidad/confianza, o
+- riesgos de anti-captura/neutralidad.
 
-### Step 4 — Resolution
-A proposal may be adopted if:
-- objections were resolved through revision, or
-- objections were withdrawn, or
-- a clear record shows objections were answered without Kernel conflict.
+### Paso 4 — Resolución
+Una propuesta puede adoptarse si:
+- las objeciones se resolvieron mediante revisión, o
+- las objeciones fueron retiradas, o
+- un registro claro muestra que las objeciones fueron respondidas sin conflicto con el Kernel.
 
-If sustained objections remain, the proposal is not adopted.
+Si quedan objeciones sostenidas, la propuesta no se adopta.
 
-### Step 5 — Ratification and Record
-Adopted proposals must be:
-- merged with a traceable commit,
-- recorded with a short change summary,
-- linked to discussion/notes where applicable.
+### Paso 5 — Ratificación y registro
+Las propuestas adoptadas deben ser:
+- fusionadas con un commit trazable,
+- registradas con un breve resumen del cambio,
+- enlazadas a la discusión/notas cuando corresponda.
 
-## Special Rule: Changes to Governance Rules
-Any change to:
-- the Kernel,
-- consensus rules,
-- custodianship rules,
-requires heightened scrutiny and explicit compatibility justification.
+## Regla especial: cambios a las reglas de gobernanza
+Cualquier cambio a:
+- el Kernel,
+- las reglas de consenso,
+- las reglas de custodia,
+requiere escrutinio elevado y justificación explícita de compatibilidad.
 
-## Non-Authority Clause
-Consensus does not create authority over outcomes.
-It only governs the integrity of the system's documents and processes.
+## Cláusula de no autoridad
+El consenso no crea autoridad sobre los resultados.
+Solo gobierna la integridad de los documentos y procesos del sistema.

--- a/docs/es/governance/CUSTODIANSHIP.md
+++ b/docs/es/governance/CUSTODIANSHIP.md
@@ -1,73 +1,73 @@
-# HUB_Optimus — Custodianship
+# HUB_Optimus — Custodia
 
-## Purpose
-Custodianship exists to protect the Kernel and the integrity of governance.
-It is not ownership, not authority over outcomes, and not a certification body.
+## Propósito
+La custodia existe para proteger el Kernel y la integridad de la gobernanza.
+No es propiedad, no es autoridad sobre resultados y no es un organismo de certificación.
 
-Custodians protect:
-- meaning coherence across languages,
-- resistance to capture and commercialization pressure,
-- traceability of governance changes,
-- and the public record of deliberation.
+Los custodios protegen:
+- la coherencia de significado entre lenguas,
+- la resistencia a la captura y a la presión de comercialización,
+- la trazabilidad de los cambios de gobernanza,
+- y el registro público de la deliberación.
 
-## What Custodianship is
-Custodianship is a constrained governance role that:
-- safeguards the Kernel (Layer 0),
-- enforces the consensus process for governance changes,
-- blocks semantic drift and deceptive rebranding,
-- ensures translations remain meaning-identical to the canonical set.
+## Qué es la custodia
+La custodia es un rol de gobernanza restringido que:
+- salvaguarda el Kernel (Capa 0),
+- hace cumplir el proceso de consenso para cambios de gobernanza,
+- bloquea la deriva semántica y el cambio de marca engañoso,
+- asegura que las traducciones permanezcan idénticas en significado al conjunto canónico.
 
-## What Custodianship is not
-Custodianship is not:
-- a tribunal or enforcement authority,
-- a political mandate,
-- a private ownership claim,
-- a gatekeeping tool for personal preference.
+## Qué no es la custodia
+La custodia no es:
+- un tribunal ni una autoridad de ejecución,
+- un mandato político,
+- una reclamación de propiedad privada,
+- una herramienta de control de acceso por preferencia personal.
 
-## Scope of powers (strictly limited)
-Custodians MAY:
-- reject governance changes that violate the Kernel,
-- require explicit rationale and traceability for governance edits,
-- require synchronization across language mirrors,
-- request removal/correction of misleading "official/endorsed" claims.
+## Alcance de poderes (estrictamente limitado)
+Los custodios PUEDEN:
+- rechazar cambios de gobernanza que violen el Kernel,
+- exigir justificación explícita y trazabilidad para ediciones de gobernanza,
+- exigir sincronización entre réplicas lingüísticas,
+- solicitar la retirada/corrección de afirmaciones engañosas de tipo "oficial/respaldado".
 
-Custodians MUST NOT:
-- impose political decisions,
-- grant "certification" status,
-- unilaterally change the Kernel,
-- rewrite history without traceable process.
+Los custodios NO DEBEN:
+- imponer decisiones políticas,
+- otorgar estado de "certificación",
+- cambiar unilateralmente el Kernel,
+- reescribir la historia sin proceso trazable.
 
-## Kernel change rule (high bar)
-Any Kernel change requires:
-1) an explicit written proposal,
-2) a rationale referencing Kernel principles,
-3) documented objections and responses,
-4) consensus review per `CONSENSUS_PROCESS.md`,
-5) custodianship approval,
-6) synchronization across all language mirrors.
+## Regla de cambio del Kernel (umbral alto)
+Cualquier cambio del Kernel requiere:
+1) una propuesta escrita explícita,
+2) una justificación que haga referencia a principios del Kernel,
+3) objeciones y respuestas documentadas,
+4) revisión por consenso según `CONSENSUS_PROCESS.md`,
+5) aprobación de custodia,
+6) sincronización entre todas las réplicas lingüísticas.
 
-Unreviewed Kernel edits are invalid by definition.
+Las ediciones del Kernel no revisadas son inválidas por definición.
 
-## Conflict of interest and anti-capture
-Custodians must disclose conflicts of interest.
-Capture indicators include:
-- introducing exceptions via translation,
-- weakening MUST/NOT language,
-- rebranding the method as a private product,
-- shifting governance into marketing.
+## Conflicto de intereses y anti-captura
+Los custodios deben revelar conflictos de intereses.
+Los indicadores de captura incluyen:
+- introducir excepciones mediante traducción,
+- debilitar lenguaje DEBE/NO DEBE,
+- renombrar el método como un producto privado,
+- desplazar la gobernanza hacia marketing.
 
-If capture indicators appear, Custodians must block the change and document why.
+Si aparecen indicadores de captura, los custodios deben bloquear el cambio y documentar por qué.
 
-## Transparency and record
-All custodian actions must be traceable:
-- what was blocked/approved,
-- why (Kernel reference),
-- and what changes were required.
+## Transparencia y registro
+Todas las acciones de custodia deben ser trazables:
+- qué fue bloqueado/aprobado,
+- por qué (referencia al Kernel),
+- y qué cambios fueron requeridos.
 
-## Removal / rotation (minimum rule)
-If a Custodian repeatedly violates the Kernel, hides conflicts, or acts deceptively,
-they lose custodianship status through the same consensus process.
+## Remoción / rotación (regla mínima)
+Si un custodio viola repetidamente el Kernel, oculta conflictos o actúa de forma engañosa,
+pierde el estado de custodia mediante el mismo proceso de consenso.
 
-## Non-sovereign statement
-Custodianship does not create authority over participants or institutions.
-It only protects the integrity and clarity of the HUB_Optimus system definition.
+## Declaración no soberana
+La custodia no crea autoridad sobre participantes ni instituciones.
+Solo protege la integridad y claridad de la definición del sistema HUB_Optimus.

--- a/docs/es/governance/KERNEL.md
+++ b/docs/es/governance/KERNEL.md
@@ -1,65 +1,65 @@
-# HUB_Optimus — Kernel (Immutable Principles)
+# HUB_Optimus — Kernel (Principios inmutables)
 
-## Purpose
-The Kernel defines the non-negotiable principles of HUB_Optimus.
-All processes and documents must remain compatible with these principles.
+## Propósito
+El Kernel define los principios no negociables de HUB_Optimus.
+Todos los procesos y documentos deben permanecer compatibles con estos principios.
 
-## Principles
+## Principios
 
-### 1) Non-Coercion
-HUB_Optimus does not coerce, enforce, punish, or compel.
-It evaluates structure; it does not execute power.
+### 1) No coerción
+HUB_Optimus no coacciona, impone, castiga ni obliga.
+Evalúa la estructura; no ejerce poder.
 
-### 2) Neutrality
-The system must remain outcome-neutral.
-It does not assign moral blame or political legitimacy.
-It clarifies consequences and structural risk.
+### 2) Neutralidad
+El sistema debe permanecer neutral respecto de los resultados.
+No asigna culpa moral ni legitimidad política.
+Clarifica consecuencias y riesgo estructural.
 
-### 3) Verifiability First
-Claims and commitments are evaluated by verifiability.
-Narrative strength, authority, urgency, or moral framing do not increase trust classification.
+### 3) Verificabilidad primero
+Las afirmaciones y los compromisos se evalúan por su verificabilidad.
+La fuerza narrativa, la autoridad, la urgencia o el encuadre moral no aumentan la clasificación de confianza.
 
-### 4) Incentive Alignment
-Evaluations must surface incentive structures and misalignment risks.
-Stability requires incentive-compatible commitments.
+### 4) Alineación de incentivos
+Las evaluaciones deben exponer las estructuras de incentivos y los riesgos de desalineación.
+La estabilidad requiere compromisos compatibles con los incentivos.
 
-### 5) Explicit Assumptions
-Hidden assumptions invalidate trust.
-Unknowns must be marked explicitly.
+### 5) Supuestos explícitos
+Los supuestos ocultos invalidan la confianza.
+Las incógnitas deben marcarse explícitamente.
 
-### 6) Reversibility Preference
-Where possible, the system favors reversible steps, checkpoints, and monitored commitments to reduce lock-in and escalation risk.
+### 6) Preferencia por la reversibilidad
+Cuando sea posible, el sistema favorece pasos reversibles, puntos de control y compromisos monitorizados para reducir el riesgo de bloqueo y escalada.
 
-### 7) Traceable Governance
-Rule changes require transparent proposals, recorded objections, and a documented resolution path.
+### 7) Gobernanza trazable
+Los cambios de reglas requieren propuestas transparentes, objeciones registradas y una ruta de resolución documentada.
 
-### 8) Anti-Capture
-No individual—including the originator—has special privileges.
-Authorship does not confer authority.
+### 8) Anti-captura
+Ningún individuo —incluido el originador— tiene privilegios especiales.
+La autoría no confiere autoridad.
 
-### 9) Preservation of Record
-The integrity of deliberation history must be preserved.
-Edits must be traceable and reviewable.
+### 9) Preservación del registro
+La integridad del historial de deliberación debe preservarse.
+Las ediciones deben ser trazables y revisables.
 
-## Interpretation
-If any document conflicts with the Kernel, the Kernel prevails.
+## Interpretación
+Si algún documento entra en conflicto con el Kernel, prevalece el Kernel.
 
 ---
 
-## Binding and coherence rules (anti-capture hardening)
+## Reglas vinculantes y de coherencia (endurecimiento anti-captura)
 
-### Binding effect
-- The Kernel is definitionally binding for any usage of the name HUB_Optimus.
-- Any material deviation in meaning constitutes a different system and must not be presented as HUB_Optimus.
+### Efecto vinculante
+- El Kernel es vinculante por definición para cualquier uso del nombre HUB_Optimus.
+- Toda desviación material de significado constituye un sistema diferente y no debe presentarse como HUB_Optimus.
 
-### Non-derivative rule
-The Kernel may be read, referenced, and cited.
-It may NOT be modified, forked, rebranded, or used to offer competing commercial services without explicit custodianship authorization.
+### Regla de no derivación
+El Kernel puede leerse, referenciarse y citarse.
+NO puede modificarse, bifurcarse, renombrarse ni usarse para ofrecer servicios comerciales competidores sin autorización explícita de custodia.
 
-### Language coherence rule
-All translations must preserve the exact meaning, order, and definitions of the canonical governance set.
-Translations are not allowed to introduce new concepts, exceptions, or alternative interpretations.
+### Regla de coherencia lingüística
+Todas las traducciones deben preservar el significado, el orden y las definiciones exactas del conjunto canónico de gobernanza.
+Las traducciones no pueden introducir conceptos nuevos, excepciones ni interpretaciones alternativas.
 
-### Custodianship
-Authority to amend the Kernel is restricted by the Custodianship and Consensus process.
-Unreviewed changes are invalid by definition.
+### Custodia
+La autoridad para enmendar el Kernel está restringida por el proceso de Custodia y Consenso.
+Los cambios no revisados son inválidos por definición.


### PR DESCRIPTION
## Summary
- Translates ES governance batch A from the canonical governance documents.
- Covers `CHARTER.md`, `KERNEL.md`, `CONSENSUS_PROCESS.md`, and `CUSTODIANSHIP.md` under `docs/es/governance/`.
- Preserves headings structure, section order, links, and normative force.

## Scope
- Touched only:
  - `docs/es/governance/CHARTER.md`
  - `docs/es/governance/KERNEL.md`
  - `docs/es/governance/CONSENSUS_PROCESS.md`
  - `docs/es/governance/CUSTODIANSHIP.md`

## Out of scope
- No governance policy changes.
- No changes to `docs/context/STATUS.md` or `docs/README.md`.
- No DE, CA, FR, RU, HE, or ZH edits.
- No `v1_core`, runtime, CI, benchmarks, schemas, or policy changes.

## Validation
- `python tools/check_mojibake.py docs/es/governance/CHARTER.md docs/es/governance/KERNEL.md docs/es/governance/CONSENSUS_PROCESS.md docs/es/governance/CUSTODIANSHIP.md` — passed.
- `lychee docs/es/governance/CHARTER.md docs/es/governance/KERNEL.md docs/es/governance/CONSENSUS_PROCESS.md docs/es/governance/CUSTODIANSHIP.md` — passed, 7 links OK, 0 errors.
- `git diff --check -- docs/es/governance/CHARTER.md docs/es/governance/KERNEL.md docs/es/governance/CONSENSUS_PROCESS.md docs/es/governance/CUSTODIANSHIP.md` — passed.
- `git diff --name-only origin/main` — returned only the four scoped files.

## Acceptance criteria
- Only the four ES governance files are changed.
- Spanish translation preserves canonical meaning.
- No governance policy is changed.
- No other language is touched.
- No runtime or CI files are touched.
- `git diff --name-only origin/main` returns only the four scoped files.

## Review focus
Review for normative drift, especially MUST/MUST NOT/MAY language and anti-capture constraints, not stylistic preference.