### PR TITLE
engine: add semantic engine CLI smoke

### DIFF
--- a/examples/semantic_engine/case_minimal.json
+++ b/examples/semantic_engine/case_minimal.json
@@ -1,0 +1,5 @@
+{
+  "case_id": "case-minimal-001",
+  "core_version_ref": "main",
+  "input_summary": "Minimal CLI smoke case for Semantic Engine contracts."
+}

--- a/semantic_engine/cli/__init__.py
+++ b/semantic_engine/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interface for the HUB_Optimus Semantic Engine."""

--- a/semantic_engine/cli/__main__.py
+++ b/semantic_engine/cli/__main__.py
@@ -1,0 +1,101 @@
+"""Minimal contract-first CLI for the HUB_Optimus Semantic Engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from semantic_engine.contracts import AnalysisResult
+
+REQUIRED_CASE_FIELDS = ("case_id", "core_version_ref", "input_summary")
+
+
+class ControlledCliError(Exception):
+    """Expected CLI error that should be printed without a traceback."""
+
+
+def load_case(path: Path) -> dict[str, Any]:
+    """Load a case JSON file and return its object payload."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ControlledCliError(f"input file not found: {path}") from exc
+    except OSError as exc:
+        raise ControlledCliError(f"cannot read input file {path}: {exc}") from exc
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ControlledCliError(f"invalid JSON in {path}: {exc.msg}") from exc
+
+    if not isinstance(payload, dict):
+        raise ControlledCliError("input JSON must be an object")
+
+    return payload
+
+
+def require_string_field(payload: dict[str, Any], field_name: str) -> str:
+    """Return a required non-empty string field or raise a controlled error."""
+
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ControlledCliError(f"missing required string field: {field_name}")
+    return value
+
+
+def build_draft_result(payload: dict[str, Any]) -> AnalysisResult:
+    """Build a draft AnalysisResult from a minimal case payload."""
+
+    return AnalysisResult(
+        case_id=require_string_field(payload, "case_id"),
+        core_version_ref=require_string_field(payload, "core_version_ref"),
+        input_summary=require_string_field(payload, "input_summary"),
+        status="draft",
+    )
+
+
+def analyze_case(input_path: Path) -> dict[str, Any]:
+    """Load a minimal case and return the contractual AnalysisResult payload."""
+
+    return build_draft_result(load_case(input_path)).to_dict()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m semantic_engine.cli",
+        description="HUB_Optimus Semantic Engine CLI",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    analyze = subparsers.add_parser(
+        "analyze",
+        help="Build a draft AnalysisResult from a minimal case JSON file.",
+    )
+    analyze.add_argument("input", help="Path to a minimal case JSON file.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "analyze":
+            payload = analyze_case(Path(args.input))
+        else:  # pragma: no cover - argparse prevents this path.
+            parser.error(f"unknown command: {args.command}")
+    except ControlledCliError as exc:
+        print(f"semantic_engine.cli: error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/semantic_engine/test_cli_smoke.py
+++ b/tests/semantic_engine/test_cli_smoke.py
@@ -1,0 +1,77 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "semantic_engine.cli", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def write_json(path: Path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_cli_analyze_happy_path_outputs_contractual_json():
+    result = run_cli("analyze", "examples/semantic_engine/case_minimal.json")
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+    payload = json.loads(result.stdout)
+    assert payload["case_id"] == "case-minimal-001"
+    assert payload["core_version_ref"] == "main"
+    assert payload["input_summary"] == "Minimal CLI smoke case for Semantic Engine contracts."
+    assert payload["claims"] == []
+    assert payload["evidence"] == []
+    assert payload["inferences"] == []
+    assert payload["uncertainties"] == []
+    assert payload["narrative_amplification"] == []
+    assert payload["operational_signal"] == "none"
+    assert payload["status"] == "draft"
+    assert payload["decision_trace"] == []
+    assert payload["audit_log"] == []
+
+
+def test_cli_missing_file_fails_cleanly():
+    result = run_cli("analyze", "examples/semantic_engine/does_not_exist.json")
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "semantic_engine.cli: error: input file not found" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_cli_invalid_json_fails_cleanly(tmp_path):
+    case_path = tmp_path / "invalid.json"
+    case_path.write_text("{not json", encoding="utf-8")
+
+    result = run_cli("analyze", str(case_path))
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "semantic_engine.cli: error: invalid JSON" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_cli_missing_required_field_fails_cleanly(tmp_path):
+    case_path = tmp_path / "missing.json"
+    write_json(
+        case_path,
+        {
+            "case_id": "case-missing-001",
+            "core_version_ref": "main",
+        },
+    )
+
+    result = run_cli("analyze", str(case_path))
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "semantic_engine.cli: error: missing required string field: input_summary" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Why

Hito 3 needs the first stable execution surface for the HUB_Optimus Semantic Engine.

The CLI is the communication contract that later API, HERMES, AWS runtime, scripts, and S3 persistence will rely on. This PR keeps it minimal and contract-first: stdout is clean JSON, stderr is for controlled errors, and exit codes are stable.

## What

Adds:

- `semantic_engine/cli/__init__.py`
- `semantic_engine/cli/__main__.py`
- `examples/semantic_engine/case_minimal.json`
- `tests/semantic_engine/test_cli_smoke.py`

Command:

```bash
python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json
```

Behavior:

- Reads minimal case JSON.
- Validates `case_id`, `core_version_ref`, and `input_summary` as required non-empty strings.
- Builds an `AnalysisResult` draft.
- Writes stable JSON to stdout using `indent=2` and `sort_keys=True`.
- Writes controlled expected errors to stderr.
- Avoids tracebacks for expected user/input errors.

## Scope

Semantic Engine CLI smoke execution only.

## Out of scope

- API
- HERMES PWA
- AWS runtime
- S3 persistence
- Vector DB
- Evaluators
- Normalizers beyond required field validation
- Scoring
- LLM/SLM judge
- Existing runtime changes
- CI changes

## Validation

Recommended:

```bash
pytest tests/semantic_engine/test_cli_smoke.py tests/semantic_engine/test_minimal_contracts.py
git diff --check
python tools/check_mojibake.py semantic_engine tests examples
```

## Gate

This PR closes Hito 3 only after merge into `main`. Until then: `Hito 3 = PR_OPEN`.