### PR TITLE
docs: add external JTAF contribution note

### DIFF
--- a/docs/rfc/judicial_transparency_audit_framework.md
+++ b/docs/rfc/judicial_transparency_audit_framework.md
@@ -290,6 +290,29 @@ Use conservative source tiers.
 
 Tiering is not verification.
 
+## External Contribution Notes
+
+External input may inform RFC wording only when it remains public-safe, is classified under `user_provided` or `unknown`, and does not become evidence by attribution alone.
+
+A display name is not institutional attribution.
+
+Example retained framing from an external WhatsApp correspondent using the display name `SpaceX`:
+
+```text
+If access to large-scale encrypted communications truly revealed extensive criminal networks, one would expect investigative visibility to be evaluated beyond the commonly cited categories of narcotics, firearms, and money laundering, including human trafficking, abuse, and exploitation wherever evidence exists.
+
+Transparency, accountability, and traceability are essential for maintaining public trust. Technology itself does not judge outcomes; it creates visibility. What matters is how institutions choose to interpret, investigate, and act upon the information they obtain.
+
+The long-term challenge is ensuring that powerful tools are applied consistently, objectively, and without selective narratives. Traceability should illuminate facts, not merely reinforce predetermined conclusions.
+```
+
+Attribution status:
+
+- credited as external unverified contribution;
+- not attributed to SpaceX as a company;
+- retained as discussion input, not as evidence;
+- operationally relevant because it supports traceability over predetermined conclusions.
+
 ## Minimal Record Shape
 
 A public-safe audit record may use this conceptual shape:


### PR DESCRIPTION
## Summary

Adds a small external contribution note to the Judicial Transparency Audit Framework RFC.

The note preserves the user's requested credit while avoiding institutional attribution to SpaceX as a company.

## Scope

- One documentation-only RFC update
- Adds an `External Contribution Notes` section
- Classifies the contribution as `user_provided` / unverified
- Keeps the text as discussion input, not evidence

## Out of scope

- No runtime changes
- No CI changes
- No schemas
- No datasets or fixtures
- No benchmarks
- No crawler, connector, dashboard, scoring, or LLM-as-judge work
- No public accusation workflow

## Validation

Not run locally in this connector-only update.

Expected validation:

```bash
python tools/check_mojibake.py docs/rfc/judicial_transparency_audit_framework.md
git diff --check -- docs/rfc/judicial_transparency_audit_framework.md
```

## Risk

Low. The addition explicitly prevents source laundering by stating that a display name is not institutional attribution and that the contribution is retained as discussion input, not evidence.

Tracks #1641.