### PR TITLE
docs: define governance intelligence concept

### DIFF
--- a/docs/concepts/governance-intelligence.md
+++ b/docs/concepts/governance-intelligence.md
@@ -1,0 +1,113 @@
+# Governance Intelligence
+
+## Purpose
+
+Governance Intelligence is a structured analytical discipline for separating claims, evidence, inference, uncertainty, narrative amplification, and operational relevance in complex institutional, civic, technological, and informational environments.
+
+It is a method for improving analysis quality. It is not an authority layer, prediction engine, or replacement for human judgment.
+
+## Relationship to HUB_Optimus
+
+HUB_Optimus uses this concept as a documentation frame for disciplined analysis.
+
+The concept supports the existing sequence:
+
+```text
+observe -> detect -> decide -> act
+```
+
+This file is documentation-only. It does not change runtime behavior, schemas, benchmarks, CI, roadmap, or governance rules.
+
+## Analytical layers
+
+| Layer | Question | Output |
+| --- | --- | --- |
+| Claim | What is being asserted? | Specific statement |
+| Evidence | What supports it? | Sources or observations |
+| Inference | What is concluded from the evidence? | Reasoned interpretation |
+| Uncertainty | What remains unknown? | Gaps and ambiguity |
+| Narrative amplification | What may be overstated? | Distortion risk |
+| Operational relevance | Why does it matter? | Small reviewable next step |
+
+## Conceptual hierarchy
+
+```text
+Governance Intelligence
+├── Claim analysis
+│   ├── Claim
+│   ├── Evidence
+│   ├── Inference
+│   ├── Uncertainty
+│   └── Narrative amplification
+├── Digital governance context
+│   ├── E-governance
+│   ├── Digital government
+│   ├── E-participation
+│   └── Public service interoperability
+├── Operational signal
+│   ├── Regression
+│   ├── Documentation drift
+│   ├── Contributor friction
+│   ├── CI/runtime signal
+│   └── Governance risk
+└── System response
+    ├── Observe
+    ├── Detect
+    ├── Decide
+    └── Act
+```
+
+## Scope
+
+This concept may be used to analyze:
+
+- institutional friction;
+- digital governance gaps;
+- claims about policy, technology, institutions, or information systems;
+- mismatches between stated objectives and observable outcomes;
+- risks caused by unclear evidence or unsupported inference.
+
+## Non-scope
+
+This concept must not be used as:
+
+- a true/false oracle;
+- a substitute for primary evidence;
+- a substitute for domain expertise;
+- a source of unsupported claims;
+- a reason to bypass repository governance.
+
+## Relation to e-governance and digital government
+
+E-governance and digital government concern how institutions use digital technologies, data, interoperability, service design, participation, and accountability to provide public value.
+
+Governance Intelligence does not replace those concepts. It provides an analytical frame for evaluating evidence quality, institutional signals, and operational consequences around governance-related claims.
+
+## External publication guardrail
+
+Repository content is useful for project traceability, but it is not automatically an independent encyclopedic source.
+
+Any external encyclopedic use should rely on reliable, independent, published secondary sources. Repository files may support project history, but they are not sufficient proof of external notability.
+
+## Operating rule
+
+Use this concept only when there is a valid signal:
+
+- regression;
+- unclear architecture;
+- contributor friction;
+- documentation drift;
+- CI/runtime signal;
+- governance risk;
+- explicit user request.
+
+If no valid signal exists, remain in controlled observation mode.
+
+## Validation
+
+This change is valid when:
+
+- it remains documentation-only;
+- it introduces no runtime, CI, schema, or benchmark changes;
+- it frames the concept as analytical, not authoritative;
+- future implementation work remains scoped to separate issues or PRs.


### PR DESCRIPTION
## Summary

Adds a documentation-only concept page for Governance Intelligence.

## Scope

- Adds `docs/concepts/governance-intelligence.md`
- Defines analytical layers: claim, evidence, inference, uncertainty, narrative amplification, and operational relevance
- Adds scope, non-scope, hierarchy, and validation notes

## Out of scope

- No runtime changes
- No CI changes
- No schema changes
- No benchmark changes
- No roadmap changes

## Validation

Documentation-only change. Manual review is sufficient.