### PR TITLE
Clarify static site GitHub links

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -33,8 +33,20 @@
 <body>
   <main>
     <h1>Page not found</h1>
-    <p>The requested page is not available on huboptimus.dev.</p>
-    <p><a href="/">Return to HUB_Optimus</a></p>
+    <p>huboptimus.dev serves the public HUB_Optimus landing page only.</p>
+    <p>Repository files and versioned documentation live on GitHub. Paths such as <code>/HUB_Optimus/...</code> are not valid on this custom domain.</p>
+    <p>
+      <a href="/">Return to HUB_Optimus</a> |
+      <a href="https://github.com/Voxterrae/HUB_Optimus">Repository</a> |
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/README.md">README</a> |
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/IP_NOTICE.md">IP Notice</a>
+    </p>
+    <p>
+      Onboarding:
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/00_start_here.md">EN</a> |
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/es/00_start_here.md">ES</a> |
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/de/00_start_here.md">DE</a>
+    </p>
   </main>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -214,13 +214,20 @@
 
       <section aria-labelledby="truth">
         <h2 id="truth">Source of truth</h2>
-        <p>GitHub repository, Issues, Pull Requests, CI, and versioned documentation.</p>
+        <p>GitHub repository, Issues, Pull Requests, CI, and versioned documentation. Repository files and documentation remain versioned in GitHub; huboptimus.dev serves the public landing page only.</p>
+      </section>
+
+      <section aria-labelledby="site-scope">
+        <h2 id="site-scope">Public site scope</h2>
+        <p>README, IP notice, documentation, assets, and runtime files are not copied into this static site. Use the GitHub links below for authoritative repository materials.</p>
       </section>
 
       <nav class="wide" aria-labelledby="links">
         <h2 id="links">Links</h2>
         <ul class="links">
           <li><a href="https://github.com/Voxterrae/HUB_Optimus">Repository</a></li>
+          <li><a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/README.md">README</a></li>
+          <li><a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/IP_NOTICE.md">IP Notice</a></li>
           <li><a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/00_start_here.md">EN onboarding</a></li>
           <li><a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/es/00_start_here.md">ES onboarding</a></li>
           <li><a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/de/00_start_here.md">DE onboarding</a></li>


### PR DESCRIPTION
﻿### Motivation
- Clarify that `huboptimus.dev` serves only the static `site/` landing page through GitHub Pages.
- Reduce user confusion after custom-domain deployment when repository-style paths such as `/HUB_Optimus/IP_NOTICE.html` return 404.
- Keep repository files, documentation, and source-of-truth materials versioned in GitHub instead of copying them into the public site.

### Scope
- Update `site/index.html` with explicit public-site-scope wording.
- Add absolute GitHub links for the repository, README, IP Notice, and EN/ES/DE onboarding documents.
- Update `site/404.html` to explain that repository files live on GitHub and `/HUB_Optimus/...` paths are not valid on the custom domain.

### Validation
- `git diff --check HEAD~1 HEAD -- site/index.html site/404.html` passed.
- `python` HTMLParser check passed for both site HTML files: required GitHub links present, viewport metadata present, and no `<script>` or `<form>` tags.
- `Select-String` forbidden href check passed: no relative href values pointing to `docs/`, `/docs`, `assets/`, `/assets`, `v1_core/`, `/v1_core`, `IP_NOTICE.html`, or `/HUB_Optimus`.
- `git diff --name-only HEAD~1 HEAD` confirmed the PR changes only `site/404.html` and `site/index.html`.

### Risks
- Low. This is static copy and link clarification only.
- The 404 page intentionally explains expected missing custom-domain paths instead of serving repository files from `huboptimus.dev`.

### Out of scope
- No runtime, simulator, benchmarks, schemas, Python package files, roadmap, or governance contract changes.
- No copied `docs/`, `assets/`, `v1_core/`, README, or IP notice files into `site/`.
- No CMS, WordPress, analytics, cookies, forms, external JavaScript, backend code, dependencies, or build step.
- `docs/context/AI_HANDOFF.md` was not updated because this narrow static-site clarification does not change operational handoff state.
