### PR TITLE
docs/de: polish German onboarding and README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 > **Primary onboarding:** [EN](docs/00_start_here.md) · [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md)
 >
-> **Translation status:** CA / FR / RU = progressive translation (not language-faithful onboarding yet) · HE = stub / full translation pending · ZH = governance stub only
+> **Translation status:** DE governance path translated · CA / FR / RU = progressive translation · HE / ZH = onboarding stubs, full translation pending
 >
 > Source of truth: [docs/context/STATUS.md](docs/context/STATUS.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Canonical language policy is defined in [context/STATUS.md](context/STATUS.md). 
 | --- | --- | --- | --- |
 | en | [00_start_here.md](00_start_here.md) | reference/default docs | canonical governance in [governance/](governance/) |
 | es | [es/00_start_here.md](es/00_start_here.md) | priority onboarding | translation in progress; some governance files may still be English mirrors |
-| de | [de/00_start_here.md](de/00_start_here.md) | priority onboarding | translation in progress; some governance files may still be English mirrors |
+| de | [de/00_start_here.md](de/00_start_here.md) | priority onboarding | governance path translated; canonical governance remains [governance/](governance/) |
 | ca | [ca/00_start_here.md](ca/00_start_here.md) | progressive | not in the priority governance translation batch |
 | fr | [fr/00_start_here.md](fr/00_start_here.md) | progressive | not in the priority governance translation batch |
 | ru | [ru/00_start_here.md](ru/00_start_here.md) | progressive | not in the priority governance translation batch |

--- a/docs/de/00_start_here.md
+++ b/docs/de/00_start_here.md
@@ -8,10 +8,10 @@ HUB_Optimus hilft dabei, Szenarien und Vereinbarungen zu bewerten, **bevor** sie
 ---
 
 ## Governance
-> Uebersetzungsstatus:
-> Diese Onboarding-Seite ist lokalisiert. Einige unten verlinkte Governance-Dokumente koennen weiterhin englische Mirrors sein.
+> Übersetzungsstatus:
+> Diese Onboarding-Seite und die unten verlinkten Governance-Dokumente sind auf Deutsch verfügbar.
 > Die kanonische Governance bleibt `docs/governance/`.
-> Jede Uebersetzung muss Bedeutung und normative Kraft erhalten.
+> Bei Bedeutungsabweichungen gilt die kanonische Quelle.
 
 - Gründungsurkunde: [governance/CHARTER.md](governance/CHARTER.md)
 - Kernel (unveränderliche Prinzipien): [governance/KERNEL.md](governance/KERNEL.md)
@@ -106,7 +106,7 @@ Sende diesen Link:
   [01_base_declaracion (EN)](../../v1_core/languages/en/01_base_declaracion.md)
 
 **Praktischer Test:**
-- Vorlage: [Szenario-Vorlage](../../v1_core/workflow/04_scenario_template.md)
-- Beispiele: [Szenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Szenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
-- Lernschleife: [Meta-Lernen](../../v1_core/workflow/05_meta_learning.md)
+- Vorlage (ES-Quelle): [Szenario-Vorlage](../../v1_core/workflow/04_scenario_template.md)
+- Beispiele (EN-Referenz): [Szenario 001](../../v1_core/workflow/scenario_001_partial_ceasefire.md), [Szenario 002](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- Lernschleife (ES-Quelle): [Meta-Lernen](../../v1_core/workflow/05_meta_learning.md)
 <!-- /HUB:TRACKS -->

--- a/docs/de/02_how_to_read_this_repo.md
+++ b/docs/de/02_how_to_read_this_repo.md
@@ -34,22 +34,22 @@ und geh danach zurück in den Workflow.
 - `legacy/`  
   Älteres oder experimentelles Material. Nützlich als Referenz, aber nicht immer "up to date".
 
-## Language policy (STATUS)
-- Source-of-truth: `docs/context/STATUS.md`
-- canonical: `../../v1_core/languages/es/`
-- parity reference: `../../v1_core/languages/en/`
+## Sprachstatus (STATUS)
+- Verbindliche Quelle: `docs/context/STATUS.md`
+- Kanonisch: `../../v1_core/languages/es/`
+- Paritätsreferenz: `../../v1_core/languages/en/`
 
 ## Navigieren ohne Kontextverlust
-1) Nutze "Start here" und "Try a scenario", um das System in Aktion zu sehen.
+1) Nutze "Start hier" und "Szenario ausprobieren", um das System in Aktion zu sehen.
 2) Wenn ein Dokument etwas aus dem Kernel (`v1_core`) zitiert, folge dem Link und komm wieder zurück.
-3) Wenn ein Abschnitt auf EN ist, nutze den Link zur EN-Quelle, damit du nicht blockierst.
+3) Wenn ein Abschnitt auf ES oder EN verweist, ist das Quellen-/Referenzmaterial, keine vollständige deutsche Übersetzung.
 
 ## Wo das Wichtige ist (Shortcuts)
 - Einstieg (DE): [docs/de/00_start_here.md](00_start_here.md)
 - Szenario ausprobieren (DE): [docs/de/03_try_a_scenario.md](03_try_a_scenario.md)
 - Kernel-Workflow (ES): [../../v1_core/workflow/es/README.md](../../v1_core/workflow/es/README.md)
 - Szenario-Vorlage (ES): [../../v1_core/workflow/es/04_scenario_template.md](../../v1_core/workflow/es/04_scenario_template.md)
-- Meta-Learning (ES): [../../v1_core/workflow/es/05_meta_learning.md](../../v1_core/workflow/es/05_meta_learning.md)
+- Meta-Lernen (ES): [../../v1_core/workflow/es/05_meta_learning.md](../../v1_core/workflow/es/05_meta_learning.md)
 
 ## Wenn du beitragen willst (ohne Links zu brechen)
 - Bevorzuge relative Links (damit sie in GitHub und lokal funktionieren).

--- a/docs/de/03_try_a_scenario.md
+++ b/docs/de/03_try_a_scenario.md
@@ -1,4 +1,4 @@
-# Try a Scenario — HUB_Optimus in der Praxis
+# Szenario ausprobieren — HUB_Optimus in der Praxis
 
 Dieser Leitfaden zeigt anhand eines Beispiels, wie du HUB_Optimus nutzt, ohne den gesamten Kernel lesen zu müssen.
 
@@ -6,12 +6,14 @@ Du vergleichst zwei Szenarien, die an der Oberfläche ähnlich wirken, aber zu s
 
 Geschätzte Dauer: 10–15 Minuten.
 
+Hinweis: Die folgenden Links führen bewusst auf `v1_core`-Quellen und Referenzen. Sie sind keine vollständigen deutschen Übersetzungen.
+
 ---
 
 ## Schritt 1 — Öffne die Szenario-Vorlage
 
 Öffne:
-- [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
+- Szenario-Vorlage (ES-Quelle): [../../v1_core/workflow/04_scenario_template.md](../../v1_core/workflow/04_scenario_template.md)
 
 Achte nur auf die Struktur:
 - Kontext
@@ -24,8 +26,8 @@ Achte nur auf die Struktur:
 
 ## Schritt 2 — Szenario 001: Teilweiser Waffenstillstand (falscher Erfolg)
 
-?ffne:
-- [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
+Öffne:
+- Szenario 001 (EN-Referenz): [../../v1_core/workflow/scenario_001_partial_ceasefire.md](../../v1_core/workflow/scenario_001_partial_ceasefire.md)
 
 Fokussiere dich auf:
 - Was behauptet wird vs. was verifiziert wird
@@ -37,7 +39,7 @@ Fokussiere dich auf:
 ## Schritt 3 — Szenario 002: Verifizierter Waffenstillstand (struktureller Erfolg)
 
 Öffne:
-- [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
+- Szenario 002 (EN-Referenz): [../../v1_core/workflow/scenario_002_verified_ceasefire.md](../../v1_core/workflow/scenario_002_verified_ceasefire.md)
 
 Fokussiere dich auf:
 - Was sich im Vergleich zu Szenario 001 geändert hat
@@ -64,7 +66,7 @@ Es fragt:
 ## Schritt 5 — Learning Layer
 
 Lies:
-- [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
+- Meta-Lernen (ES-Quelle): [../../v1_core/workflow/05_meta_learning.md](../../v1_core/workflow/05_meta_learning.md)
 
 Dort wird erklärt, wie Muster extrahiert und "gemerkt" werden.
 
@@ -81,7 +83,7 @@ Das ist der Kern von HUB_Optimus.
 
 ## Nächste Schritte
 
-Grundlagen:
+Grundlagen (EN-Referenz):
 
 - [../../v1_core/languages/en/01_base_declaracion.md](../../v1_core/languages/en/01_base_declaracion.md)
 - [../../v1_core/languages/en/02_arquitectura_base.md](../../v1_core/languages/en/02_arquitectura_base.md)
@@ -91,6 +93,5 @@ Grundlagen:
 Mitmachen:
 - Lies [CONTRIBUTING.md](../../CONTRIBUTING.md)
 - Schlage ein neues Szenario mithilfe der Vorlage vor
-
 
 


### PR DESCRIPTION
## Summary
- Polishes the German onboarding path and README language status.
- Keeps existing visual branding.
- Fixes stale language status after the DE governance translation PRs.
- Fixes visible DE onboarding mojibake.
- Does not change governance content or canonical policy.

## Scope
Touched only:
- README.md
- docs/README.md
- docs/de/00_start_here.md
- docs/de/02_how_to_read_this_repo.md
- docs/de/03_try_a_scenario.md

`docs/context/AI_HANDOFF.md` was not updated because the current AGENTS.md handoff rule says not to update it for narrow translation, typo, link, formatting, or parity-only PRs unless the scoped issue or PR changes operational handoff state.

## Out of scope
- No governance translations.
- No governance policy changes.
- No v1_core translation.
- No runtime, CI, benchmarks, schemas, or brand asset changes.
- No new logo or visual identity work.

## Validation
- `python tools/check_mojibake.py README.md docs/README.md docs/de/00_start_here.md docs/de/02_how_to_read_this_repo.md docs/de/03_try_a_scenario.md` — passed: `Mojibake check passed (5 markdown files scanned).`
- `lychee README.md docs/README.md docs/de/00_start_here.md docs/de/02_how_to_read_this_repo.md docs/de/03_try_a_scenario.md` — passed: `82 Total`, `81 OK`, `0 Errors`, `1 Redirects`.
- `git diff --check -- README.md docs/README.md docs/de/00_start_here.md docs/de/02_how_to_read_this_repo.md docs/de/03_try_a_scenario.md` — passed with no output.
- `git diff --name-only origin/main` — returned only:
  - `README.md`
  - `docs/README.md`
  - `docs/de/00_start_here.md`
  - `docs/de/02_how_to_read_this_repo.md`
  - `docs/de/03_try_a_scenario.md`

## Acceptance criteria
- German onboarding path is clear for a German-speaking reviewer.
- README.md language status is truthful and no longer stale.
- docs/README.md DE row is truthful after #1609 and #1617.
- docs/de/00_start_here.md no longer claims linked DE governance may still be English mirrors.
- v1_core is not falsely presented as fully translated into German.
- README visual branding remains the existing hero-based branding.
- No new visual assets are added.
- No governance content is changed in this PR.
- No policy or canonical hierarchy is changed.
- No visible mojibake remains in touched DE onboarding files.
- `git diff --name-only origin/main` returns only the scoped files listed above.

## Risks
- v1_core remains canonical ES with EN as parity reference and is not fully localized into DE.
- docs/context/STATUS.md is intentionally unchanged in this PR.