### PR TITLE
docs: restore missing governance mirrors

### DIFF
--- a/docs/ca/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
+++ b/docs/ca/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
@@ -1,0 +1,42 @@
+# GitHub Settings Protection Checklist
+
+## Purpose
+Document expected repository protection settings and mark observed state as
+`verified`, `pending`, or `unknown`.
+
+This document does not change GitHub Settings, workflows, CODEOWNERS, branch
+rules, automation, or runtime behavior.
+
+## Verification Context
+- Repository: `Voxterrae/HUB_Optimus`
+- Default branch: `main`
+- Verification date: 2026-05-15
+- Evidence source: GitHub CLI/API read-only queries and repository files
+
+## Status Key
+- `verified`: observed evidence matches the expected protection.
+- `pending`: expected protection is not fully observed, or needs explicit maintainer confirmation.
+- `unknown`: current state cannot be verified from available evidence.
+
+## Checklist
+
+| Setting | Expected state | Observed state | Evidence | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Branch protection for `main` | Enabled | `main` reports `protected: true` through GitHub branch metadata. Legacy branch-protection endpoint returns `404 Branch not protected`, so protection appears ruleset-based rather than legacy branch protection. | `gh api repos/Voxterrae/HUB_Optimus/branches/main`; `gh api repos/Voxterrae/HUB_Optimus/branches/main/protection` | verified | Track this as ruleset-based protection, not legacy branch protection. |
+| Active branch rulesets | At least one active ruleset applies to `main` | Two active branch rulesets apply to `main`: `Protect main (restricted)` and `protect-main`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Duplicate or overlapping rulesets should be reviewed before future settings changes. |
+| Required PR before merge | Enabled | Active `pull_request` rules are present for `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Current rules show `required_approving_review_count: 0`; review strength is tracked separately below. |
+| Required status checks | CI, Kernel Guard, Link Check, and PR Safety should be required before merge | Workflows exist and run on PRs, but no required status-check rule was observed through legacy branch-protection endpoints or active branch rules. | `.github/workflows/ci.yml`; `.github/workflows/kernel-guard.yml`; `.github/workflows/link-check.yml`; `.github/workflows/pr-safety-check.yml`; branch protection status-check endpoint returned `404 Branch not protected` | pending | Decide whether required checks should be enforced through rulesets in a separate settings-change issue. |
+| CODEOWNERS review | Enabled for protected paths | `.github/CODEOWNERS` maps protected paths to `@Voxterrae`, but active pull-request rules report `require_code_owner_review: false`. | `.github/CODEOWNERS`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | CODEOWNERS exists, but enforcement through GitHub Settings is not currently observed. |
+| Force pushes | Disabled | Active `non_fast_forward` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This blocks non-fast-forward updates, including force pushes. |
+| Branch deletion | Restricted or disabled | Active `deletion` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This protects `main` from branch deletion through rulesets. |
+| Required signed commits | Enabled if required by repository policy | Active `required_signatures` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Linear history | Enabled if required by repository policy | Active `required_linear_history` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Admin or role bypass | Restricted or explicitly documented | One active ruleset has no bypass actors. Another has a `RepositoryRole` bypass actor with `bypass_mode: always`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets/11637867`; `gh api repos/Voxterrae/HUB_Optimus/rulesets/11665521` | pending | Confirm whether the role bypass is intentional and document who may use it. |
+| Merge method restrictions | Expected merge methods should be explicit | One ruleset allows `merge`, `squash`, and `rebase`; the other allows `squash` only. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | Overlapping rulesets make the effective merge-method policy harder to audit. |
+
+## Follow-up Items
+- Decide whether required status checks should be enforced in GitHub rulesets.
+- Decide whether CODEOWNERS review should be enforced in GitHub rulesets.
+- Confirm and document the intended admin or repository-role bypass policy.
+- Review overlapping branch rulesets before making any future settings changes.
+- Keep any settings mutation out of this PR; open a separate issue for configuration changes.

--- a/docs/ca/governance/SYSTEM_PROTECTION_MATRIX.md
+++ b/docs/ca/governance/SYSTEM_PROTECTION_MATRIX.md
@@ -1,0 +1,36 @@
+# HUB_Optimus - System Protection Matrix
+
+## Purpose
+This matrix records the current protection surface for HUB_Optimus and the
+visible gaps that still need verification or follow-up.
+
+It is descriptive only. It does not add enforcement, change GitHub settings, or
+redefine repository architecture.
+
+## Status Key
+- `active`: protection exists in the repository or documented policy.
+- `partial`: protection exists but does not cover the full risk.
+- `pending`: expected protection or verification is not complete.
+- `unknown`: current state cannot be verified from repository files alone.
+
+## Matrix
+
+| Zone | Risk | Current protection | Owner | Status | Gaps |
+| --- | --- | --- | --- | --- | --- |
+| IP and usage rights | Public visibility may be mistaken for unrestricted license, commercial permission, or permission to create competing derivative systems. | `IP_NOTICE.md` and `docs/governance/IP_NOTICE.md` define restricted rights, kernel protection, operational method restrictions, scenario/documentation use limits, trademark notice, and enforcement language. | HUB_Optimus Governance / `@Voxterrae` | active | Keep wording aligned between root and governance IP notices. Legal enforceability and external misuse handling remain outside repo automation. |
+| Kernel and governance docs | Governance drift, translation drift, or unauthorized changes could weaken the constitutional core. | `docs/governance/` is covered by `.github/CODEOWNERS`; translation drift is addressed by `docs/governance/TRANSLATION_POLICY.md`; source-of-truth conflicts defer to `docs/context/STATUS.md`. | `@Voxterrae` | active | CODEOWNERS review depends on GitHub branch/ruleset enforcement. Translation parity checks are policy-based unless a separate issue adds automation. |
+| Canonical v1 language content | Canonical content could diverge from parity translations or be edited without appropriate scrutiny. | `.github/CODEOWNERS` assigns `v1_core/languages/`, `v1_core/languages/es/`, and `v1_core/languages/en/` to `@Voxterrae`; `docs/context/STATUS.md` states ES is canonical for v1 and EN is the parity target. | `@Voxterrae` | active | Automated parity verification is not established here. Future canonical-language changes require separate governed scope. |
+| CODEOWNERS review map | Protected files could change without the expected maintainer review if CODEOWNERS is incomplete or not enforced. | `.github/CODEOWNERS` maps kernel language content, governance docs, `.github/`, root configs, simulator files, `hub_optimus/`, and benchmarks to `@Voxterrae`. | `@Voxterrae` | active | GitHub must enforce CODEOWNERS through branch protection or rulesets; that Settings state is pending verification in #1590. |
+| CI baseline | Regressions, encoding problems, or test failures could enter `main`. | `.github/workflows/ci.yml` runs the mojibake guard, narrative consistency check, `pytest`, and non-blocking benchmarks on pull requests and pushes to `main`. | `@Voxterrae` | active | CI only protects merges if required checks are configured in GitHub Settings. Required-check status is pending verification in #1590. |
+| Kernel guard | Protected kernel/governance changes could be merged without explicit acknowledgement. | `.github/workflows/kernel-guard.yml` runs `tools/kernel_guard.py` on pull requests and requires the `allow-kernel-change` label to permit kernel changes. | `@Voxterrae` | active | Guard strength depends on the maintained protected-path list and required-check enforcement. Required status is pending verification in #1590. |
+| PR risk classification | High-risk changes could be reviewed as ordinary documentation or tooling edits. | `.github/workflows/pr-safety-check.yml` classifies protected-path changes, including `docs/governance/`, `.github/workflows/`, `.github/CODEOWNERS`, runtime files, schema, expected benchmarks, and v1 language content. | `@Voxterrae` | active | The workflow warns and summarizes risk; it does not itself block merge unless configured as a required check. |
+| External contributor quarantine | First-time fork PRs could run untrusted code or bypass maintainer attention. | `.github/workflows/pr-quarantine.yml` is metadata-only, avoids checkout/execution, labels first-time external fork PRs, and comments that maintainer review is required. | `@Voxterrae` | active | Applies only to first-time external fork PRs. Label existence and required-review policy still depend on GitHub configuration. |
+| Branch protection and rulesets | Direct pushes, force pushes, missing required checks, or missing review requirements could bypass repo policy. | Expected protection belongs in GitHub Settings, not in repository files. Local repo evidence cannot fully verify rulesets or branch protection. | `@Voxterrae` | pending | Verify branch protection, required checks, CODEOWNERS enforcement, no force pushes, and deletion restrictions in #1590. Until then, treat Settings state as pending/unknown. |
+| AI handoff and chat decisions | Unsynced chat decisions could be treated as governance, roadmap, or implementation authority. | `docs/context/AI_HANDOFF.md` states GitHub is the source of truth and chat context only matters when reflected in issues, PRs, or repo docs. | `@Voxterrae` | active | Detailed AI access levels are not defined here; that belongs to #1584 and #1585. |
+
+## Current Gaps To Track
+- Verify GitHub branch protection and rulesets in #1590.
+- Verify required checks for CI, kernel guard, and risk classification in #1590.
+- Confirm CODEOWNERS enforcement through GitHub Settings in #1590.
+- Keep external AI roles out of scope for this matrix; define them separately in #1584 and #1585.
+- Keep architecture terminology and capability status out of scope for this matrix; define them separately in #1586, #1587, and #1589.

--- a/docs/de/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
+++ b/docs/de/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
@@ -1,0 +1,42 @@
+# GitHub Settings Protection Checklist
+
+## Purpose
+Document expected repository protection settings and mark observed state as
+`verified`, `pending`, or `unknown`.
+
+This document does not change GitHub Settings, workflows, CODEOWNERS, branch
+rules, automation, or runtime behavior.
+
+## Verification Context
+- Repository: `Voxterrae/HUB_Optimus`
+- Default branch: `main`
+- Verification date: 2026-05-15
+- Evidence source: GitHub CLI/API read-only queries and repository files
+
+## Status Key
+- `verified`: observed evidence matches the expected protection.
+- `pending`: expected protection is not fully observed, or needs explicit maintainer confirmation.
+- `unknown`: current state cannot be verified from available evidence.
+
+## Checklist
+
+| Setting | Expected state | Observed state | Evidence | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Branch protection for `main` | Enabled | `main` reports `protected: true` through GitHub branch metadata. Legacy branch-protection endpoint returns `404 Branch not protected`, so protection appears ruleset-based rather than legacy branch protection. | `gh api repos/Voxterrae/HUB_Optimus/branches/main`; `gh api repos/Voxterrae/HUB_Optimus/branches/main/protection` | verified | Track this as ruleset-based protection, not legacy branch protection. |
+| Active branch rulesets | At least one active ruleset applies to `main` | Two active branch rulesets apply to `main`: `Protect main (restricted)` and `protect-main`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Duplicate or overlapping rulesets should be reviewed before future settings changes. |
+| Required PR before merge | Enabled | Active `pull_request` rules are present for `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Current rules show `required_approving_review_count: 0`; review strength is tracked separately below. |
+| Required status checks | CI, Kernel Guard, Link Check, and PR Safety should be required before merge | Workflows exist and run on PRs, but no required status-check rule was observed through legacy branch-protection endpoints or active branch rules. | `.github/workflows/ci.yml`; `.github/workflows/kernel-guard.yml`; `.github/workflows/link-check.yml`; `.github/workflows/pr-safety-check.yml`; branch protection status-check endpoint returned `404 Branch not protected` | pending | Decide whether required checks should be enforced through rulesets in a separate settings-change issue. |
+| CODEOWNERS review | Enabled for protected paths | `.github/CODEOWNERS` maps protected paths to `@Voxterrae`, but active pull-request rules report `require_code_owner_review: false`. | `.github/CODEOWNERS`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | CODEOWNERS exists, but enforcement through GitHub Settings is not currently observed. |
+| Force pushes | Disabled | Active `non_fast_forward` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This blocks non-fast-forward updates, including force pushes. |
+| Branch deletion | Restricted or disabled | Active `deletion` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This protects `main` from branch deletion through rulesets. |
+| Required signed commits | Enabled if required by repository policy | Active `required_signatures` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Linear history | Enabled if required by repository policy | Active `required_linear_history` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Admin or role bypass | Restricted or explicitly documented | One active ruleset has no bypass actors. Another has a `RepositoryRole` bypass actor with `bypass_mode: always`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets/11637867`; `gh api repos/Voxterrae/HUB_Optimus/rulesets/11665521` | pending | Confirm whether the role bypass is intentional and document who may use it. |
+| Merge method restrictions | Expected merge methods should be explicit | One ruleset allows `merge`, `squash`, and `rebase`; the other allows `squash` only. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | Overlapping rulesets make the effective merge-method policy harder to audit. |
+
+## Follow-up Items
+- Decide whether required status checks should be enforced in GitHub rulesets.
+- Decide whether CODEOWNERS review should be enforced in GitHub rulesets.
+- Confirm and document the intended admin or repository-role bypass policy.
+- Review overlapping branch rulesets before making any future settings changes.
+- Keep any settings mutation out of this PR; open a separate issue for configuration changes.

--- a/docs/de/governance/SYSTEM_PROTECTION_MATRIX.md
+++ b/docs/de/governance/SYSTEM_PROTECTION_MATRIX.md
@@ -1,0 +1,36 @@
+# HUB_Optimus - System Protection Matrix
+
+## Purpose
+This matrix records the current protection surface for HUB_Optimus and the
+visible gaps that still need verification or follow-up.
+
+It is descriptive only. It does not add enforcement, change GitHub settings, or
+redefine repository architecture.
+
+## Status Key
+- `active`: protection exists in the repository or documented policy.
+- `partial`: protection exists but does not cover the full risk.
+- `pending`: expected protection or verification is not complete.
+- `unknown`: current state cannot be verified from repository files alone.
+
+## Matrix
+
+| Zone | Risk | Current protection | Owner | Status | Gaps |
+| --- | --- | --- | --- | --- | --- |
+| IP and usage rights | Public visibility may be mistaken for unrestricted license, commercial permission, or permission to create competing derivative systems. | `IP_NOTICE.md` and `docs/governance/IP_NOTICE.md` define restricted rights, kernel protection, operational method restrictions, scenario/documentation use limits, trademark notice, and enforcement language. | HUB_Optimus Governance / `@Voxterrae` | active | Keep wording aligned between root and governance IP notices. Legal enforceability and external misuse handling remain outside repo automation. |
+| Kernel and governance docs | Governance drift, translation drift, or unauthorized changes could weaken the constitutional core. | `docs/governance/` is covered by `.github/CODEOWNERS`; translation drift is addressed by `docs/governance/TRANSLATION_POLICY.md`; source-of-truth conflicts defer to `docs/context/STATUS.md`. | `@Voxterrae` | active | CODEOWNERS review depends on GitHub branch/ruleset enforcement. Translation parity checks are policy-based unless a separate issue adds automation. |
+| Canonical v1 language content | Canonical content could diverge from parity translations or be edited without appropriate scrutiny. | `.github/CODEOWNERS` assigns `v1_core/languages/`, `v1_core/languages/es/`, and `v1_core/languages/en/` to `@Voxterrae`; `docs/context/STATUS.md` states ES is canonical for v1 and EN is the parity target. | `@Voxterrae` | active | Automated parity verification is not established here. Future canonical-language changes require separate governed scope. |
+| CODEOWNERS review map | Protected files could change without the expected maintainer review if CODEOWNERS is incomplete or not enforced. | `.github/CODEOWNERS` maps kernel language content, governance docs, `.github/`, root configs, simulator files, `hub_optimus/`, and benchmarks to `@Voxterrae`. | `@Voxterrae` | active | GitHub must enforce CODEOWNERS through branch protection or rulesets; that Settings state is pending verification in #1590. |
+| CI baseline | Regressions, encoding problems, or test failures could enter `main`. | `.github/workflows/ci.yml` runs the mojibake guard, narrative consistency check, `pytest`, and non-blocking benchmarks on pull requests and pushes to `main`. | `@Voxterrae` | active | CI only protects merges if required checks are configured in GitHub Settings. Required-check status is pending verification in #1590. |
+| Kernel guard | Protected kernel/governance changes could be merged without explicit acknowledgement. | `.github/workflows/kernel-guard.yml` runs `tools/kernel_guard.py` on pull requests and requires the `allow-kernel-change` label to permit kernel changes. | `@Voxterrae` | active | Guard strength depends on the maintained protected-path list and required-check enforcement. Required status is pending verification in #1590. |
+| PR risk classification | High-risk changes could be reviewed as ordinary documentation or tooling edits. | `.github/workflows/pr-safety-check.yml` classifies protected-path changes, including `docs/governance/`, `.github/workflows/`, `.github/CODEOWNERS`, runtime files, schema, expected benchmarks, and v1 language content. | `@Voxterrae` | active | The workflow warns and summarizes risk; it does not itself block merge unless configured as a required check. |
+| External contributor quarantine | First-time fork PRs could run untrusted code or bypass maintainer attention. | `.github/workflows/pr-quarantine.yml` is metadata-only, avoids checkout/execution, labels first-time external fork PRs, and comments that maintainer review is required. | `@Voxterrae` | active | Applies only to first-time external fork PRs. Label existence and required-review policy still depend on GitHub configuration. |
+| Branch protection and rulesets | Direct pushes, force pushes, missing required checks, or missing review requirements could bypass repo policy. | Expected protection belongs in GitHub Settings, not in repository files. Local repo evidence cannot fully verify rulesets or branch protection. | `@Voxterrae` | pending | Verify branch protection, required checks, CODEOWNERS enforcement, no force pushes, and deletion restrictions in #1590. Until then, treat Settings state as pending/unknown. |
+| AI handoff and chat decisions | Unsynced chat decisions could be treated as governance, roadmap, or implementation authority. | `docs/context/AI_HANDOFF.md` states GitHub is the source of truth and chat context only matters when reflected in issues, PRs, or repo docs. | `@Voxterrae` | active | Detailed AI access levels are not defined here; that belongs to #1584 and #1585. |
+
+## Current Gaps To Track
+- Verify GitHub branch protection and rulesets in #1590.
+- Verify required checks for CI, kernel guard, and risk classification in #1590.
+- Confirm CODEOWNERS enforcement through GitHub Settings in #1590.
+- Keep external AI roles out of scope for this matrix; define them separately in #1584 and #1585.
+- Keep architecture terminology and capability status out of scope for this matrix; define them separately in #1586, #1587, and #1589.

--- a/docs/es/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
+++ b/docs/es/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
@@ -1,0 +1,42 @@
+# GitHub Settings Protection Checklist
+
+## Purpose
+Document expected repository protection settings and mark observed state as
+`verified`, `pending`, or `unknown`.
+
+This document does not change GitHub Settings, workflows, CODEOWNERS, branch
+rules, automation, or runtime behavior.
+
+## Verification Context
+- Repository: `Voxterrae/HUB_Optimus`
+- Default branch: `main`
+- Verification date: 2026-05-15
+- Evidence source: GitHub CLI/API read-only queries and repository files
+
+## Status Key
+- `verified`: observed evidence matches the expected protection.
+- `pending`: expected protection is not fully observed, or needs explicit maintainer confirmation.
+- `unknown`: current state cannot be verified from available evidence.
+
+## Checklist
+
+| Setting | Expected state | Observed state | Evidence | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Branch protection for `main` | Enabled | `main` reports `protected: true` through GitHub branch metadata. Legacy branch-protection endpoint returns `404 Branch not protected`, so protection appears ruleset-based rather than legacy branch protection. | `gh api repos/Voxterrae/HUB_Optimus/branches/main`; `gh api repos/Voxterrae/HUB_Optimus/branches/main/protection` | verified | Track this as ruleset-based protection, not legacy branch protection. |
+| Active branch rulesets | At least one active ruleset applies to `main` | Two active branch rulesets apply to `main`: `Protect main (restricted)` and `protect-main`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Duplicate or overlapping rulesets should be reviewed before future settings changes. |
+| Required PR before merge | Enabled | Active `pull_request` rules are present for `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Current rules show `required_approving_review_count: 0`; review strength is tracked separately below. |
+| Required status checks | CI, Kernel Guard, Link Check, and PR Safety should be required before merge | Workflows exist and run on PRs, but no required status-check rule was observed through legacy branch-protection endpoints or active branch rules. | `.github/workflows/ci.yml`; `.github/workflows/kernel-guard.yml`; `.github/workflows/link-check.yml`; `.github/workflows/pr-safety-check.yml`; branch protection status-check endpoint returned `404 Branch not protected` | pending | Decide whether required checks should be enforced through rulesets in a separate settings-change issue. |
+| CODEOWNERS review | Enabled for protected paths | `.github/CODEOWNERS` maps protected paths to `@Voxterrae`, but active pull-request rules report `require_code_owner_review: false`. | `.github/CODEOWNERS`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | CODEOWNERS exists, but enforcement through GitHub Settings is not currently observed. |
+| Force pushes | Disabled | Active `non_fast_forward` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This blocks non-fast-forward updates, including force pushes. |
+| Branch deletion | Restricted or disabled | Active `deletion` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This protects `main` from branch deletion through rulesets. |
+| Required signed commits | Enabled if required by repository policy | Active `required_signatures` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Linear history | Enabled if required by repository policy | Active `required_linear_history` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Admin or role bypass | Restricted or explicitly documented | One active ruleset has no bypass actors. Another has a `RepositoryRole` bypass actor with `bypass_mode: always`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets/11637867`; `gh api repos/Voxterrae/HUB_Optimus/rulesets/11665521` | pending | Confirm whether the role bypass is intentional and document who may use it. |
+| Merge method restrictions | Expected merge methods should be explicit | One ruleset allows `merge`, `squash`, and `rebase`; the other allows `squash` only. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | Overlapping rulesets make the effective merge-method policy harder to audit. |
+
+## Follow-up Items
+- Decide whether required status checks should be enforced in GitHub rulesets.
+- Decide whether CODEOWNERS review should be enforced in GitHub rulesets.
+- Confirm and document the intended admin or repository-role bypass policy.
+- Review overlapping branch rulesets before making any future settings changes.
+- Keep any settings mutation out of this PR; open a separate issue for configuration changes.

--- a/docs/es/governance/SYSTEM_PROTECTION_MATRIX.md
+++ b/docs/es/governance/SYSTEM_PROTECTION_MATRIX.md
@@ -1,0 +1,36 @@
+# HUB_Optimus - System Protection Matrix
+
+## Purpose
+This matrix records the current protection surface for HUB_Optimus and the
+visible gaps that still need verification or follow-up.
+
+It is descriptive only. It does not add enforcement, change GitHub settings, or
+redefine repository architecture.
+
+## Status Key
+- `active`: protection exists in the repository or documented policy.
+- `partial`: protection exists but does not cover the full risk.
+- `pending`: expected protection or verification is not complete.
+- `unknown`: current state cannot be verified from repository files alone.
+
+## Matrix
+
+| Zone | Risk | Current protection | Owner | Status | Gaps |
+| --- | --- | --- | --- | --- | --- |
+| IP and usage rights | Public visibility may be mistaken for unrestricted license, commercial permission, or permission to create competing derivative systems. | `IP_NOTICE.md` and `docs/governance/IP_NOTICE.md` define restricted rights, kernel protection, operational method restrictions, scenario/documentation use limits, trademark notice, and enforcement language. | HUB_Optimus Governance / `@Voxterrae` | active | Keep wording aligned between root and governance IP notices. Legal enforceability and external misuse handling remain outside repo automation. |
+| Kernel and governance docs | Governance drift, translation drift, or unauthorized changes could weaken the constitutional core. | `docs/governance/` is covered by `.github/CODEOWNERS`; translation drift is addressed by `docs/governance/TRANSLATION_POLICY.md`; source-of-truth conflicts defer to `docs/context/STATUS.md`. | `@Voxterrae` | active | CODEOWNERS review depends on GitHub branch/ruleset enforcement. Translation parity checks are policy-based unless a separate issue adds automation. |
+| Canonical v1 language content | Canonical content could diverge from parity translations or be edited without appropriate scrutiny. | `.github/CODEOWNERS` assigns `v1_core/languages/`, `v1_core/languages/es/`, and `v1_core/languages/en/` to `@Voxterrae`; `docs/context/STATUS.md` states ES is canonical for v1 and EN is the parity target. | `@Voxterrae` | active | Automated parity verification is not established here. Future canonical-language changes require separate governed scope. |
+| CODEOWNERS review map | Protected files could change without the expected maintainer review if CODEOWNERS is incomplete or not enforced. | `.github/CODEOWNERS` maps kernel language content, governance docs, `.github/`, root configs, simulator files, `hub_optimus/`, and benchmarks to `@Voxterrae`. | `@Voxterrae` | active | GitHub must enforce CODEOWNERS through branch protection or rulesets; that Settings state is pending verification in #1590. |
+| CI baseline | Regressions, encoding problems, or test failures could enter `main`. | `.github/workflows/ci.yml` runs the mojibake guard, narrative consistency check, `pytest`, and non-blocking benchmarks on pull requests and pushes to `main`. | `@Voxterrae` | active | CI only protects merges if required checks are configured in GitHub Settings. Required-check status is pending verification in #1590. |
+| Kernel guard | Protected kernel/governance changes could be merged without explicit acknowledgement. | `.github/workflows/kernel-guard.yml` runs `tools/kernel_guard.py` on pull requests and requires the `allow-kernel-change` label to permit kernel changes. | `@Voxterrae` | active | Guard strength depends on the maintained protected-path list and required-check enforcement. Required status is pending verification in #1590. |
+| PR risk classification | High-risk changes could be reviewed as ordinary documentation or tooling edits. | `.github/workflows/pr-safety-check.yml` classifies protected-path changes, including `docs/governance/`, `.github/workflows/`, `.github/CODEOWNERS`, runtime files, schema, expected benchmarks, and v1 language content. | `@Voxterrae` | active | The workflow warns and summarizes risk; it does not itself block merge unless configured as a required check. |
+| External contributor quarantine | First-time fork PRs could run untrusted code or bypass maintainer attention. | `.github/workflows/pr-quarantine.yml` is metadata-only, avoids checkout/execution, labels first-time external fork PRs, and comments that maintainer review is required. | `@Voxterrae` | active | Applies only to first-time external fork PRs. Label existence and required-review policy still depend on GitHub configuration. |
+| Branch protection and rulesets | Direct pushes, force pushes, missing required checks, or missing review requirements could bypass repo policy. | Expected protection belongs in GitHub Settings, not in repository files. Local repo evidence cannot fully verify rulesets or branch protection. | `@Voxterrae` | pending | Verify branch protection, required checks, CODEOWNERS enforcement, no force pushes, and deletion restrictions in #1590. Until then, treat Settings state as pending/unknown. |
+| AI handoff and chat decisions | Unsynced chat decisions could be treated as governance, roadmap, or implementation authority. | `docs/context/AI_HANDOFF.md` states GitHub is the source of truth and chat context only matters when reflected in issues, PRs, or repo docs. | `@Voxterrae` | active | Detailed AI access levels are not defined here; that belongs to #1584 and #1585. |
+
+## Current Gaps To Track
+- Verify GitHub branch protection and rulesets in #1590.
+- Verify required checks for CI, kernel guard, and risk classification in #1590.
+- Confirm CODEOWNERS enforcement through GitHub Settings in #1590.
+- Keep external AI roles out of scope for this matrix; define them separately in #1584 and #1585.
+- Keep architecture terminology and capability status out of scope for this matrix; define them separately in #1586, #1587, and #1589.

--- a/docs/fr/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
+++ b/docs/fr/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
@@ -1,0 +1,42 @@
+# GitHub Settings Protection Checklist
+
+## Purpose
+Document expected repository protection settings and mark observed state as
+`verified`, `pending`, or `unknown`.
+
+This document does not change GitHub Settings, workflows, CODEOWNERS, branch
+rules, automation, or runtime behavior.
+
+## Verification Context
+- Repository: `Voxterrae/HUB_Optimus`
+- Default branch: `main`
+- Verification date: 2026-05-15
+- Evidence source: GitHub CLI/API read-only queries and repository files
+
+## Status Key
+- `verified`: observed evidence matches the expected protection.
+- `pending`: expected protection is not fully observed, or needs explicit maintainer confirmation.
+- `unknown`: current state cannot be verified from available evidence.
+
+## Checklist
+
+| Setting | Expected state | Observed state | Evidence | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Branch protection for `main` | Enabled | `main` reports `protected: true` through GitHub branch metadata. Legacy branch-protection endpoint returns `404 Branch not protected`, so protection appears ruleset-based rather than legacy branch protection. | `gh api repos/Voxterrae/HUB_Optimus/branches/main`; `gh api repos/Voxterrae/HUB_Optimus/branches/main/protection` | verified | Track this as ruleset-based protection, not legacy branch protection. |
+| Active branch rulesets | At least one active ruleset applies to `main` | Two active branch rulesets apply to `main`: `Protect main (restricted)` and `protect-main`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Duplicate or overlapping rulesets should be reviewed before future settings changes. |
+| Required PR before merge | Enabled | Active `pull_request` rules are present for `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Current rules show `required_approving_review_count: 0`; review strength is tracked separately below. |
+| Required status checks | CI, Kernel Guard, Link Check, and PR Safety should be required before merge | Workflows exist and run on PRs, but no required status-check rule was observed through legacy branch-protection endpoints or active branch rules. | `.github/workflows/ci.yml`; `.github/workflows/kernel-guard.yml`; `.github/workflows/link-check.yml`; `.github/workflows/pr-safety-check.yml`; branch protection status-check endpoint returned `404 Branch not protected` | pending | Decide whether required checks should be enforced through rulesets in a separate settings-change issue. |
+| CODEOWNERS review | Enabled for protected paths | `.github/CODEOWNERS` maps protected paths to `@Voxterrae`, but active pull-request rules report `require_code_owner_review: false`. | `.github/CODEOWNERS`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | CODEOWNERS exists, but enforcement through GitHub Settings is not currently observed. |
+| Force pushes | Disabled | Active `non_fast_forward` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This blocks non-fast-forward updates, including force pushes. |
+| Branch deletion | Restricted or disabled | Active `deletion` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This protects `main` from branch deletion through rulesets. |
+| Required signed commits | Enabled if required by repository policy | Active `required_signatures` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Linear history | Enabled if required by repository policy | Active `required_linear_history` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Admin or role bypass | Restricted or explicitly documented | One active ruleset has no bypass actors. Another has a `RepositoryRole` bypass actor with `bypass_mode: always`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets/11637867`; `gh api repos/Voxterrae/HUB_Optimus/rulesets/11665521` | pending | Confirm whether the role bypass is intentional and document who may use it. |
+| Merge method restrictions | Expected merge methods should be explicit | One ruleset allows `merge`, `squash`, and `rebase`; the other allows `squash` only. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | Overlapping rulesets make the effective merge-method policy harder to audit. |
+
+## Follow-up Items
+- Decide whether required status checks should be enforced in GitHub rulesets.
+- Decide whether CODEOWNERS review should be enforced in GitHub rulesets.
+- Confirm and document the intended admin or repository-role bypass policy.
+- Review overlapping branch rulesets before making any future settings changes.
+- Keep any settings mutation out of this PR; open a separate issue for configuration changes.

--- a/docs/fr/governance/SYSTEM_PROTECTION_MATRIX.md
+++ b/docs/fr/governance/SYSTEM_PROTECTION_MATRIX.md
@@ -1,0 +1,36 @@
+# HUB_Optimus - System Protection Matrix
+
+## Purpose
+This matrix records the current protection surface for HUB_Optimus and the
+visible gaps that still need verification or follow-up.
+
+It is descriptive only. It does not add enforcement, change GitHub settings, or
+redefine repository architecture.
+
+## Status Key
+- `active`: protection exists in the repository or documented policy.
+- `partial`: protection exists but does not cover the full risk.
+- `pending`: expected protection or verification is not complete.
+- `unknown`: current state cannot be verified from repository files alone.
+
+## Matrix
+
+| Zone | Risk | Current protection | Owner | Status | Gaps |
+| --- | --- | --- | --- | --- | --- |
+| IP and usage rights | Public visibility may be mistaken for unrestricted license, commercial permission, or permission to create competing derivative systems. | `IP_NOTICE.md` and `docs/governance/IP_NOTICE.md` define restricted rights, kernel protection, operational method restrictions, scenario/documentation use limits, trademark notice, and enforcement language. | HUB_Optimus Governance / `@Voxterrae` | active | Keep wording aligned between root and governance IP notices. Legal enforceability and external misuse handling remain outside repo automation. |
+| Kernel and governance docs | Governance drift, translation drift, or unauthorized changes could weaken the constitutional core. | `docs/governance/` is covered by `.github/CODEOWNERS`; translation drift is addressed by `docs/governance/TRANSLATION_POLICY.md`; source-of-truth conflicts defer to `docs/context/STATUS.md`. | `@Voxterrae` | active | CODEOWNERS review depends on GitHub branch/ruleset enforcement. Translation parity checks are policy-based unless a separate issue adds automation. |
+| Canonical v1 language content | Canonical content could diverge from parity translations or be edited without appropriate scrutiny. | `.github/CODEOWNERS` assigns `v1_core/languages/`, `v1_core/languages/es/`, and `v1_core/languages/en/` to `@Voxterrae`; `docs/context/STATUS.md` states ES is canonical for v1 and EN is the parity target. | `@Voxterrae` | active | Automated parity verification is not established here. Future canonical-language changes require separate governed scope. |
+| CODEOWNERS review map | Protected files could change without the expected maintainer review if CODEOWNERS is incomplete or not enforced. | `.github/CODEOWNERS` maps kernel language content, governance docs, `.github/`, root configs, simulator files, `hub_optimus/`, and benchmarks to `@Voxterrae`. | `@Voxterrae` | active | GitHub must enforce CODEOWNERS through branch protection or rulesets; that Settings state is pending verification in #1590. |
+| CI baseline | Regressions, encoding problems, or test failures could enter `main`. | `.github/workflows/ci.yml` runs the mojibake guard, narrative consistency check, `pytest`, and non-blocking benchmarks on pull requests and pushes to `main`. | `@Voxterrae` | active | CI only protects merges if required checks are configured in GitHub Settings. Required-check status is pending verification in #1590. |
+| Kernel guard | Protected kernel/governance changes could be merged without explicit acknowledgement. | `.github/workflows/kernel-guard.yml` runs `tools/kernel_guard.py` on pull requests and requires the `allow-kernel-change` label to permit kernel changes. | `@Voxterrae` | active | Guard strength depends on the maintained protected-path list and required-check enforcement. Required status is pending verification in #1590. |
+| PR risk classification | High-risk changes could be reviewed as ordinary documentation or tooling edits. | `.github/workflows/pr-safety-check.yml` classifies protected-path changes, including `docs/governance/`, `.github/workflows/`, `.github/CODEOWNERS`, runtime files, schema, expected benchmarks, and v1 language content. | `@Voxterrae` | active | The workflow warns and summarizes risk; it does not itself block merge unless configured as a required check. |
+| External contributor quarantine | First-time fork PRs could run untrusted code or bypass maintainer attention. | `.github/workflows/pr-quarantine.yml` is metadata-only, avoids checkout/execution, labels first-time external fork PRs, and comments that maintainer review is required. | `@Voxterrae` | active | Applies only to first-time external fork PRs. Label existence and required-review policy still depend on GitHub configuration. |
+| Branch protection and rulesets | Direct pushes, force pushes, missing required checks, or missing review requirements could bypass repo policy. | Expected protection belongs in GitHub Settings, not in repository files. Local repo evidence cannot fully verify rulesets or branch protection. | `@Voxterrae` | pending | Verify branch protection, required checks, CODEOWNERS enforcement, no force pushes, and deletion restrictions in #1590. Until then, treat Settings state as pending/unknown. |
+| AI handoff and chat decisions | Unsynced chat decisions could be treated as governance, roadmap, or implementation authority. | `docs/context/AI_HANDOFF.md` states GitHub is the source of truth and chat context only matters when reflected in issues, PRs, or repo docs. | `@Voxterrae` | active | Detailed AI access levels are not defined here; that belongs to #1584 and #1585. |
+
+## Current Gaps To Track
+- Verify GitHub branch protection and rulesets in #1590.
+- Verify required checks for CI, kernel guard, and risk classification in #1590.
+- Confirm CODEOWNERS enforcement through GitHub Settings in #1590.
+- Keep external AI roles out of scope for this matrix; define them separately in #1584 and #1585.
+- Keep architecture terminology and capability status out of scope for this matrix; define them separately in #1586, #1587, and #1589.

--- a/docs/ru/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
+++ b/docs/ru/governance/GITHUB_SETTINGS_PROTECTION_CHECKLIST.md
@@ -1,0 +1,42 @@
+# GitHub Settings Protection Checklist
+
+## Purpose
+Document expected repository protection settings and mark observed state as
+`verified`, `pending`, or `unknown`.
+
+This document does not change GitHub Settings, workflows, CODEOWNERS, branch
+rules, automation, or runtime behavior.
+
+## Verification Context
+- Repository: `Voxterrae/HUB_Optimus`
+- Default branch: `main`
+- Verification date: 2026-05-15
+- Evidence source: GitHub CLI/API read-only queries and repository files
+
+## Status Key
+- `verified`: observed evidence matches the expected protection.
+- `pending`: expected protection is not fully observed, or needs explicit maintainer confirmation.
+- `unknown`: current state cannot be verified from available evidence.
+
+## Checklist
+
+| Setting | Expected state | Observed state | Evidence | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Branch protection for `main` | Enabled | `main` reports `protected: true` through GitHub branch metadata. Legacy branch-protection endpoint returns `404 Branch not protected`, so protection appears ruleset-based rather than legacy branch protection. | `gh api repos/Voxterrae/HUB_Optimus/branches/main`; `gh api repos/Voxterrae/HUB_Optimus/branches/main/protection` | verified | Track this as ruleset-based protection, not legacy branch protection. |
+| Active branch rulesets | At least one active ruleset applies to `main` | Two active branch rulesets apply to `main`: `Protect main (restricted)` and `protect-main`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Duplicate or overlapping rulesets should be reviewed before future settings changes. |
+| Required PR before merge | Enabled | Active `pull_request` rules are present for `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Current rules show `required_approving_review_count: 0`; review strength is tracked separately below. |
+| Required status checks | CI, Kernel Guard, Link Check, and PR Safety should be required before merge | Workflows exist and run on PRs, but no required status-check rule was observed through legacy branch-protection endpoints or active branch rules. | `.github/workflows/ci.yml`; `.github/workflows/kernel-guard.yml`; `.github/workflows/link-check.yml`; `.github/workflows/pr-safety-check.yml`; branch protection status-check endpoint returned `404 Branch not protected` | pending | Decide whether required checks should be enforced through rulesets in a separate settings-change issue. |
+| CODEOWNERS review | Enabled for protected paths | `.github/CODEOWNERS` maps protected paths to `@Voxterrae`, but active pull-request rules report `require_code_owner_review: false`. | `.github/CODEOWNERS`; `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | CODEOWNERS exists, but enforcement through GitHub Settings is not currently observed. |
+| Force pushes | Disabled | Active `non_fast_forward` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This blocks non-fast-forward updates, including force pushes. |
+| Branch deletion | Restricted or disabled | Active `deletion` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | This protects `main` from branch deletion through rulesets. |
+| Required signed commits | Enabled if required by repository policy | Active `required_signatures` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Linear history | Enabled if required by repository policy | Active `required_linear_history` rules apply to `main`. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | verified | Present as an active ruleset protection. |
+| Admin or role bypass | Restricted or explicitly documented | One active ruleset has no bypass actors. Another has a `RepositoryRole` bypass actor with `bypass_mode: always`. | `gh api repos/Voxterrae/HUB_Optimus/rulesets/11637867`; `gh api repos/Voxterrae/HUB_Optimus/rulesets/11665521` | pending | Confirm whether the role bypass is intentional and document who may use it. |
+| Merge method restrictions | Expected merge methods should be explicit | One ruleset allows `merge`, `squash`, and `rebase`; the other allows `squash` only. | `gh api repos/Voxterrae/HUB_Optimus/rules/branches/main` | pending | Overlapping rulesets make the effective merge-method policy harder to audit. |
+
+## Follow-up Items
+- Decide whether required status checks should be enforced in GitHub rulesets.
+- Decide whether CODEOWNERS review should be enforced in GitHub rulesets.
+- Confirm and document the intended admin or repository-role bypass policy.
+- Review overlapping branch rulesets before making any future settings changes.
+- Keep any settings mutation out of this PR; open a separate issue for configuration changes.

--- a/docs/ru/governance/SYSTEM_PROTECTION_MATRIX.md
+++ b/docs/ru/governance/SYSTEM_PROTECTION_MATRIX.md
@@ -1,0 +1,36 @@
+# HUB_Optimus - System Protection Matrix
+
+## Purpose
+This matrix records the current protection surface for HUB_Optimus and the
+visible gaps that still need verification or follow-up.
+
+It is descriptive only. It does not add enforcement, change GitHub settings, or
+redefine repository architecture.
+
+## Status Key
+- `active`: protection exists in the repository or documented policy.
+- `partial`: protection exists but does not cover the full risk.
+- `pending`: expected protection or verification is not complete.
+- `unknown`: current state cannot be verified from repository files alone.
+
+## Matrix
+
+| Zone | Risk | Current protection | Owner | Status | Gaps |
+| --- | --- | --- | --- | --- | --- |
+| IP and usage rights | Public visibility may be mistaken for unrestricted license, commercial permission, or permission to create competing derivative systems. | `IP_NOTICE.md` and `docs/governance/IP_NOTICE.md` define restricted rights, kernel protection, operational method restrictions, scenario/documentation use limits, trademark notice, and enforcement language. | HUB_Optimus Governance / `@Voxterrae` | active | Keep wording aligned between root and governance IP notices. Legal enforceability and external misuse handling remain outside repo automation. |
+| Kernel and governance docs | Governance drift, translation drift, or unauthorized changes could weaken the constitutional core. | `docs/governance/` is covered by `.github/CODEOWNERS`; translation drift is addressed by `docs/governance/TRANSLATION_POLICY.md`; source-of-truth conflicts defer to `docs/context/STATUS.md`. | `@Voxterrae` | active | CODEOWNERS review depends on GitHub branch/ruleset enforcement. Translation parity checks are policy-based unless a separate issue adds automation. |
+| Canonical v1 language content | Canonical content could diverge from parity translations or be edited without appropriate scrutiny. | `.github/CODEOWNERS` assigns `v1_core/languages/`, `v1_core/languages/es/`, and `v1_core/languages/en/` to `@Voxterrae`; `docs/context/STATUS.md` states ES is canonical for v1 and EN is the parity target. | `@Voxterrae` | active | Automated parity verification is not established here. Future canonical-language changes require separate governed scope. |
+| CODEOWNERS review map | Protected files could change without the expected maintainer review if CODEOWNERS is incomplete or not enforced. | `.github/CODEOWNERS` maps kernel language content, governance docs, `.github/`, root configs, simulator files, `hub_optimus/`, and benchmarks to `@Voxterrae`. | `@Voxterrae` | active | GitHub must enforce CODEOWNERS through branch protection or rulesets; that Settings state is pending verification in #1590. |
+| CI baseline | Regressions, encoding problems, or test failures could enter `main`. | `.github/workflows/ci.yml` runs the mojibake guard, narrative consistency check, `pytest`, and non-blocking benchmarks on pull requests and pushes to `main`. | `@Voxterrae` | active | CI only protects merges if required checks are configured in GitHub Settings. Required-check status is pending verification in #1590. |
+| Kernel guard | Protected kernel/governance changes could be merged without explicit acknowledgement. | `.github/workflows/kernel-guard.yml` runs `tools/kernel_guard.py` on pull requests and requires the `allow-kernel-change` label to permit kernel changes. | `@Voxterrae` | active | Guard strength depends on the maintained protected-path list and required-check enforcement. Required status is pending verification in #1590. |
+| PR risk classification | High-risk changes could be reviewed as ordinary documentation or tooling edits. | `.github/workflows/pr-safety-check.yml` classifies protected-path changes, including `docs/governance/`, `.github/workflows/`, `.github/CODEOWNERS`, runtime files, schema, expected benchmarks, and v1 language content. | `@Voxterrae` | active | The workflow warns and summarizes risk; it does not itself block merge unless configured as a required check. |
+| External contributor quarantine | First-time fork PRs could run untrusted code or bypass maintainer attention. | `.github/workflows/pr-quarantine.yml` is metadata-only, avoids checkout/execution, labels first-time external fork PRs, and comments that maintainer review is required. | `@Voxterrae` | active | Applies only to first-time external fork PRs. Label existence and required-review policy still depend on GitHub configuration. |
+| Branch protection and rulesets | Direct pushes, force pushes, missing required checks, or missing review requirements could bypass repo policy. | Expected protection belongs in GitHub Settings, not in repository files. Local repo evidence cannot fully verify rulesets or branch protection. | `@Voxterrae` | pending | Verify branch protection, required checks, CODEOWNERS enforcement, no force pushes, and deletion restrictions in #1590. Until then, treat Settings state as pending/unknown. |
+| AI handoff and chat decisions | Unsynced chat decisions could be treated as governance, roadmap, or implementation authority. | `docs/context/AI_HANDOFF.md` states GitHub is the source of truth and chat context only matters when reflected in issues, PRs, or repo docs. | `@Voxterrae` | active | Detailed AI access levels are not defined here; that belongs to #1584 and #1585. |
+
+## Current Gaps To Track
+- Verify GitHub branch protection and rulesets in #1590.
+- Verify required checks for CI, kernel guard, and risk classification in #1590.
+- Confirm CODEOWNERS enforcement through GitHub Settings in #1590.
+- Keep external AI roles out of scope for this matrix; define them separately in #1584 and #1585.
+- Keep architecture terminology and capability status out of scope for this matrix; define them separately in #1586, #1587, and #1589.


### PR DESCRIPTION
Restores missing governance mirror files across de, es, fr, ca, and ru so tools/check_mirror.py passes again.