### PR TITLE
docs: define platform-neutral compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 
 
 
-
 ---
 
 ## What it is
@@ -103,6 +102,7 @@ HUB_Optimus exists to **break that cycle** by evaluating scenarios **before** de
 - `docs/` → onboarding and reading paths (recommended entry point)
 - `v1_core/` → active kernel: architecture, operational flow, workflow, templates, scenarios, meta-learning
 - `docs/architecture/runtime_contract.md` → full technical contract (schema, runtime, CI, encoding)
+- `docs/architecture/platform_compatibility.md` → platform-neutral access and execution policy
 - `legacy/` → historical/exploratory materials (v0), preserved for transparency
 
 > Source-of-truth policy is defined in `docs/context/STATUS.md`: `v1_core/languages/es/` is canonical and `v1_core/languages/en/` is parity reference.

--- a/docs/architecture/platform_compatibility.md
+++ b/docs/architecture/platform_compatibility.md
@@ -1,0 +1,50 @@
+# Platform Compatibility Policy
+
+HUB_Optimus is platform-neutral by contract.
+
+It must remain accessible from modern desktop and mobile operating systems without requiring users or contributors to change device for reading, review, or participation.
+
+## Compatibility layers
+
+| Layer | Capability | Expected support |
+|---|---|---|
+| Reading | README, docs, scenarios | Any modern browser |
+| Review | Issues, pull requests, diffs, CI results | GitHub web or app |
+| Light editing | Documentation edits, comments, small text fixes | GitHub web editor |
+| Local execution | Simulator, tests, tools | Python-compatible environment |
+| Official validation | Tests, benchmarks, link checks, guardrails | GitHub Actions / CI |
+
+## Runtime guarantee
+
+The runtime guarantee is not tied to a native operating system.
+
+The current runtime contract is based on:
+
+- UTF-8 text files
+- JSON scenario input
+- JSON Schema validation
+- Python CLI execution
+- deterministic JSON output
+- CI validation
+
+## Mobile platforms
+
+iOS and Android are supported as access and review platforms.
+
+Native mobile execution is not part of the current runtime guarantee. Android-based terminal environments may work when they provide compatible Python and Git tooling, but CI remains the authoritative validation layer.
+
+## Non-goals
+
+This policy does not introduce:
+
+- native iOS app support
+- native Android app support
+- device-specific forks
+- platform-specific runtime behavior
+- separate mobile roadmap
+
+## Canonical rule
+
+HUB_Optimus is readable via web, reviewable via GitHub, executable in Python-compatible environments, and validated by CI.
+
+Native mobile execution is not part of the current runtime guarantee.


### PR DESCRIPTION
## Summary

Defines a small platform-neutral compatibility policy for HUB_Optimus.

This clarifies that the project should be accessible from modern devices and operating systems without requiring users to change device, while keeping the runtime guarantee tied to open contracts, Python-compatible execution environments, and CI validation.

## Scope

- Add `docs/architecture/platform_compatibility.md`
- Link the policy from the README repository map

## Out of scope

- No runtime changes
- No CI changes
- No schema changes
- No simulator changes
- No benchmark changes
- No native iOS or Android support
- No mobile roadmap expansion

## Definition of Done

- Compatibility is described by layers: reading, review, light editing, local execution, official validation
- iOS and Android are documented as access/review platforms
- Native mobile execution is explicitly outside the current runtime guarantee
- GitHub Actions / CI remains the authoritative validation layer

## Validation

Docs-only change. Expected validation:

- link check through existing CI
- markdown review
- no runtime test impact expected

## Risk

Low. The change is documentation-only and reversible. Main risk is overpromising platform support; the policy avoids this by separating access/review from local execution.