### PR TITLE
docs: align scenario template and runtime contract

### DIFF
--- a/SIMULATION_README.md
+++ b/SIMULATION_README.md
@@ -1,15 +1,16 @@
 # Guía de Uso del Núcleo de Simulación de HUB_Optimus
 
-Este documento explica cómo utilizar el núcleo de simulación prototípico que acompaña a HUB_Optimus.  El propósito de este núcleo es ofrecer una base de código mínima pero funcional para cargar escenarios, asignar políticas básicas a actores, ejecutar rondas de negociación y evaluar condiciones de éxito.
+Este documento explica cómo utilizar el núcleo de simulación prototípico que acompaña a HUB_Optimus.  El propósito de este núcleo es ofrecer una base de código mínima pero funcional para cargar escenarios JSON, asignar políticas básicas a actores, ejecutar rondas de negociación y evaluar condiciones de éxito.
 
-> **Alcance actual:** El prototipo implementa carga de escenarios, políticas de oferta simples y un informe JSON con `status`, `rounds`, `history` y `detail`.  Funcionalidades como el **Índice de Integridad**, el cifrado de comunicaciones y políticas de negociación avanzadas son **ampliaciones planificadas** (ver sección 4), no características del núcleo actual.
+> **Alcance actual:** El prototipo implementa carga de escenarios JSON estrictos, políticas de oferta simples y un informe JSON con `status`, `rounds`, `history` y `detail`.  Funcionalidades como el **Índice de Integridad**, el cifrado de comunicaciones y políticas de negociación avanzadas son **ampliaciones planificadas** (ver sección 4), no características del núcleo actual.
 
 ## Archivos principales
 
 | Archivo                      | Descripción                                                                                                      |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| `hub_optimus_simulator.py`  | Módulo que define las clases `Scenario`, `Actor` y `Simulator`, así como políticas sencillas de ejemplo.  Permite cargar escenarios desde JSON/YAML y ejecutar rondas de negociación. |
-| `run_scenario.py`           | Script de línea de comandos que invoca al simulador sobre un escenario determinado y devuelve un informe JSON.   |
+| `hub_optimus_simulator.py`  | Módulo que define las clases `Scenario`, `Actor` y `Simulator`, así como políticas sencillas de ejemplo.  Ejecuta rondas de negociación sobre escenarios ya validados. |
+| `run_scenario.py`           | Script de línea de comandos que valida un escenario JSON estricto e invoca el simulador para devolver un informe JSON.   |
+| `scenario.schema.json`      | Contrato JSON Schema canónico para los archivos de escenario ejecutables.                                         |
 | `example_scenario.json`     | Escenario de ejemplo donde dos facciones negocian un alto el fuego parcial.                                        |
 | `i18n_sync.py`              | Utilidad para comprobar la coherencia de traducciones en la documentación (ver sección 5).                        |
 
@@ -26,7 +27,7 @@ source venv/bin/activate
 
 ## 2. Estructura de un escenario
 
-Los escenarios se describen mediante un archivo JSON (también se acepta YAML) con los campos siguientes:
+Los escenarios ejecutables se describen mediante un archivo JSON que debe validar contra `scenario.schema.json`. El contrato actual es estricto: no se aceptan campos extra en la raíz del documento ni dentro de `roles[]`.
 
 ```json
 {
@@ -41,10 +42,12 @@ Los escenarios se describen mediante un archivo JSON (también se acepta YAML) c
 }
 ```
 
-* `title` y `description` proporcionan contexto humano.
-* `roles` define los actores que participarán en la negociación.  Cada elemento puede incluir campos adicionales (por ejemplo, la política a usar).
+* `title` y `description` proporcionan contexto humano mínimo para el runtime.
+* `roles` define los actores que participarán en la negociación.  Cada elemento debe contener solo `name` y `role`.
 * `success_criteria` es un mapa de clave/valor.  La simulación se detiene cuando cualquier actor emite una acción que coincida con una clave y valor del criterio (por ejemplo, `{"offer": 5}`).
 * `max_rounds` limita el número máximo de rondas para evitar bucles infinitos.
+
+La plantilla de trabajo más rica (`v1_core/workflow/04_scenario_template.md`) sirve para diseñar escenarios humanos con contexto, verificación, riesgos, evaluación y meta-learning. Esas secciones no forman parte del JSON ejecutable actual salvo que el schema, los ejemplos, los tests y la documentación se actualicen en un PR específico.
 
 ## 3. Ejecución desde la línea de comandos
 
@@ -54,7 +57,7 @@ Para ejecutar un escenario:
 python run_scenario.py --scenario example_scenario.json --seed 42
 ```
 
-* `--scenario` especifica la ruta al archivo de escenario.  Puede ser una ruta relativa o absoluta.
+* `--scenario` especifica la ruta al archivo de escenario JSON.  Puede ser una ruta relativa o absoluta.
 * `--seed` es opcional; fija la semilla del generador aleatorio para obtener resultados reproducibles.
 
 El script imprimirá un informe JSON como el siguiente:
@@ -81,7 +84,7 @@ El campo `status` indica si se alcanzó el criterio de éxito (`"success"`) o se
 
 ### Opciones adicionales
 
-El módulo `hub_optimus_simulator.py` está diseñado para ser extensible.  Puedes definir políticas personalizadas para los actores proporcionando funciones que acepten el estado de la negociación y devuelvan la siguiente acción.  También puedes cargar escenarios desde YAML o definirlos directamente como diccionarios en Python y pasarlos al simulador.
+El módulo `hub_optimus_simulator.py` está diseñado para ser extensible.  Puedes definir políticas personalizadas para los actores proporcionando funciones que acepten el estado de la negociación y devuelvan la siguiente acción.  Esas políticas se asignan desde Python o mediante las opciones soportadas por el runner; no se declaran como campos extra dentro del JSON de escenario actual.
 
 ## 4. Ampliaciones futuras
 

--- a/docs/governance/SCENARIO_SCHEMA.md
+++ b/docs/governance/SCENARIO_SCHEMA.md
@@ -17,15 +17,67 @@ A scenario is a structured input contract, not an argumentative narrative.
 
 ## Validation behavior
 - Unknown top-level fields are rejected (`additionalProperties: false`).
+- Unknown role-level fields are rejected (`additionalProperties: false`).
 - Empty role arrays are rejected.
 - Missing required fields are rejected.
 
 ## Typical invalid inputs (must fail)
 - Missing `success_criteria`.
 - `roles` is an empty array.
+- `roles[]` contains extra fields beyond `name` and `role`.
 - `max_rounds` is `0` or a non-integer value.
+
+## Relationship to the workflow scenario template
+
+The workflow scenario template is the human authoring contract.
+The JSON schema is the current machine runtime contract.
+They are intentionally not equivalent.
+
+The template helps authors describe context, actors, incentives, verification,
+risks, rounds, evaluation, and meta-learning. The runtime schema only accepts the
+minimal fields needed by the current prototype simulator.
+
+Do not add template-only sections directly to runtime JSON files unless
+`scenario.schema.json`, examples, tests, and documentation are updated in the same
+scoped PR.
+
+| Workflow template section | Current JSON runtime field | Status | Future semantic destination |
+| --- | --- | --- | --- |
+| `0) Metadatos` | Not represented | Template-only | Provenance, audit metadata, `core_version_ref` |
+| `1) Resumen ejecutivo` | `description` | Partial | `input_summary`, case context |
+| `2) Actores y roles` | `roles[].name`, `roles[].role` | Partial | Stakeholders, affected actors, role context |
+| `3) Contexto y línea de tiempo` | `description` | Partial | Evidence context, uncertainty context |
+| `4) Intereses, posiciones y restricciones` | Not represented | Template-only | Incentive analysis, conflict analysis |
+| `5) Objetivo mínimo y criterios de éxito` | `success_criteria` | Partial | Outcome boundary, proposal success criteria |
+| `6) Propuesta inicial` | Not represented | Template-only | `proposal_analysis`, submitted proposal boundary |
+| `7) Verificación y cumplimiento` | Not represented | Template-only | Verification requirements, audit checks |
+| `8) Riesgos y puntos de fricción` | Not represented | Template-only | Failure modes, abuse vectors, uncertainty |
+| `9) Rondas recomendadas` | `max_rounds` | Partial | Sequencing requirements, negotiation plan |
+| `10) Evaluación (post-mortem)` | Not represented | Template-only | Lab notes, evaluation trace, audit record |
+| `11) Meta-learning` | Not represented | Template-only | Meta-learning record, decision trace |
+
+## Runtime boundary
+
+Current runtime success is intentionally narrow: `run_scenario.py` validates a JSON
+scenario, executes round-based actor offers, checks whether any actor action
+matches any `success_criteria` key/value pair, and writes a deterministic JSON
+result.
+
+This schema does not currently evaluate:
+
+- incentive alignment;
+- sequencing quality;
+- verification strength;
+- long-term stability;
+- false-success risk;
+- corrective options;
+- meta-learning outcomes.
+
+Those capabilities belong to the broader governance and Semantic Engine direction
+and require separate issues or RFC follow-ups before implementation.
 
 ## Extension guidance
 - Keep backward compatibility when possible; add optional fields first.
 - If a new required field is needed, bump schema version and update examples/tests in the same PR.
 - Update this document and `scenario.schema.json` together; never update one without the other.
+- Preserve the distinction between template authoring fields and runtime executable fields.


### PR DESCRIPTION
## Decision

This PR is closed because it mixed two review scopes:

1. normal simulator documentation (`SIMULATION_README.md`);
2. protected governance contract documentation (`docs/governance/SCENARIO_SCHEMA.md`).

## Reasoning

Kernel Guard correctly blocks protected governance files unless the PR is explicitly reviewed with the auditable `allow-kernel-change` label.

## Follow-up split

The work will continue as two smaller PRs:

- Runtime documentation only: `SIMULATION_README.md`.
- Governance contract documentation: `docs/governance/SCENARIO_SCHEMA.md` plus required governance mirror sync.

No runtime, schema, benchmark, or CI changes are authorized by this closed PR.