### PR TITLE
docs: add capability status table

### DIFF
--- a/docs/architecture/capability_status.md
+++ b/docs/architecture/capability_status.md
@@ -6,8 +6,9 @@ This table separates implemented repository capabilities from planned or explici
 | --- | --- | --- | --- |
 | Scenario schema validation | Implemented | `docs/architecture/runtime_contract.md`; `scenario.schema.json`; `tests/test_run_scenario_cli.py` | The CLI validates scenario JSON against the schema before runtime execution. |
 | Deterministic simulator runtime | Implemented | `docs/architecture/runtime_contract.md`; `hub_optimus_simulator.py`; `run_scenario.py`; `tests/test_run_scenario_cli.py` | Seeded runs produce deterministic JSON output for the current prototype behavior. |
-| Benchmark hard gate | Not implemented | `docs/architecture/runtime_contract.md`; `.github/workflows/ci.yml` | Benchmark execution exists, but the CI benchmark job is non-blocking. |
-| Structural drift diagnostics | Planned / RFC | `docs/context/hub_optimus_checkpoint.md` | Listed as future benchmark drift analysis; not a runtime or CI gate. |
+| Benchmark byte-level comparison | Implemented | `benchmarks/run_benchmarks.py`; `benchmarks/expected/`; `docs/architecture/runtime_contract.md` | The runner compares benchmark output byte-for-byte and exits non-zero on mismatch. The CI benchmark job is currently non-blocking. |
+| Structural drift diagnostics | Implemented | `benchmarks/run_benchmarks.py` | The benchmark runner compares outcome/status, rounds, and actor count and classifies differences by severity. |
+| Blocking benchmark CI gate | Not implemented | `.github/workflows/ci.yml` | The benchmark job runs in CI but uses `continue-on-error: true`. |
 | CI summary / visibility | Implemented | `.github/workflows/ci.yml`; `docs/architecture/runtime_contract.md` | CI writes narrative consistency and benchmark summaries to `GITHUB_STEP_SUMMARY`. |
 | Multilingual documentation | Implemented | `README.md`; `docs/context/STATUS.md` | Documentation structure exists across priority, progressive, and stub languages; `v1_core/languages/es/` remains canonical for v1. |
 | Narrative-risk claim triage | Implemented | `tools/check_narrative_consistency.py`; `tests/test_narrative_consistency.py`; `tests/test_geopolitical_claim_packs.py`; `.github/workflows/ci.yml` | Implemented as deterministic dataset/schema consistency checks, not truth adjudication or LLM-as-judge. |

--- a/docs/architecture/capability_status.md
+++ b/docs/architecture/capability_status.md
@@ -1,0 +1,18 @@
+# Capability Status
+
+This table separates implemented repository capabilities from planned or explicitly out-of-scope work. It is a descriptive audit aid for issue #1589, not a roadmap or implementation plan.
+
+| Capability | Status | Source | Notes |
+| --- | --- | --- | --- |
+| Scenario schema validation | Implemented | `docs/architecture/runtime_contract.md`; `scenario.schema.json`; `tests/test_run_scenario_cli.py` | The CLI validates scenario JSON against the schema before runtime execution. |
+| Deterministic simulator runtime | Implemented | `docs/architecture/runtime_contract.md`; `hub_optimus_simulator.py`; `run_scenario.py`; `tests/test_run_scenario_cli.py` | Seeded runs produce deterministic JSON output for the current prototype behavior. |
+| Benchmark hard gate | Not implemented | `docs/architecture/runtime_contract.md`; `.github/workflows/ci.yml` | Benchmark execution exists, but the CI benchmark job is non-blocking. |
+| Structural drift diagnostics | Planned / RFC | `docs/context/hub_optimus_checkpoint.md` | Listed as future benchmark drift analysis; not a runtime or CI gate. |
+| CI summary / visibility | Implemented | `.github/workflows/ci.yml`; `docs/architecture/runtime_contract.md` | CI writes narrative consistency and benchmark summaries to `GITHUB_STEP_SUMMARY`. |
+| Multilingual documentation | Implemented | `README.md`; `docs/context/STATUS.md` | Documentation structure exists across priority, progressive, and stub languages; `v1_core/languages/es/` remains canonical for v1. |
+| Narrative-risk claim triage | Implemented | `tools/check_narrative_consistency.py`; `tests/test_narrative_consistency.py`; `tests/test_geopolitical_claim_packs.py`; `.github/workflows/ci.yml` | Implemented as deterministic dataset/schema consistency checks, not truth adjudication or LLM-as-judge. |
+| Post-quantum control plane | Planned / RFC | `docs/rfc/post_quantum_control_plane.md` | RFC-only planned control layer around artifacts; not simulator runtime behavior. |
+| ML-KEM sealed exchange | Not implemented | `docs/rfc/post_quantum_control_plane.md` | Allowed as a future standardized primitive reference only. |
+| ML-DSA artifact signing | Not implemented | `docs/rfc/post_quantum_control_plane.md` | Allowed as a future standardized primitive reference only. |
+| SLH-DSA long-lived signature option | Not implemented | `docs/rfc/post_quantum_control_plane.md` | Allowed as a future standardized primitive reference only. |
+| Custom cryptographic algorithms | Explicitly out of scope | `docs/rfc/post_quantum_control_plane.md` | The RFC prohibits custom cryptographic primitives. |

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -46,14 +46,16 @@ Source: Codex execution for GitHub issue #1589
 Repo state: local branch `docs/capability-status-table`
 Branch: `docs/capability-status-table`
 Active issue: #1589
-Decision made: add a capability status table separating implemented, planned, not implemented, and out-of-scope capabilities
-Reason: issue #1589 requests a source-backed table to avoid overpromising current runtime behavior
+Decision made: add a capability status table and correct benchmark/drift rows to match implemented runner behavior
+Reason: issue #1589 requests a source-backed table to avoid overpromising or under-reporting current runtime behavior
 Files changed:
 - docs/architecture/capability_status.md
 - docs/context/AI_HANDOFF.md
 Validation:
 - `python tools/check_mojibake.py docs/architecture/capability_status.md` passed
 - `git diff --check -- docs/architecture/capability_status.md` passed
+- `python tools/check_mojibake.py docs/context/AI_HANDOFF.md` passed
+- `git diff --check -- docs/context/AI_HANDOFF.md` passed
 Risks: documentation-only; table wording must remain conservative and source-backed
 Next action: review table wording against issue #1589 and PR #1580 before opening a PR
 Out of scope:

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -42,6 +42,33 @@ No action until CI, collaborator friction, regression, or user request creates a
 ## AI Sync Block
 
 Date: 2026-05-24
+Source: Codex execution for GitHub issue #1589
+Repo state: local branch `docs/capability-status-table`
+Branch: `docs/capability-status-table`
+Active issue: #1589
+Decision made: add a capability status table separating implemented, planned, not implemented, and out-of-scope capabilities
+Reason: issue #1589 requests a source-backed table to avoid overpromising current runtime behavior
+Files changed:
+- docs/architecture/capability_status.md
+- docs/context/AI_HANDOFF.md
+Validation:
+- `python tools/check_mojibake.py docs/architecture/capability_status.md` passed
+- `git diff --check -- docs/architecture/capability_status.md` passed
+Risks: documentation-only; table wording must remain conservative and source-backed
+Next action: review table wording against issue #1589 and PR #1580 before opening a PR
+Out of scope:
+- runtime changes
+- CI changes
+- benchmark changes
+- schema changes
+- roadmap changes
+- multilingual docs
+- crypto implementation
+- dependency additions
+
+## AI Sync Block
+
+Date: 2026-05-24
 Source: Codex execution for RFC branch `rfc/post-quantum-control-plane`
 Repo state: local RFC branch
 Branch: `rfc/post-quantum-control-plane`


### PR DESCRIPTION
## Summary
- Adds a conservative capability status table for implemented, planned/RFC, not implemented, and explicitly out-of-scope capabilities.
- Clarifies post-quantum status after the merged RFC: control plane is planned/RFC only; ML-KEM, ML-DSA, and SLH-DSA are not implemented.
- Keeps capability claims source-backed to avoid overpromising.

## Scope
Changed only:
- `docs/architecture/capability_status.md`
- `docs/context/AI_HANDOFF.md`

Closes #1589.

## Out of scope
- Runtime changes
- CI changes
- Benchmark changes
- Schema changes
- README changes
- AGENTS changes
- Roadmap edits
- Multilingual docs
- Crypto dependencies
- Crypto implementation

## Validation
- `python tools/check_mojibake.py docs/architecture/capability_status.md`
- `git diff --check -- docs/architecture/capability_status.md`
- `python tools/check_mojibake.py docs/context/AI_HANDOFF.md`
- `git diff --check -- docs/context/AI_HANDOFF.md`

## Acceptance criteria
- Each capability row has conservative status and source/reference.
- Planned capabilities are marked as planned/RFC or not implemented.
- Post-quantum rows do not imply implementation.
- Custom cryptographic algorithms are explicitly out of scope.
- No runtime, CI, benchmark, schema, dependency, or roadmap changes.

## Review focus
- Overclaiming risk
- Source alignment
- Post-quantum status wording
- Whether the table adds claims not supported by repo docs