### PR TITLE
engine: copy audit snapshots in serialization

### DIFF
--- a/semantic_engine/contracts/audit_log.py
+++ b/semantic_engine/contracts/audit_log.py
@@ -13,6 +13,14 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
+def copy_snapshot(snapshot: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return a shallow copy of an audit snapshot if one exists."""
+
+    if snapshot is None:
+        return None
+    return dict(snapshot)
+
+
 @dataclass(frozen=True)
 class AuditLogEntry:
     """A durable audit event for a Semantic Engine action."""
@@ -36,8 +44,8 @@ class AuditLogEntry:
             "action": self.action,
             "object_type": self.object_type,
             "object_id": self.object_id,
-            "before": self.before,
-            "after": self.after,
+            "before": copy_snapshot(self.before),
+            "after": copy_snapshot(self.after),
             "reason": self.reason,
             "metadata": dict(self.metadata),
         }

--- a/tests/semantic_engine/test_minimal_contracts.py
+++ b/tests/semantic_engine/test_minimal_contracts.py
@@ -76,3 +76,25 @@ def test_contracts_are_stdlib_serializable_shapes():
     assert payload["decision_trace"] == []
     assert payload["audit_log"] == []
     assert payload["status"] == "draft"
+
+
+def test_audit_log_serialization_copies_before_after_snapshots():
+    before = {"status": "draft"}
+    after = {"status": "complete"}
+    audit = AuditLogEntry(
+        event_id="audit-2",
+        action="updated",
+        object_type="analysis_result",
+        object_id="analysis-2",
+        reason="Snapshot copy test.",
+        timestamp="2026-05-30T00:00:00+00:00",
+        before=before,
+        after=after,
+    )
+
+    payload = audit.to_dict()
+    payload["before"]["status"] = "mutated"
+    payload["after"]["status"] = "mutated"
+
+    assert audit.before == {"status": "draft"}
+    assert audit.after == {"status": "complete"}


### PR DESCRIPTION
## Why

PR #1614 merged the minimal Semantic Engine contracts. Review surfaced one real hardening issue: `AuditLogEntry.to_dict()` returned `before` and `after` snapshot dictionaries directly, so downstream mutation of the serialized payload could silently mutate the audit entry's stored snapshots.

This is contract hardening before moving to the next functional hito.

## What

- Add `copy_snapshot()` helper for shallow-copying audit snapshots.
- Return copied `before` / `after` dictionaries from `AuditLogEntry.to_dict()`.
- Add a focused regression test proving mutation of serialized payload does not mutate the audit entry.

## Scope

Hito 2.1 hardening only.

## Out of scope

- CLI
- API
- HERMES
- AWS
- S3
- Vector DB
- Evaluators
- Normalizers
- Scoring
- Runtime changes
- CI changes

## Validation

Recommended:

```bash
pytest tests/semantic_engine/test_minimal_contracts.py
git diff --check
python tools/check_mojibake.py semantic_engine tests
```

## Gate

After this PR is merged, move to the next small hito: Semantic Engine CLI smoke execution.