### PR TITLE
i18n/de: translate governance batch B

### DIFF
--- a/docs/de/governance/EVALUATION_STANDARD.md
+++ b/docs/de/governance/EVALUATION_STANDARD.md
@@ -29,7 +29,7 @@ Verborgene Annahmen machen Vertrauen ungültig.
 ### 4. Anreizstruktur
 - Kurzfristige Anreize
 - Langfristige Anreize
-- Risiken von Fehlanreizen
+- Fehlausrichtungsrisiken
 
 ### 5. Klassifikation der Vertrauensebene
 - Nachweisklasse (A / B / C)

--- a/docs/de/governance/LEGITIMACY_MODEL.md
+++ b/docs/de/governance/LEGITIMACY_MODEL.md
@@ -11,9 +11,9 @@ HUB_Optimus leitet Legitimität ab aus:
 - Verifizierbarkeit von Behauptungen,
 - anreizkompatibler Begründung,
 - nachvollziehbarem Konsens,
-- und Bewahrung der Beratungsaufzeichnung.
+- und Bewahrung des Beratungsprotokolls.
 
-Legitimität ist prozedural, nicht positional.
+Legitimität ist prozedural, nicht positionsgebunden.
 
 ## Worauf HUB_Optimus sich nicht stützt
 Es stützt sich NICHT auf:

--- a/docs/de/governance/SCENARIO_SCHEMA.md
+++ b/docs/de/governance/SCENARIO_SCHEMA.md
@@ -1,4 +1,4 @@
-# HUB_Optimus — Szenario-Schema
+# HUB_Optimus Szenario-Schema
 
 ## Zweck
 Die Mindeststruktur definieren, die erforderlich ist, um `run_scenario.py` sicher auszuführen.

--- a/docs/de/governance/TRADEMARKS.md
+++ b/docs/de/governance/TRADEMARKS.md
@@ -64,5 +64,12 @@ Kustoden vergeben keine "Zertifizierung". Sie schützen nur Klarheit und verhind
 - Benennung eines Forks oder Derivats als "HUB_Optimus" oder Nutzung verwechselbar ähnlicher Markenführung.
 - Irreführende "Kompatibilitäts"-Behauptungen, die Governance-Ausrichtung implizieren.
 
+## Erlaubte Nutzungen (ohne Genehmigung)
+Der Name/die Marke darf genutzt werden, um:
+- auf dieses Repository und seine Dokumente zu verweisen,
+- HUB_Optimus in akademischen oder gemeinwohlorientierten Diskussionen zu zitieren,
+- Werkzeuge zu bauen, die HUB_Optimus-Methoden *implementieren*,
+- Übersetzungen zu erstellen, die Bedeutung bewahren.
+
 ### Durchsetzung
 Nicht autorisierte Nutzung stellt eine Markenverletzung dar und kann rechtliche Schritte auslösen.

--- a/docs/de/governance/TRUST_LAYER.md
+++ b/docs/de/governance/TRUST_LAYER.md
@@ -59,7 +59,7 @@ Für jede Verpflichtung erstellt HUB_Optimus ein **Vertrauensprofil** anhand der
 - Gibt es eine Prüfspur (wer/was/wann/wo)?
 
 3) **Unabhängigkeit**
-- Ist die Verifikation unabhängig vom Anspruchsteller?
+- Ist die Verifikation unabhängig von der behauptenden Partei?
 
 4) **Abdeckung**
 - Deckt die Verifikation die gesamte Verpflichtung ab oder nur Fragmente?
@@ -83,7 +83,7 @@ Eine Verpflichtung wird nur dann als "zuverlässig genug für die Planung" behan
 
 ---
 
-## Streitfälle und Herabstufung (nicht zwangsausübende Durchsetzung)
+## Streitfälle und Herabstufung (nicht-zwanghafte Durchsetzung)
 HUB_Optimus setzt keine Ergebnisse durch.
 Es setzt **epistemische Disziplin** durch:
 
@@ -115,6 +115,7 @@ selbst wenn sie als Klasse A präsentiert wird.
 - Beitragende: dürfen Änderungen an Nicht-Kernel-Materialien zur Prüfung vorschlagen.
 - Kustoden: dürfen Governance-Änderungen unter strengem Prozess genehmigen.
 
+### ## Kernel-Zugriff und Anti-Vereinnahmungsregeln (Härtung)
 Direkte Änderungen an Kernel-Dokumenten erfordern:
 1) ausdrückliche Begründung mit Bezug auf Kernel-Prinzipien,
 2) Konsensprüfung gemäß CONSENSUS_PROCESS,


### PR DESCRIPTION
## Summary
- Translates German governance batch B from canonical governance documents.
- Covers Trust Layer, Evaluation Standard, Scenario Schema, Legitimacy Model, and Trademarks under docs/de/governance/.
- Preserves structure, links, section order, and normative force.

## Scope
Touched only:
- docs/de/governance/TRUST_LAYER.md
- docs/de/governance/EVALUATION_STANDARD.md
- docs/de/governance/SCENARIO_SCHEMA.md
- docs/de/governance/LEGITIMACY_MODEL.md
- docs/de/governance/TRADEMARKS.md

## Out of scope
- No governance policy changes.
- No onboarding polish.
- No README changes.
- No ES or other language edits.
- No v1_core, runtime, CI, benchmarks, schemas, or policy changes.

## Validation
- `python tools/check_mojibake.py docs/de/governance/TRUST_LAYER.md docs/de/governance/EVALUATION_STANDARD.md docs/de/governance/SCENARIO_SCHEMA.md docs/de/governance/LEGITIMACY_MODEL.md docs/de/governance/TRADEMARKS.md` — passed: `Mojibake check passed (5 markdown files scanned).`
- `lychee docs/de/governance/TRUST_LAYER.md docs/de/governance/EVALUATION_STANDARD.md docs/de/governance/SCENARIO_SCHEMA.md docs/de/governance/LEGITIMACY_MODEL.md docs/de/governance/TRADEMARKS.md` — passed: `1 Total`, `1 OK`, `0 Errors`.
- `git diff --check -- docs/de/governance/TRUST_LAYER.md docs/de/governance/EVALUATION_STANDARD.md docs/de/governance/SCENARIO_SCHEMA.md docs/de/governance/LEGITIMACY_MODEL.md docs/de/governance/TRADEMARKS.md` — passed with no output.
- `git diff --name-only origin/main` — returned only:
  - `docs/de/governance/EVALUATION_STANDARD.md`
  - `docs/de/governance/LEGITIMACY_MODEL.md`
  - `docs/de/governance/SCENARIO_SCHEMA.md`
  - `docs/de/governance/TRADEMARKS.md`
  - `docs/de/governance/TRUST_LAYER.md`

## Acceptance criteria
- Only the five DE governance batch B files are changed.
- German translation preserves canonical meaning.
- All links remain valid.
- No governance policy is changed.
- No onboarding files are touched.
- No README files are touched.
- No other language is touched.
- No runtime, CI, benchmark, schema, or v1_core files are touched.
- `git diff --name-only origin/main` returns only:
  - `docs/de/governance/TRUST_LAYER.md`
  - `docs/de/governance/EVALUATION_STANDARD.md`
  - `docs/de/governance/SCENARIO_SCHEMA.md`
  - `docs/de/governance/LEGITIMACY_MODEL.md`
  - `docs/de/governance/TRADEMARKS.md`

## Review focus
Review for normative drift, especially verification, legitimacy, trademark/identity restrictions, non-enforcement, and anti-capture language.