### PR TITLE
engine: add CLI output file option

### DIFF
--- a/docs/architecture/semantic_engine_cli.md
+++ b/docs/architecture/semantic_engine_cli.md
@@ -1,0 +1,69 @@
+# Semantic Engine CLI
+
+## Status
+
+Minimal CLI usage document for the HUB_Optimus Semantic Engine.
+
+The CLI is the first execution surface for Semantic Engine contracts. It is intentionally small and does not implement API, HERMES, AWS, S3, vector search, evaluators, normalizers, scoring, or model-based judging.
+
+## Command
+
+```bash
+python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json
+```
+
+By default, the command writes contractual JSON to stdout.
+
+## Output file
+
+Use `--output` to write the same contractual JSON to a local file:
+
+```bash
+python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json \
+  --output outputs/semantic_engine/analysis_result.json
+```
+
+When `--output` is used:
+
+- stdout remains empty on success;
+- the JSON result is written as UTF-8;
+- parent directories are created if needed;
+- stderr remains reserved for controlled errors.
+
+## Operating contract
+
+```text
+stdout = contractual JSON only when no --output path is provided
+stderr = controlled human-readable errors
+exit 0 = success
+exit 1 = expected input/output error
+```
+
+## Current input contract
+
+The minimal case JSON must be an object with non-empty string fields:
+
+```json
+{
+  "case_id": "case-minimal-001",
+  "core_version_ref": "main",
+  "input_summary": "Minimal CLI smoke case for Semantic Engine contracts."
+}
+```
+
+## Out of scope
+
+- API
+- HERMES PWA
+- AWS runtime
+- S3 persistence
+- Vector DB
+- Evaluators
+- Normalizers beyond required field validation
+- Scoring
+- LLM/SLM judge
+- Existing scenario runtime changes
+
+## Next gate
+
+After local output writing is stable, the next persistence step can define archive layout and S3 handoff rules. S3 should not be added until local output behavior is stable and reviewable.

--- a/semantic_engine/cli/__main__.py
+++ b/semantic_engine/cli/__main__.py
@@ -64,6 +64,22 @@ def analyze_case(input_path: Path) -> dict[str, Any]:
     return build_draft_result(load_case(input_path)).to_dict()
 
 
+def serialize_payload(payload: dict[str, Any]) -> str:
+    """Return stable JSON for CLI stdout or file output."""
+
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def write_output(path: Path, content: str) -> None:
+    """Write CLI output to a UTF-8 file, creating parent directories."""
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise ControlledCliError(f"cannot write output file {path}: {exc}") from exc
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m semantic_engine.cli",
@@ -76,6 +92,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Build a draft AnalysisResult from a minimal case JSON file.",
     )
     analyze.add_argument("input", help="Path to a minimal case JSON file.")
+    analyze.add_argument(
+        "--output",
+        help="Optional path for writing the contractual JSON result instead of stdout.",
+    )
 
     return parser
 
@@ -93,7 +113,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"semantic_engine.cli: error: {exc}", file=sys.stderr)
         return 1
 
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    content = serialize_payload(payload)
+
+    if args.output:
+        try:
+            write_output(Path(args.output), content)
+        except ControlledCliError as exc:
+            print(f"semantic_engine.cli: error: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print(content, end="")
+
     return 0
 
 

--- a/tests/semantic_engine/test_cli_smoke.py
+++ b/tests/semantic_engine/test_cli_smoke.py
@@ -38,6 +38,28 @@ def test_cli_analyze_happy_path_outputs_contractual_json():
     assert payload["audit_log"] == []
 
 
+def test_cli_output_file_writes_contractual_json_and_keeps_stdout_empty(tmp_path):
+    output_path = tmp_path / "outputs" / "analysis_result.json"
+
+    result = run_cli(
+        "analyze",
+        "examples/semantic_engine/case_minimal.json",
+        "--output",
+        str(output_path),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert output_path.exists()
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["case_id"] == "case-minimal-001"
+    assert payload["status"] == "draft"
+    assert payload["claims"] == []
+    assert output_path.read_text(encoding="utf-8").endswith("\n")
+
+
 def test_cli_missing_file_fails_cleanly():
     result = run_cli("analyze", "examples/semantic_engine/does_not_exist.json")
 


### PR DESCRIPTION
## Why

Hito 3 established the Semantic Engine CLI as the first stable execution surface. Hito 4A prepares local persistence before S3 by allowing the same contractual JSON output to be written to a local file.

This keeps the CLI communication contract stable:

- stdout contains contractual JSON only when no `--output` is used;
- stdout remains empty when `--output` is used;
- stderr remains reserved for controlled errors;
- S3 is still out of scope.

## What

- Add `--output` to `python -m semantic_engine.cli analyze`.
- Add stable `serialize_payload()` helper.
- Add `write_output()` helper that creates parent directories and writes UTF-8 JSON.
- Add tests for local output writing.
- Add minimal CLI usage documentation.

## Scope

Hito 4A: local CLI output writing only.

## Out of scope

- S3 persistence
- AWS runtime
- API
- HERMES PWA
- Vector DB
- Evaluators
- Normalizers beyond required field validation
- Scoring
- LLM/SLM judge
- Existing scenario runtime changes
- CI changes

## Validation

Recommended:

```bash
pytest tests/semantic_engine/test_cli_smoke.py tests/semantic_engine/test_minimal_contracts.py
git diff --check
python tools/check_mojibake.py semantic_engine tests examples docs
```

## Gate

This PR closes Hito 4A only after merge into `main`. After that, the next persistence hito can define archive layout and S3 handoff rules.