### PR TITLE
engine: add minimal semantic engine contracts

### DIFF
--- a/semantic_engine/__init__.py
+++ b/semantic_engine/__init__.py
@@ -1,0 +1,7 @@
+"""HUB_Optimus Semantic Engine package.
+
+This package contains executable translations of HUB_Optimus Core contracts.
+It does not define UI, API, AWS, S3, vector search, or model judging behavior.
+"""
+
+__all__ = ["contracts"]

--- a/semantic_engine/contracts/__init__.py
+++ b/semantic_engine/contracts/__init__.py
@@ -1,0 +1,14 @@
+"""Minimal Semantic Engine contracts."""
+
+from .audit_log import AuditLogEntry
+from .decision_trace import DecisionTrace
+from .records import ClaimRecord, EvidenceRecord
+from .analysis_result import AnalysisResult
+
+__all__ = [
+    "AnalysisResult",
+    "AuditLogEntry",
+    "ClaimRecord",
+    "DecisionTrace",
+    "EvidenceRecord",
+]

--- a/semantic_engine/contracts/analysis_result.py
+++ b/semantic_engine/contracts/analysis_result.py
@@ -1,0 +1,51 @@
+"""Analysis result contract for the HUB_Optimus Semantic Engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .audit_log import AuditLogEntry
+from .decision_trace import DecisionTrace
+from .records import ClaimRecord, EvidenceRecord
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    """The minimal structured output of a Semantic Engine analysis.
+
+    This contract separates claims, evidence, inferences, uncertainties,
+    narrative amplification, and operational signal. It does not perform
+    evaluation or scoring by itself.
+    """
+
+    case_id: str
+    core_version_ref: str
+    input_summary: str
+    claims: tuple[ClaimRecord, ...] = ()
+    evidence: tuple[EvidenceRecord, ...] = ()
+    inferences: tuple[str, ...] = ()
+    uncertainties: tuple[str, ...] = ()
+    narrative_amplification: tuple[str, ...] = ()
+    operational_signal: str = "none"
+    status: str = "draft"
+    decision_trace: tuple[DecisionTrace, ...] = ()
+    audit_log: tuple[AuditLogEntry, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "core_version_ref": self.core_version_ref,
+            "input_summary": self.input_summary,
+            "claims": [claim.to_dict() for claim in self.claims],
+            "evidence": [item.to_dict() for item in self.evidence],
+            "inferences": list(self.inferences),
+            "uncertainties": list(self.uncertainties),
+            "narrative_amplification": list(self.narrative_amplification),
+            "operational_signal": self.operational_signal,
+            "status": self.status,
+            "decision_trace": [entry.to_dict() for entry in self.decision_trace],
+            "audit_log": [entry.to_dict() for entry in self.audit_log],
+            "metadata": dict(self.metadata),
+        }

--- a/semantic_engine/contracts/audit_log.py
+++ b/semantic_engine/contracts/audit_log.py
@@ -1,0 +1,43 @@
+"""Audit log contract for Semantic Engine runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+def utc_now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp with second precision."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+@dataclass(frozen=True)
+class AuditLogEntry:
+    """A durable audit event for a Semantic Engine action."""
+
+    event_id: str
+    action: str
+    object_type: str
+    object_id: str
+    reason: str
+    timestamp: str = field(default_factory=utc_now_iso)
+    operator: str = "system"
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "timestamp": self.timestamp,
+            "operator": self.operator,
+            "action": self.action,
+            "object_type": self.object_type,
+            "object_id": self.object_id,
+            "before": self.before,
+            "after": self.after,
+            "reason": self.reason,
+            "metadata": dict(self.metadata),
+        }

--- a/semantic_engine/contracts/decision_trace.py
+++ b/semantic_engine/contracts/decision_trace.py
@@ -1,0 +1,30 @@
+"""Decision trace contract for Semantic Engine runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DecisionTrace:
+    """A single traceable transformation or rule application."""
+
+    step: str
+    rule_applied: str
+    input_ref: str
+    output_ref: str
+    reason: str
+    uncertainty: str = "unknown"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "rule_applied": self.rule_applied,
+            "input_ref": self.input_ref,
+            "output_ref": self.output_ref,
+            "reason": self.reason,
+            "uncertainty": self.uncertainty,
+            "metadata": dict(self.metadata),
+        }

--- a/semantic_engine/contracts/records.py
+++ b/semantic_engine/contracts/records.py
@@ -1,0 +1,61 @@
+"""Core record contracts for the HUB_Optimus Semantic Engine.
+
+These dataclasses intentionally stay small and stdlib-only. They define the
+first executable shape for claims and evidence without adding evaluators,
+scoring, API, HERMES, AWS, S3, vector search, or model-judge behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    """A structured claim extracted or submitted for analysis."""
+
+    claim_id: str
+    text: str
+    source_ref: str
+    claim_type: str = "unknown"
+    requires_evidence: bool = True
+    status: str = "pending"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "text": self.text,
+            "source_ref": self.source_ref,
+            "claim_type": self.claim_type,
+            "requires_evidence": self.requires_evidence,
+            "status": self.status,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    """A structured evidence item linked to one or more claims."""
+
+    evidence_id: str
+    text: str
+    source_ref: str
+    source_type: str = "unknown"
+    supports_claim_ids: tuple[str, ...] = ()
+    contradicts_claim_ids: tuple[str, ...] = ()
+    limitations: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "evidence_id": self.evidence_id,
+            "text": self.text,
+            "source_ref": self.source_ref,
+            "source_type": self.source_type,
+            "supports_claim_ids": list(self.supports_claim_ids),
+            "contradicts_claim_ids": list(self.contradicts_claim_ids),
+            "limitations": list(self.limitations),
+            "metadata": dict(self.metadata),
+        }

--- a/tests/semantic_engine/test_minimal_contracts.py
+++ b/tests/semantic_engine/test_minimal_contracts.py
@@ -1,0 +1,78 @@
+from semantic_engine.contracts import (
+    AnalysisResult,
+    AuditLogEntry,
+    ClaimRecord,
+    DecisionTrace,
+    EvidenceRecord,
+)
+
+
+def test_analysis_result_preserves_core_decomposition_fields():
+    claim = ClaimRecord(
+        claim_id="claim-1",
+        text="HUB_Optimus separates evidence from inference.",
+        source_ref="README.md",
+    )
+    evidence = EvidenceRecord(
+        evidence_id="evidence-1",
+        text="The core map requires separate claim, evidence, inference, uncertainty, narrative, and signal fields.",
+        source_ref="docs/architecture/core_to_engine_translation_map.md",
+        supports_claim_ids=("claim-1",),
+    )
+    trace = DecisionTrace(
+        step="contract_shape",
+        rule_applied="core_decomposition",
+        input_ref="claim-1",
+        output_ref="analysis-1",
+        reason="Keep core decomposition explicit in the result contract.",
+    )
+    audit = AuditLogEntry(
+        event_id="audit-1",
+        action="created",
+        object_type="analysis_result",
+        object_id="analysis-1",
+        reason="Minimal contract fixture.",
+        timestamp="2026-05-30T00:00:00+00:00",
+    )
+
+    result = AnalysisResult(
+        case_id="case-1",
+        core_version_ref="main@core-to-engine-map",
+        input_summary="Minimal contract test case.",
+        claims=(claim,),
+        evidence=(evidence,),
+        inferences=("Inference remains separated.",),
+        uncertainties=("No evaluator has run yet.",),
+        narrative_amplification=("No amplification assessed yet.",),
+        operational_signal="none",
+        status="draft",
+        decision_trace=(trace,),
+        audit_log=(audit,),
+    )
+
+    payload = result.to_dict()
+
+    assert payload["case_id"] == "case-1"
+    assert payload["claims"][0]["claim_id"] == "claim-1"
+    assert payload["evidence"][0]["supports_claim_ids"] == ["claim-1"]
+    assert payload["inferences"] == ["Inference remains separated."]
+    assert payload["uncertainties"] == ["No evaluator has run yet."]
+    assert payload["narrative_amplification"] == ["No amplification assessed yet."]
+    assert payload["decision_trace"][0]["rule_applied"] == "core_decomposition"
+    assert payload["audit_log"][0]["object_type"] == "analysis_result"
+
+
+def test_contracts_are_stdlib_serializable_shapes():
+    result = AnalysisResult(
+        case_id="case-2",
+        core_version_ref="main@contracts",
+        input_summary="Empty draft result.",
+    )
+
+    payload = result.to_dict()
+
+    assert payload["claims"] == []
+    assert payload["evidence"] == []
+    assert payload["decision_trace"] == []
+    assert payload["audit_log"] == []
+    assert payload["status"] == "draft"


### PR DESCRIPTION
## Why

Hito 1 (`core_to_engine_translation_map.md`) is merged and defines the next gate: minimal engine contracts before CLI, API, HERMES, AWS, S3, vector search, or scoring.

This PR starts Hito 2 by adding the smallest executable contract layer for the HUB_Optimus Semantic Engine.

## What

Adds stdlib-only dataclass contracts for:

- `AnalysisResult`
- `ClaimRecord`
- `EvidenceRecord`
- `DecisionTrace`
- `AuditLogEntry`

Adds focused tests for:

- required decomposition shape: claims, evidence, inferences, uncertainties, narrative amplification, operational signal
- nested `to_dict()` serialization
- empty draft result shape

## Scope

Minimal contracts only.

## Out of scope

- CLI execution
- API
- HERMES PWA
- AWS runtime
- S3 persistence
- Vector DB
- Evaluators
- Normalizers
- Scoring logic
- LLM/SLM judge
- Runtime changes
- CI changes
- Existing scenario runner changes

## Validation

Recommended:

```bash
pytest tests/semantic_engine/test_minimal_contracts.py
git diff --check
python tools/check_mojibake.py semantic_engine tests
```

## Gate

This PR closes Hito 2 only after merge into `main`. Until then: `Hito 2 = PR_OPEN`.