### PR TITLE
infra: add AWS dev runtime bootstrap

### DIFF
--- a/docs/architecture/aws_dev_runtime.md
+++ b/docs/architecture/aws_dev_runtime.md
@@ -1,0 +1,106 @@
+# AWS Dev Runtime
+
+## Status
+
+Development-runtime setup guide for running HUB_Optimus Semantic Engine CLI on an AWS EC2 instance.
+
+This is not production deployment. It does not implement HERMES, API, S3 persistence, vector search, workers, dashboards, or model-based judging.
+
+## Purpose
+
+The AWS Dev Runtime is the external execution container for the current Semantic Engine CLI.
+
+It exists to run the same contract-first command already validated locally:
+
+```bash
+python -m semantic_engine.cli analyze inputs/case.json --output outputs/analysis_result.json
+```
+
+AWS does not define semantic authority. GitHub remains the source of truth.
+
+## Recommended instance shape
+
+Start simple:
+
+```text
+OS: Ubuntu LTS
+CPU/RAM: development-sized EC2 instance
+Disk: enough for repo, inputs, outputs, logs, and future artifacts
+Access: SSH with key pair
+Inbound: SSH only at first
+```
+
+Do not expose HTTP ports until API or HERMES exist.
+
+## Runtime layout
+
+Recommended path:
+
+```text
+/opt/hub-optimus/
+  repo/
+  inputs/
+  outputs/
+  logs/
+  runs/
+```
+
+Meaning:
+
+- `repo/` contains the cloned `Voxterrae/HUB_Optimus` repository.
+- `inputs/` contains case input JSON files copied or generated for runtime tests.
+- `outputs/` contains CLI output JSON files.
+- `logs/` contains manual or scripted runtime logs.
+- `runs/` is reserved for the later archive-layout hito.
+
+## Bootstrap
+
+After provisioning the EC2 instance and connecting through SSH, run:
+
+```bash
+bash scripts/infra/bootstrap_aws_dev_runtime.sh
+```
+
+The script installs the minimum system packages, creates `/opt/hub-optimus`, clones the repo if missing, creates a virtual environment, installs pytest, and runs a CLI smoke test.
+
+## Smoke test
+
+Expected command:
+
+```bash
+cd /opt/hub-optimus/repo
+python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json \
+  --output /opt/hub-optimus/outputs/analysis_result.json
+```
+
+Expected result:
+
+- exit code `0`;
+- stdout empty because `--output` is used;
+- `/opt/hub-optimus/outputs/analysis_result.json` exists;
+- output JSON contains `case_id`, `core_version_ref`, `input_summary`, and draft decomposition fields.
+
+## Out of scope
+
+- HERMES PWA
+- API
+- S3 sync or bucket creation
+- AWS IAM automation
+- public HTTP exposure
+- reverse proxy
+- TLS
+- systemd services
+- workers or queues
+- vector DB
+- scoring
+- normalizers/evaluators beyond current CLI validation
+
+## Gate to next hito
+
+Move to S3/archive work only when:
+
+- AWS instance can run the CLI smoke command;
+- local output file is created successfully;
+- runtime folders exist;
+- no secrets are committed to the repo;
+- no public service is exposed unnecessarily.

--- a/docs/architecture/aws_dev_runtime.md
+++ b/docs/architecture/aws_dev_runtime.md
@@ -23,7 +23,7 @@ AWS does not define semantic authority. GitHub remains the source of truth.
 Start simple:
 
 ```text
-OS: Ubuntu LTS
+OS: Ubuntu LTS with Python >= 3.11 available
 CPU/RAM: development-sized EC2 instance
 Disk: enough for repo, inputs, outputs, logs, and future artifacts
 Access: SSH with key pair
@@ -58,10 +58,12 @@ Meaning:
 After provisioning the EC2 instance and connecting through SSH, run:
 
 ```bash
-bash scripts/infra/bootstrap_aws_dev_runtime.sh
+sudo bash scripts/infra/bootstrap_aws_dev_runtime.sh
 ```
 
-The script installs the minimum system packages, creates `/opt/hub-optimus`, clones the repo if missing, creates a virtual environment, installs pytest, and runs a CLI smoke test.
+The script installs the minimum system packages, verifies Python `>=3.11`, creates `/opt/hub-optimus`, clones the repo if missing, creates a virtual environment, installs dependencies from `requirements-dev.txt`, and runs a CLI smoke test.
+
+The script must be launched with `sudo` because it installs packages and prepares `/opt/hub-optimus`. After root-only setup is done, repository operations, Python dependency installation, and CLI execution run as the invoking non-root user.
 
 ## Smoke test
 

--- a/scripts/infra/bootstrap_aws_dev_runtime.sh
+++ b/scripts/infra/bootstrap_aws_dev_runtime.sh
@@ -6,6 +6,7 @@ REPO_URL="${REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
 REPO_DIR="${REPO_DIR:-${RUNTIME_ROOT}/repo}"
 VENV_DIR="${VENV_DIR:-${RUNTIME_ROOT}/venv}"
 OUTPUT_FILE="${OUTPUT_FILE:-${RUNTIME_ROOT}/outputs/analysis_result.json}"
+RUNTIME_USER="${SUDO_USER:-${USER}}"
 
 log() {
   printf '[aws-dev-runtime] %s\n' "$1"
@@ -18,8 +19,25 @@ require_command() {
   fi
 }
 
+run_as_runtime_user() {
+  sudo -u "${RUNTIME_USER}" -H bash -lc "$1"
+}
+
+require_python_version() {
+  python3 - <<'PY'
+import sys
+if sys.version_info < (3, 11):
+    raise SystemExit("Python >= 3.11 is required")
+PY
+}
+
 if [ "$(id -u)" -ne 0 ]; then
   log "run this bootstrap with sudo or as root"
+  exit 1
+fi
+
+if [ -z "${RUNTIME_USER}" ] || [ "${RUNTIME_USER}" = "root" ]; then
+  log "run with sudo from a non-root SSH user so repo code does not execute as root"
   exit 1
 fi
 
@@ -33,35 +51,33 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 require_command git
 require_command python3
+require_python_version
 
 log "creating runtime directories"
 mkdir -p "${RUNTIME_ROOT}/inputs" "${RUNTIME_ROOT}/outputs" "${RUNTIME_ROOT}/logs" "${RUNTIME_ROOT}/runs"
+chown -R "${RUNTIME_USER}:${RUNTIME_USER}" "${RUNTIME_ROOT}"
 
 if [ ! -d "${REPO_DIR}/.git" ]; then
   log "cloning repository into ${REPO_DIR}"
-  git clone "${REPO_URL}" "${REPO_DIR}"
+  run_as_runtime_user "git clone '${REPO_URL}' '${REPO_DIR}'"
 else
   log "repository already exists; fetching latest main"
-  git -C "${REPO_DIR}" fetch origin main
-  git -C "${REPO_DIR}" checkout main
-  git -C "${REPO_DIR}" pull --ff-only origin main
+  run_as_runtime_user "git -C '${REPO_DIR}' fetch origin main"
+  run_as_runtime_user "git -C '${REPO_DIR}' checkout main"
+  run_as_runtime_user "git -C '${REPO_DIR}' pull --ff-only origin main"
 fi
 
 log "creating Python virtual environment"
-python3 -m venv "${VENV_DIR}"
-# shellcheck disable=SC1091
-source "${VENV_DIR}/bin/activate"
+run_as_runtime_user "python3 -m venv '${VENV_DIR}'"
 
-log "installing runtime test dependency"
-python -m pip install --upgrade pip
-python -m pip install pytest
+log "installing repository development dependencies"
+run_as_runtime_user "source '${VENV_DIR}/bin/activate' && python -m pip install --upgrade pip && python -m pip install -r '${REPO_DIR}/requirements-dev.txt'"
 
 log "running CLI smoke test"
-cd "${REPO_DIR}"
-python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json --output "${OUTPUT_FILE}"
+run_as_runtime_user "cd '${REPO_DIR}' && source '${VENV_DIR}/bin/activate' && python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json --output '${OUTPUT_FILE}'"
 
 test -s "${OUTPUT_FILE}"
-python -m json.tool "${OUTPUT_FILE}" >/dev/null
+run_as_runtime_user "python3 -m json.tool '${OUTPUT_FILE}' >/dev/null"
 
 log "runtime ready"
 log "output written to ${OUTPUT_FILE}"

--- a/scripts/infra/bootstrap_aws_dev_runtime.sh
+++ b/scripts/infra/bootstrap_aws_dev_runtime.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNTIME_ROOT="${RUNTIME_ROOT:-/opt/hub-optimus}"
+REPO_URL="${REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
+REPO_DIR="${REPO_DIR:-${RUNTIME_ROOT}/repo}"
+VENV_DIR="${VENV_DIR:-${RUNTIME_ROOT}/venv}"
+OUTPUT_FILE="${OUTPUT_FILE:-${RUNTIME_ROOT}/outputs/analysis_result.json}"
+
+log() {
+  printf '[aws-dev-runtime] %s\n' "$1"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "missing required command: $1"
+    exit 1
+  fi
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+  log "run this bootstrap with sudo or as root"
+  exit 1
+fi
+
+log "installing system packages"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  git \
+  python3 \
+  python3-venv \
+  python3-pip
+
+require_command git
+require_command python3
+
+log "creating runtime directories"
+mkdir -p "${RUNTIME_ROOT}/inputs" "${RUNTIME_ROOT}/outputs" "${RUNTIME_ROOT}/logs" "${RUNTIME_ROOT}/runs"
+
+if [ ! -d "${REPO_DIR}/.git" ]; then
+  log "cloning repository into ${REPO_DIR}"
+  git clone "${REPO_URL}" "${REPO_DIR}"
+else
+  log "repository already exists; fetching latest main"
+  git -C "${REPO_DIR}" fetch origin main
+  git -C "${REPO_DIR}" checkout main
+  git -C "${REPO_DIR}" pull --ff-only origin main
+fi
+
+log "creating Python virtual environment"
+python3 -m venv "${VENV_DIR}"
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+
+log "installing runtime test dependency"
+python -m pip install --upgrade pip
+python -m pip install pytest
+
+log "running CLI smoke test"
+cd "${REPO_DIR}"
+python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json --output "${OUTPUT_FILE}"
+
+test -s "${OUTPUT_FILE}"
+python -m json.tool "${OUTPUT_FILE}" >/dev/null
+
+log "runtime ready"
+log "output written to ${OUTPUT_FILE}"


### PR DESCRIPTION
## Why

Hito 5 needs an external development runtime for running the already-merged Semantic Engine CLI on AWS.

This PR does not deploy HERMES, API, S3, workers, dashboards, vector search, or production services. It only defines a safe EC2/Ubuntu dev runtime and a bootstrap script to validate the current CLI command.

## What

Adds:

- `docs/architecture/aws_dev_runtime.md`
- `scripts/infra/bootstrap_aws_dev_runtime.sh`

The bootstrap script:

- installs minimal Ubuntu packages;
- creates `/opt/hub-optimus` runtime folders;
- clones or updates `Voxterrae/HUB_Optimus`;
- creates a Python virtual environment;
- installs `pytest`;
- runs the Semantic Engine CLI smoke command with `--output`;
- verifies the output JSON exists and parses.

## Scope

Hito 5: AWS Dev Runtime bootstrap only.

## Out of scope

- HERMES PWA
- API
- S3 sync or bucket creation
- IAM automation
- public HTTP exposure
- reverse proxy
- TLS
- systemd services
- workers or queues
- vector DB
- scoring
- normalizers/evaluators beyond current CLI validation

## Validation

Recommended:

```bash
git diff --check
python tools/check_mojibake.py docs scripts
```

Manual runtime validation on EC2:

```bash
sudo bash scripts/infra/bootstrap_aws_dev_runtime.sh
```

Expected smoke command inside the runtime:

```bash
cd /opt/hub-optimus/repo
python -m semantic_engine.cli analyze examples/semantic_engine/case_minimal.json \
  --output /opt/hub-optimus/outputs/analysis_result.json
```

## Gate

This PR closes Hito 5 only after merge into `main` and one manual EC2 smoke run confirms the CLI output file is created.