### PR TITLE
docs: refresh handoff and status discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,11 +70,15 @@ Do not introduce LLM-as-judge, dashboards, semantic scoring, roadmap changes, or
 
 ## Handoff Discipline
 
-After meaningful work, update `docs/context/AI_HANDOFF.md` with:
+Update `docs/context/AI_HANDOFF.md` only when the scoped issue or PR changes operational handoff state, including:
 
-- What changed
-- Which issue or PR justified it
-- What validation ran
-- What remains pending
-- What should not be done yet
-- The next recommended action
+- operational state
+- active priorities
+- architecture
+- governance posture
+- runtime, CI, or benchmark posture
+- contributor handoff requirements
+
+Do not update `docs/context/AI_HANDOFF.md` for narrowly scoped translation, typo, link, formatting, or parity-only PRs unless the issue or PR explicitly requires it.
+
+If `docs/context/AI_HANDOFF.md` is not updated, say why in the PR body.

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -1,23 +1,15 @@
 # HUB_Optimus AI Handoff
 
-This file is the living bridge between ChatGPT PM/Tech Lead work and Codex repo execution.
-GitHub remains the source of truth; chat context only matters when it is reflected in issues, PRs, or repo docs.
+This file records operational handoff state for ChatGPT/Codex repo execution.
+GitHub remains the source of truth; chat summaries are advisory unless reflected in issues, PRs, commits, or repo docs.
 
-## Current System State
+## Operating Discipline
 
 - Release: use GitHub Releases as source of truth.
-- Last merged PR: #1578, `docs: add AI handoff protocol for ChatGPT/Codex sync`.
-- Current branch: see active GitHub issue or PR; `main` is the source of truth after merge.
+- Current branch and active assignment: use the active GitHub issue or PR.
 - CI status: use GitHub Checks on the active PR as source of truth.
-- Active issue: none; use GitHub Issues/Project board for current assignment.
-- Current priority: observe -> detect -> decide -> act; no build without signal.
-
-## Recent Decisions
-
-- Decision: synchronize ChatGPT and Codex through GitHub state, not through unsynchronized chat memory.
-- Reason: repository files, issues, and PRs are reviewable, durable, and reproducible.
-- Date: 2026-05-08.
-- Source: GitHub issue #1577 and ChatGPT PM handoff summary.
+- Default loop: observe -> detect -> decide -> act.
+- Default rule: no build without signal.
 
 ## Current Constraints
 
@@ -27,9 +19,30 @@ GitHub remains the source of truth; chat context only matters when it is reflect
 - Small PRs only.
 - Keep source-of-truth conflicts resolved by `docs/context/STATUS.md`.
 
-## Next Recommended Action
+## Handoff Update Discipline
+
+Update this file only when the scoped issue or PR changes operational handoff state, including:
+
+- operational state
+- active priorities
+- architecture
+- governance posture
+- runtime, CI, or benchmark posture
+- contributor handoff requirements
+
+Do not update this file for narrowly scoped translation, typo, link, formatting, or parity-only PRs unless the issue or PR explicitly requires it.
+
+If this file is not updated, say why in the PR body.
+
+## Current Recommended Action
 
 No action until CI, collaborator friction, regression, or user request creates a concrete signal.
+
+## Meta-learning Follow-up
+
+- `.github/copilot-instructions.md` currently identifies `v1_core/workflow/05_meta_learning.md` as the meta-learning update location.
+- Other meta-learning copies or link targets require canonical/parity/legacy classification in a separate PR.
+- Do not consolidate or delete meta-learning files in this handoff/status discipline PR.
 
 ## Do Not Do
 
@@ -39,7 +52,11 @@ No action until CI, collaborator friction, regression, or user request creates a
 - Do not add dashboards, semantic scoring, or new metrics without approved issue scope.
 - Do not treat chat-only decisions as roadmap changes.
 
-## AI Sync Block
+## Historical AI Sync Blocks
+
+The entries below are retained as historical execution notes. They are not current branch, PR, issue, or priority state.
+
+### AI Sync Block
 
 Date: 2026-05-24
 Source: Codex execution for GitHub issue #1589
@@ -68,7 +85,7 @@ Out of scope:
 - crypto implementation
 - dependency additions
 
-## AI Sync Block
+### AI Sync Block
 
 Date: 2026-05-24
 Source: Codex execution for RFC branch `rfc/post-quantum-control-plane`
@@ -97,14 +114,14 @@ Out of scope:
 - dashboards
 - LLM-as-judge
 
-## AI Sync Block
+### AI Sync Block
 
 Date: 2026-05-08
 Source: Codex execution for GitHub issue #1577
 Repo state: governance protocol merged to main
-Branch: see active GitHub issue or PR; `main` is the source of truth after merge
-Last merged PR: #1578
-Active issue: none
+Branch at the time: see active GitHub issue or PR; `main` is the source of truth after merge
+Merged PR for this historical block: #1578
+Active issue at the time: none
 Decision made: add persistent repo-level handoff protocol for ChatGPT/Codex sync
 Reason: align AI work through GitHub state instead of fragile chat-memory synchronization
 Files changed:

--- a/docs/context/STATUS.md
+++ b/docs/context/STATUS.md
@@ -1,3 +1,7 @@
+## Status freshness
+
+This file records stable repository policy and high-level status. For current PR/issue state, GitHub Issues, Pull Requests, and CI are authoritative.
+
 ### Canonical languages policy (v1)
 
 **v1_core/** (normative spec):
@@ -19,7 +23,8 @@
 **Planned switch (later, not now):**
 - Once en reaches stable parity, we may declare **en as canonical** for a future version (v1.1 or v2).
 
-## Next steps
-- [ ] Decidir si REPO_TREE.txt y SNAPSHOT.txt van a git (sí/no) y actuar en consecuencia
-- [ ] Validar/finalizar tools/fix_encoding_docs.ps1 (y documentar uso en WORKFLOWS.md)
-- [ ] Ejecutar link-check (Lychee) localmente o vía GitHub Actions y corregir rotos
+## Meta-learning file status
+
+- `.github/copilot-instructions.md` identifies `v1_core/workflow/05_meta_learning.md` as the meta-learning update location.
+- Other meta-learning files exist as compatibility targets, translations, or unclassified copies and need separate canonical/parity/legacy classification.
+- Do not consolidate, delete, or rewrite meta-learning files without a scoped issue or PR.


### PR DESCRIPTION
Decision
Refresh handoff/status discipline in the smallest documentation-only PR.

Scope
- Remove stale current-state framing from AI_HANDOFF.md.
- Reframe STATUS.md as stable policy/high-level status, with GitHub Issues, PRs, and CI authoritative for live state.
- Scope AGENTS.md handoff updates so translation, typo, link, formatting, and parity-only PRs are exempt unless explicitly required.
- Flag meta-learning duplication/classification as follow-up without rewriting or deleting files.

Files changed
- AGENTS.md
- docs/context/AI_HANDOFF.md
- docs/context/STATUS.md

Out of scope
- Runtime changes
- CI changes
- Benchmark changes
- Schema changes
- Roadmap changes
- Dashboards
- LLM-as-judge
- Semantic scoring
- Full i18n parity sweep
- Deleting duplicate meta-learning files
- Broad mojibake cleanup

Acceptance criteria
- Diff is documentation-only.
- STATUS.md no longer presents old next steps as current operational priorities.
- AI_HANDOFF.md no longer presents #1578 or 2026-05-08 as current operational state.
- AI_HANDOFF update discipline is scoped, not mandatory for every meaningful PR.
- Translation/parity-only PRs are explicitly exempt from mandatory AI_HANDOFF updates unless issue-scoped.
- Meta-learning duplication is flagged as follow-up, not solved broadly.
- Mojibake cleanup is limited to touched files; .github/copilot-instructions.md and docs/lab_state.md are left for a separate PR.
- No runtime/CI/benchmark/schema files changed.

Validation
- git status --short: clean before edits.
- git log --oneline --decorate -20: confirmed branch was based on origin/main at 226cadf after #1617 merge.
- gh pr view 1617 --json number,state,title,headRefName,baseRefName,mergedAt,mergeCommit,url: confirmed #1617 was MERGED on 2026-06-01.
- git diff --name-only origin/main: AGENTS.md, docs/context/AI_HANDOFF.md, docs/context/STATUS.md.
- git diff --check --: passed.
- python tools/check_mojibake.py AGENTS.md docs/context/STATUS.md docs/context/AI_HANDOFF.md: passed, 3 markdown files scanned.
- python -m pytest -q: passed, 49 tests.

Risks
- Documentation-only governance wording; reviewers should confirm the exemption wording matches expected PR-body discipline.
- Historical AI sync blocks remain as historical notes, but are explicitly labeled as non-current state.

AI_HANDOFF.md update
Updated because this PR changes operational handoff discipline itself. Future narrow translation, typo, link, formatting, or parity-only PRs do not need AI_HANDOFF.md updates unless the scoped issue or PR requires it.

Follow-up candidates
1. docs: classify meta-learning canonical/parity/legacy files
2. docs: fix mojibake in lab_state and copilot instructions
3. docs: audit multilingual governance parity after German batch B