### PR TITLE
engine: deep-copy audit snapshots in serialization

### DIFF
--- a/semantic_engine/contracts/audit_log.py
+++ b/semantic_engine/contracts/audit_log.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -14,11 +15,11 @@ def utc_now_iso() -> str:
 
 
 def copy_snapshot(snapshot: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Return a shallow copy of an audit snapshot if one exists."""
+    """Return a deep copy of an audit snapshot if one exists."""
 
     if snapshot is None:
         return None
-    return dict(snapshot)
+    return deepcopy(snapshot)
 
 
 @dataclass(frozen=True)

--- a/tests/semantic_engine/test_minimal_contracts.py
+++ b/tests/semantic_engine/test_minimal_contracts.py
@@ -98,3 +98,39 @@ def test_audit_log_serialization_copies_before_after_snapshots():
 
     assert audit.before == {"status": "draft"}
     assert audit.after == {"status": "complete"}
+
+
+def test_audit_log_serialization_deep_copies_nested_snapshots():
+    before = {
+        "claims": [{"claim_id": "claim-1", "metadata": {"tier": "draft"}}],
+        "tags": ["initial"],
+    }
+    after = {
+        "claims": [{"claim_id": "claim-1", "metadata": {"tier": "complete"}}],
+        "tags": ["final"],
+    }
+    audit = AuditLogEntry(
+        event_id="audit-3",
+        action="updated",
+        object_type="analysis_result",
+        object_id="analysis-3",
+        reason="Nested snapshot copy test.",
+        timestamp="2026-05-30T00:00:00+00:00",
+        before=before,
+        after=after,
+    )
+
+    payload = audit.to_dict()
+    payload["before"]["claims"][0]["metadata"]["tier"] = "mutated"
+    payload["before"]["tags"].append("mutated")
+    payload["after"]["claims"][0]["metadata"]["tier"] = "mutated"
+    payload["after"]["tags"].append("mutated")
+
+    assert audit.before == {
+        "claims": [{"claim_id": "claim-1", "metadata": {"tier": "draft"}}],
+        "tags": ["initial"],
+    }
+    assert audit.after == {
+        "claims": [{"claim_id": "claim-1", "metadata": {"tier": "complete"}}],
+        "tags": ["final"],
+    }


### PR DESCRIPTION
## Why

Hito 2.1 hardened `AuditLogEntry.to_dict()` by copying `before` / `after` snapshots, but the copy is currently shallow. Review surfaced that realistic audit snapshots may contain nested contract payloads such as `AnalysisResult.to_dict()`, including lists and nested metadata dictionaries.

This PR closes Hito 2.2 by deep-copying audit snapshots before moving to the CLI smoke hito.

## What

- Import `copy.deepcopy`.
- Change `copy_snapshot()` from shallow `dict(snapshot)` to `deepcopy(snapshot)`.
- Add a focused nested snapshot regression test.

## Scope

Hito 2.2 contract hardening only.

## Out of scope

- CLI
- API
- HERMES
- AWS
- S3
- Vector DB
- Evaluators
- Normalizers
- Scoring
- Runtime changes
- CI changes

## Validation

Recommended:

```bash
pytest tests/semantic_engine/test_minimal_contracts.py
git diff --check
python tools/check_mojibake.py semantic_engine tests
```

## Gate

After this PR is merged, Hito 3 can begin: Semantic Engine CLI smoke execution.