### PR TITLE
ops: add EC2 local backend scripts

### DIFF
--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -1,0 +1,80 @@
+# EC2 local backend operations
+
+This directory captures the manually validated EC2 backend v0.1 operational layer for HUB_Optimus.
+
+## Scope
+
+Included:
+
+- release deployment helper
+- rollback helper
+- local backend command wrappers
+- run registry helper
+- local API launcher
+- local API systemd control wrapper
+- systemd unit for the local API
+
+## Non-goals
+
+This does not add:
+
+- public API exposure
+- nginx
+- DNS/domain configuration
+- Elastic IP configuration
+- Terraform
+- AWS automation
+- frontend
+- secrets handling
+
+## Current validated shape
+
+The local backend runs as:
+
+- hub-ops: deploy, rollback and validation operations
+- hub-core: backend execution commands
+- hub-runs: run registry inspection
+- hub-product: local product status
+- hub-api: localhost API wrapper
+- hub-api-control: systemd wrapper
+- hub-api.service: local API service
+
+## Local API
+
+The API binds locally only:
+
+127.0.0.1:8080
+
+Validated endpoints:
+
+- GET /health
+- GET /status
+- POST /analyze
+
+POST /analyze returns direct JSON with:
+
+- status
+- run_id
+- run_path
+- analysis_result
+
+## Installation note
+
+These scripts are documented from a validated EC2 instance. They are not automatically installed by this repository.
+
+Manual installation targets:
+
+- /opt/hub-optimus/shared/bin/
+- /etc/systemd/system/hub-api.service
+
+## Validation
+
+Run from the repository root:
+
+bash -n ops/ec2/*.sh
+
+Runtime validation on EC2:
+
+hub-product
+hub-api-control status
+curl -sS http://127.0.0.1:8080/health

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/hub-optimus"
+REPO_URL="https://github.com/Voxterrae/HUB_Optimus.git"
+RELEASE_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RELEASE_DIR="$APP_ROOT/releases/$RELEASE_ID"
+
+echo "[deploy] Starting HUB_Optimus deploy"
+echo "[deploy] Release: $RELEASE_ID"
+
+mkdir -p "$APP_ROOT/releases" "$APP_ROOT/shared/logs"
+
+if [ -e "$RELEASE_DIR" ]; then
+  echo "[deploy:error] Release directory already exists: $RELEASE_DIR"
+  exit 1
+fi
+
+echo "[deploy] Cloning repository"
+git clone --depth 1 "$REPO_URL" "$RELEASE_DIR"
+
+cd "$RELEASE_DIR"
+
+echo "[deploy] Creating venv"
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo "[deploy] Installing dependencies"
+python -m pip install --upgrade pip
+python -m pip install -r requirements-dev.txt
+
+echo "[deploy] Running tests"
+python -m pytest -q
+
+deactivate
+
+echo "[deploy] Hiding local venv from git status"
+grep -qxF ".venv/" "$RELEASE_DIR/.git/info/exclude" || echo ".venv/" >> "$RELEASE_DIR/.git/info/exclude"
+
+if [ -L "$APP_ROOT/current" ]; then
+  PREVIOUS="$(readlink -f "$APP_ROOT/current")"
+  echo "$PREVIOUS" > "$APP_ROOT/shared/previous_release"
+  echo "[deploy] Previous release: $PREVIOUS"
+else
+  echo "[deploy] No previous release detected"
+fi
+
+echo "[deploy] Switching current symlink"
+ln -sfn "$RELEASE_DIR" "$APP_ROOT/current.new"
+mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
+
+cd "$APP_ROOT/current"
+
+COMMIT="$(git rev-parse --short HEAD)"
+CURRENT_PATH="$(readlink -f "$APP_ROOT/current")"
+
+cat > "$APP_ROOT/shared/RELEASE_STATE" <<STATE
+release=$RELEASE_ID
+commit=$COMMIT
+path=$CURRENT_PATH
+validated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+validation=pytest 55 passed
+status=production-candidate-core
+STATE
+
+echo "$RELEASE_ID" > "$APP_ROOT/shared/current_release"
+
+echo "[deploy] Current release:"
+readlink -f "$APP_ROOT/current"
+
+echo "[deploy] Git commit:"
+git rev-parse --short HEAD
+
+echo "[deploy] Git status:"
+git status --short
+
+echo "[deploy] Release state:"
+cat "$APP_ROOT/shared/RELEASE_STATE"
+
+echo "[deploy] Done"

--- a/ops/ec2/hub-api-control.sh
+++ b/ops/ec2/hub-api-control.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="hub-api.service"
+LOG_FILE="/opt/hub-optimus/shared/logs/hub-api.systemd.log"
+
+usage() {
+  cat <<USAGE
+HUB_Optimus local API control
+
+Usage:
+  hub-api-control start
+  hub-api-control stop
+  hub-api-control restart
+  hub-api-control status
+  hub-api-control log
+USAGE
+}
+
+status_api() {
+  echo "[hub-api] systemd:"
+  systemctl status "$SERVICE" --no-pager || true
+
+  echo
+  echo "[hub-api] active:"
+  systemctl is-active "$SERVICE" || true
+
+  echo
+  echo "[hub-api] enabled:"
+  systemctl is-enabled "$SERVICE" || true
+
+  echo
+  echo "[hub-api] port:"
+  ss -ltnp | grep ':8080' || true
+
+  echo
+  echo "[hub-api] health:"
+  curl -sS http://127.0.0.1:8080/health 2>/dev/null || true
+  echo
+}
+
+log_api() {
+  echo "[hub-api] journal:"
+  journalctl -u "$SERVICE" -n 80 --no-pager || true
+
+  echo
+  echo "[hub-api] file log:"
+  tail -80 "$LOG_FILE" 2>/dev/null || echo "[hub-api] no file log"
+}
+
+case "${1:-}" in
+  start)
+    sudo systemctl start "$SERVICE"
+    status_api
+    ;;
+  stop)
+    sudo systemctl stop "$SERVICE"
+    echo "[hub-api] stopped"
+    ;;
+  restart)
+    sudo systemctl restart "$SERVICE"
+    sleep 1
+    status_api
+    ;;
+  status)
+    status_api
+    ;;
+  log|logs)
+    log_api
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "[hub-api-control:error] unknown command: $1"
+    echo
+    usage
+    exit 1
+    ;;
+esac

--- a/ops/ec2/hub-api.service
+++ b/ops/ec2/hub-api.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=HUB_Optimus local API
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/opt/hub-optimus/current
+Environment=PATH=/opt/hub-optimus/shared/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/opt/hub-optimus/shared/bin/hub-api
+Restart=on-failure
+RestartSec=3
+StandardOutput=append:/opt/hub-optimus/shared/logs/hub-api.systemd.log
+StandardError=append:/opt/hub-optimus/shared/logs/hub-api.systemd.log
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/hub-optimus"
+API_DIR="$APP_ROOT/shared/api"
+API_FILE="$API_DIR/hub_api.py"
+
+mkdir -p "$API_DIR"
+
+cat > "$API_FILE" <<'PY'
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+APP_ROOT = Path("/opt/hub-optimus")
+CURRENT = APP_ROOT / "current"
+SHARED = APP_ROOT / "shared"
+
+
+def read_text(path: Path, default: str = "") -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return default
+
+
+def run_command(args: list[str], input_text: str | None = None) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        args,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def product_status() -> dict:
+    current_path = ""
+    commit = ""
+    if CURRENT.is_symlink():
+        current_path = str(CURRENT.resolve())
+        code, stdout, _ = run_command(["git", "-C", current_path, "rev-parse", "--short", "HEAD"])
+        if code == 0:
+            commit = stdout.strip()
+
+    release_state = read_text(SHARED / "RELEASE_STATE")
+
+    return {
+        "product": "HUB_Optimus backend v0.1",
+        "current": current_path,
+        "commit": commit,
+        "release_state": release_state,
+        "capabilities": {
+            "semantic_analyze": True,
+            "scenario_runner": True,
+            "deploy_rollback": True,
+            "runs_registry": True,
+            "public_api": False,
+            "frontend": False,
+        },
+    }
+
+
+def latest_run_id(command: str) -> str | None:
+    command_dir = SHARED / "runs" / command
+    if not command_dir.is_dir():
+        return None
+    runs = sorted(p.name for p in command_dir.iterdir() if p.is_dir())
+    return runs[-1] if runs else None
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "HUBOptimusAPI/0.1"
+
+    def send_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        encoded = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+
+        if path == "/status":
+            self.send_json(200, product_status())
+            return
+
+        if path == "/health":
+            self.send_json(200, {"status": "ok"})
+            return
+
+        self.send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path
+
+        if path != "/analyze":
+            self.send_json(404, {"error": "not found"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length).decode("utf-8")
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            self.send_json(400, {"error": f"invalid JSON: {exc.msg}"})
+            return
+
+        case_dir = SHARED / "api" / "cases"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        case_path = case_dir / "api-case.json"
+        case_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        before_latest = latest_run_id("analyze")
+
+        code, stdout, stderr = run_command([
+            "/opt/hub-optimus/shared/bin/hub-core",
+            "analyze",
+            str(case_path),
+        ])
+
+        after_latest = latest_run_id("analyze")
+
+        if code != 0:
+            self.send_json(
+                500,
+                {
+                    "error": "analysis failed",
+                    "stderr": stderr,
+                    "stdout": stdout,
+                },
+            )
+            return
+
+        if not after_latest or after_latest == before_latest:
+            self.send_json(
+                500,
+                {
+                    "error": "analysis completed but run output was not detected",
+                    "stdout": stdout,
+                },
+            )
+            return
+
+        run_path = SHARED / "runs" / "analyze" / after_latest
+        result_path = run_path / "analysis_result.json"
+
+        try:
+            analysis_result = json.loads(result_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            self.send_json(500, {"error": f"cannot read analysis result: {exc}"})
+            return
+        except json.JSONDecodeError as exc:
+            self.send_json(500, {"error": f"analysis result is invalid JSON: {exc.msg}"})
+            return
+
+        self.send_json(
+            200,
+            {
+                "status": "ok",
+                "run_id": after_latest,
+                "run_path": str(run_path),
+                "analysis_result": analysis_result,
+            },
+        )
+
+
+def main() -> int:
+    host = "127.0.0.1"
+    port = 8080
+    httpd = HTTPServer((host, port), Handler)
+    print(f"[hub-api] listening on http://{host}:{port}", flush=True)
+    httpd.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY
+
+chmod +x "$API_FILE"
+
+echo "[hub-api] Starting local API on 127.0.0.1:8080"
+exec python3 "$API_FILE"

--- a/ops/ec2/hub-core.sh
+++ b/ops/ec2/hub-core.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/hub-optimus"
+RUN_ROOT="$APP_ROOT/shared/runs"
+
+usage() {
+  cat <<USAGE
+HUB_Optimus core runner
+
+Usage:
+  hub-core status
+  hub-core test
+  hub-core benchmark
+  hub-core narrative-benchmark
+  hub-core semantic-smoke
+  hub-core scenario-smoke
+  hub-core analyze <case.json>
+
+Commands:
+  status               Show active release and available core commands.
+  test                 Run full pytest suite on current release.
+  benchmark            Run benchmark pack v0 and store output.
+  narrative-benchmark  Run narrative benchmark pack and store output.
+  semantic-smoke       Run Semantic Engine minimal case and store JSON result.
+  scenario-smoke       Run example scenario and store JSON result.
+  analyze              Analyze a provided Semantic Engine case JSON and store result.
+USAGE
+}
+
+require_current() {
+  if [ ! -L "$APP_ROOT/current" ]; then
+    echo "[hub-core:error] current symlink does not exist."
+    exit 1
+  fi
+  cd "$APP_ROOT/current"
+}
+
+activate_current() {
+  require_current
+  if [ ! -d ".venv" ]; then
+    echo "[hub-core:error] .venv does not exist in current release."
+    exit 1
+  fi
+  source .venv/bin/activate
+}
+
+new_run_dir() {
+  local name="$1"
+  local ts
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  local dir="$RUN_ROOT/$name/$ts"
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
+write_run_meta() {
+  local dir="$1"
+  local command_name="$2"
+  local input_path="${3:-}"
+  local commit
+  local release
+  local current_path
+
+  require_current
+  commit="$(git rev-parse --short HEAD)"
+  current_path="$(readlink -f "$APP_ROOT/current")"
+  release="$(basename "$current_path")"
+
+  cat > "$dir/RUN_STATE" <<STATE
+command=$command_name
+release=$release
+commit=$commit
+path=$current_path
+input=$input_path
+ran_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+STATE
+}
+
+status_core() {
+  require_current
+
+  echo "[hub-core] HUB_Optimus core"
+  echo
+
+  echo "[hub-core] current:"
+  readlink -f "$APP_ROOT/current"
+  echo
+
+  echo "[hub-core] release_state:"
+  cat "$APP_ROOT/shared/RELEASE_STATE" 2>/dev/null || echo "none"
+  echo
+
+  echo "[hub-core] commit:"
+  git rev-parse --short HEAD
+  echo
+
+  echo "[hub-core] available commands:"
+  usage
+}
+
+run_tests() {
+  activate_current
+
+  local dir
+  dir="$(new_run_dir test)"
+  write_run_meta "$dir" "test"
+
+  echo "[hub-core:test] Output dir: $dir"
+  python -m pytest -q | tee "$dir/pytest.log"
+
+  deactivate
+  echo "[hub-core:test] Done"
+}
+
+run_benchmark() {
+  activate_current
+
+  local dir
+  dir="$(new_run_dir benchmark)"
+  write_run_meta "$dir" "benchmark"
+
+  echo "[hub-core:benchmark] Output dir: $dir"
+  python benchmarks/run_benchmarks.py --summary-file "$dir/benchmark_summary.md" | tee "$dir/benchmark.log"
+
+  deactivate
+  echo "[hub-core:benchmark] Done"
+}
+
+run_narrative_benchmark() {
+  activate_current
+
+  local dir
+  dir="$(new_run_dir narrative-benchmark)"
+  write_run_meta "$dir" "narrative-benchmark"
+
+  echo "[hub-core:narrative-benchmark] Output dir: $dir"
+  python benchmarks/run_narrative_benchmarks.py | tee "$dir/narrative_benchmark.log"
+
+  deactivate
+  echo "[hub-core:narrative-benchmark] Done"
+}
+
+run_semantic_smoke() {
+  activate_current
+
+  local dir
+  dir="$(new_run_dir semantic-smoke)"
+  write_run_meta "$dir" "semantic-smoke"
+
+  echo "[hub-core:semantic-smoke] Output dir: $dir"
+  python -m semantic_engine.cli analyze \
+    examples/semantic_engine/case_minimal.json \
+    --output "$dir/analysis_result.json"
+
+  cp examples/semantic_engine/case_minimal.json "$dir/input_case.json"
+  cat "$dir/analysis_result.json"
+
+  deactivate
+  echo "[hub-core:semantic-smoke] Done"
+}
+
+run_scenario_smoke() {
+  activate_current
+
+  local dir
+  dir="$(new_run_dir scenario-smoke)"
+  write_run_meta "$dir" "scenario-smoke"
+
+  echo "[hub-core:scenario-smoke] Output dir: $dir"
+  python run_scenario.py \
+    --scenario example_scenario.json \
+    --output "$dir/example_scenario.result.json" \
+    --seed 42 | tee "$dir/scenario_stdout.json"
+
+  cp example_scenario.json "$dir/input_scenario.json"
+
+  deactivate
+  echo "[hub-core:scenario-smoke] Done"
+}
+
+run_analyze() {
+  local input="${1:-}"
+
+  if [ -z "$input" ]; then
+    echo "[hub-core:error] case JSON path required."
+    echo
+    usage
+    exit 1
+  fi
+
+  if [ ! -f "$input" ]; then
+    echo "[hub-core:error] case JSON not found: $input"
+    exit 1
+  fi
+
+  activate_current
+
+  local dir
+  dir="$(new_run_dir analyze)"
+  write_run_meta "$dir" "analyze" "$input"
+
+  echo "[hub-core:analyze] Output dir: $dir"
+
+  cp "$input" "$dir/input_case.json"
+
+  python -m semantic_engine.cli analyze \
+    "$dir/input_case.json" \
+    --output "$dir/analysis_result.json"
+
+  cat "$dir/analysis_result.json"
+
+  deactivate
+  echo "[hub-core:analyze] Done"
+}
+
+case "${1:-}" in
+  status)
+    status_core
+    ;;
+  test)
+    run_tests
+    ;;
+  benchmark)
+    run_benchmark
+    ;;
+  narrative-benchmark)
+    run_narrative_benchmark
+    ;;
+  semantic-smoke)
+    run_semantic_smoke
+    ;;
+  scenario-smoke)
+    run_scenario_smoke
+    ;;
+  analyze)
+    shift
+    run_analyze "${1:-}"
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "[hub-core:error] Unknown command: $1"
+    echo
+    usage
+    exit 1
+    ;;
+esac

--- a/ops/ec2/hub-ops.sh
+++ b/ops/ec2/hub-ops.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/hub-optimus"
+
+usage() {
+  cat <<USAGE
+HUB_Optimus EC2 ops
+
+Usage:
+  hub-ops status
+  hub-ops validate
+  hub-ops deploy
+  hub-ops rollback
+
+Commands:
+  status    Show current release, previous release, state, commit, git status, releases and disk usage.
+  validate  Run pytest on current release and show commit/status.
+  deploy    Run deploy-current.
+  rollback  Run rollback-current.
+USAGE
+}
+
+status_current() {
+  echo "[status] HUB_Optimus EC2"
+  echo
+
+  echo "[status] current:"
+  readlink -f "$APP_ROOT/current" 2>/dev/null || echo "none"
+  echo
+
+  echo "[status] previous:"
+  cat "$APP_ROOT/shared/previous_release" 2>/dev/null || echo "none"
+  echo
+
+  echo "[status] current_release:"
+  cat "$APP_ROOT/shared/current_release" 2>/dev/null || echo "none"
+  echo
+
+  echo "[status] release_state:"
+  cat "$APP_ROOT/shared/RELEASE_STATE" 2>/dev/null || echo "none"
+  echo
+
+  echo "[status] last_rollback_from:"
+  cat "$APP_ROOT/shared/last_rollback_from" 2>/dev/null || echo "none"
+  echo
+
+  echo "[status] git commit:"
+  if [ -L "$APP_ROOT/current" ]; then
+    cd "$APP_ROOT/current"
+    git rev-parse --short HEAD
+  else
+    echo "none"
+  fi
+  echo
+
+  echo "[status] git status:"
+  if [ -L "$APP_ROOT/current" ]; then
+    cd "$APP_ROOT/current"
+    git status --short
+  else
+    echo "none"
+  fi
+  echo
+
+  echo "[status] releases:"
+  ls -1 "$APP_ROOT/releases" 2>/dev/null | sort || echo "none"
+  echo
+
+  echo "[status] disk:"
+  df -h "$APP_ROOT" | tail -n 1
+}
+
+validate_current() {
+  if [ ! -L "$APP_ROOT/current" ]; then
+    echo "[validate:error] current symlink does not exist."
+    exit 1
+  fi
+
+  cd "$APP_ROOT/current"
+
+  if [ ! -d ".venv" ]; then
+    echo "[validate:error] .venv does not exist in current release."
+    exit 1
+  fi
+
+  source .venv/bin/activate
+
+  echo "[validate] Running pytest"
+  python -m pytest -q
+
+  deactivate
+
+  echo "[validate] Git status"
+  git status --short
+
+  echo "[validate] Commit"
+  git rev-parse --short HEAD
+
+  echo "[validate] Done"
+}
+
+case "${1:-}" in
+  status)
+    status_current
+    ;;
+  validate)
+    validate_current
+    ;;
+  deploy)
+    exec "$APP_ROOT/shared/bin/deploy-current"
+    ;;
+  rollback)
+    exec "$APP_ROOT/shared/bin/rollback-current"
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "[hub-ops:error] Unknown command: $1"
+    echo
+    usage
+    exit 1
+    ;;
+esac

--- a/ops/ec2/hub-product.sh
+++ b/ops/ec2/hub-product.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/hub-optimus"
+
+api_active="$(systemctl is-active hub-api 2>/dev/null || echo not_configured)"
+api_enabled="$(systemctl is-enabled hub-api 2>/dev/null || echo not_configured)"
+
+echo "HUB_Optimus backend v0.1"
+echo
+
+echo "[core]"
+echo "current=$(readlink -f "$APP_ROOT/current" 2>/dev/null || echo none)"
+echo "release=$(cat "$APP_ROOT/shared/current_release" 2>/dev/null || echo none)"
+echo "commit=$(
+  if [ -L "$APP_ROOT/current" ]; then
+    cd "$APP_ROOT/current"
+    git rev-parse --short HEAD
+  else
+    echo none
+  fi
+)"
+echo "status=$(grep '^status=' "$APP_ROOT/shared/RELEASE_STATE" 2>/dev/null | cut -d= -f2- || echo unknown)"
+echo
+
+echo "[capabilities]"
+command -v hub-ops >/dev/null && echo "hub-ops=active" || echo "hub-ops=missing"
+command -v hub-core >/dev/null && echo "hub-core=active" || echo "hub-core=missing"
+command -v hub-runs >/dev/null && echo "hub-runs=active" || echo "hub-runs=missing"
+command -v hub-api-control >/dev/null && echo "hub-api-control=active" || echo "hub-api-control=missing"
+
+echo "semantic_analyze=active"
+echo "scenario_runner=active"
+echo "deploy_rollback=active"
+echo "runs_registry=active"
+echo "local_api=$api_active"
+echo "systemd_service=$api_enabled"
+echo "api_bind=127.0.0.1:8080"
+echo "api_contract=direct_json"
+echo
+
+echo "[not_configured]"
+echo "public_api=not_configured"
+echo "frontend=not_configured"
+echo "nginx=not_configured"
+echo "elastic_ip=deferred"
+echo "ami=deferred"
+echo "domain=deferred"
+echo "typescript_artifact=not_present"
+echo
+
+echo "[latest_runs]"
+if [ -d "$APP_ROOT/shared/runs" ]; then
+  find "$APP_ROOT/shared/runs" -mindepth 2 -maxdepth 2 -type d \
+    | sed "s#$APP_ROOT/shared/runs/##" \
+    | sort \
+    | tail -n 10
+else
+  echo "none"
+fi

--- a/ops/ec2/hub-runs.sh
+++ b/ops/ec2/hub-runs.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ROOT="/opt/hub-optimus/shared/runs"
+
+usage() {
+  cat <<USAGE
+HUB_Optimus run registry
+
+Usage:
+  hub-runs list
+  hub-runs latest <command>
+  hub-runs show <command> <run_id>
+
+Examples:
+  hub-runs list
+  hub-runs latest semantic-smoke
+  hub-runs show scenario-smoke 20260629T125443Z
+USAGE
+}
+
+list_runs() {
+  if [ ! -d "$RUN_ROOT" ]; then
+    echo "[runs] no runs directory"
+    exit 0
+  fi
+
+  echo "[runs] available:"
+  find "$RUN_ROOT" -mindepth 2 -maxdepth 2 -type d \
+    | sed "s#$RUN_ROOT/##" \
+    | sort
+}
+
+latest_run() {
+  local command="${1:-}"
+
+  if [ -z "$command" ]; then
+    echo "[runs:error] command name required"
+    exit 1
+  fi
+
+  local command_dir="$RUN_ROOT/$command"
+
+  if [ ! -d "$command_dir" ]; then
+    echo "[runs:error] no runs for command: $command"
+    exit 1
+  fi
+
+  ls -1 "$command_dir" | sort | tail -n 1
+}
+
+show_run() {
+  local command="${1:-}"
+  local run_id="${2:-}"
+
+  if [ -z "$command" ] || [ -z "$run_id" ]; then
+    echo "[runs:error] command and run_id required"
+    exit 1
+  fi
+
+  local dir="$RUN_ROOT/$command/$run_id"
+
+  if [ ! -d "$dir" ]; then
+    echo "[runs:error] run not found: $command/$run_id"
+    exit 1
+  fi
+
+  echo "[runs] path:"
+  echo "$dir"
+  echo
+
+  echo "[runs] files:"
+  find "$dir" -maxdepth 1 -type f -printf "%f\n" | sort
+  echo
+
+  if [ -f "$dir/RUN_STATE" ]; then
+    echo "[runs] RUN_STATE:"
+    cat "$dir/RUN_STATE"
+    echo
+  fi
+
+  for file in "$dir"/*.json "$dir"/*.md "$dir"/*.log; do
+    if [ -f "$file" ]; then
+      echo "[runs] --- $(basename "$file") ---"
+      cat "$file"
+      echo
+    fi
+  done
+}
+
+case "${1:-}" in
+  list)
+    list_runs
+    ;;
+  latest)
+    latest_run "${2:-}"
+    ;;
+  show)
+    show_run "${2:-}" "${3:-}"
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "[runs:error] unknown command: $1"
+    echo
+    usage
+    exit 1
+    ;;
+esac

--- a/ops/ec2/rollback-current.sh
+++ b/ops/ec2/rollback-current.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/hub-optimus"
+
+if [ ! -L "$APP_ROOT/current" ]; then
+  echo "[rollback:error] Current symlink does not exist."
+  exit 1
+fi
+
+if [ ! -f "$APP_ROOT/shared/previous_release" ]; then
+  echo "[rollback] No previous release recorded."
+  exit 1
+fi
+
+CURRENT="$(readlink -f "$APP_ROOT/current")"
+PREVIOUS="$(cat "$APP_ROOT/shared/previous_release")"
+
+if [ ! -d "$PREVIOUS" ]; then
+  echo "[rollback:error] Previous release path does not exist: $PREVIOUS"
+  exit 1
+fi
+
+if [ "$CURRENT" = "$PREVIOUS" ]; then
+  echo "[rollback] Current release already matches previous_release target:"
+  echo "$CURRENT"
+  exit 0
+fi
+
+echo "$CURRENT" > "$APP_ROOT/shared/last_rollback_from"
+
+ln -sfn "$PREVIOUS" "$APP_ROOT/current.new"
+mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
+
+cd "$APP_ROOT/current"
+
+RELEASE="$(basename "$(readlink -f "$APP_ROOT/current")")"
+COMMIT="$(git rev-parse --short HEAD)"
+CURRENT_PATH="$(readlink -f "$APP_ROOT/current")"
+
+cat > "$APP_ROOT/shared/RELEASE_STATE" <<STATE
+release=$RELEASE
+commit=$COMMIT
+path=$CURRENT_PATH
+validated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+validation=rollback to previously validated release
+status=production-candidate-core
+STATE
+
+echo "$RELEASE" > "$APP_ROOT/shared/current_release"
+
+echo "[rollback] Rolled back to:"
+readlink -f "$APP_ROOT/current"
+
+echo "[rollback] Release state:"
+cat "$APP_ROOT/shared/RELEASE_STATE"


### PR DESCRIPTION
## Summary

Adds the manually validated EC2 local backend operations layer under `ops/ec2`.

## Scope

- Adds release deploy and rollback helpers.
- Adds local backend command wrappers.
- Adds run registry inspection helper.
- Adds localhost API launcher.
- Adds systemd control wrapper.
- Adds local-only systemd unit for `hub-api`.
- Documents installation, non-goals, and validation.

## Non-goals

This PR does not add:

- public API exposure
- nginx
- DNS/domain configuration
- Elastic IP configuration
- Terraform
- AWS automation
- frontend
- secrets handling

## Validation

- `bash -n ops/ec2/*.sh`
- Manual EC2 validation already performed:
  - `hub-product`
  - `hub-api-control status`
  - `curl -sS http://127.0.0.1:8080/health`
  - `POST /analyze` returns direct JSON with `analysis_result`.

## Risk

Low. This documents and versions already validated operational scripts. It does not modify runtime core behavior.
