### PR TITLE
docs: credit trusted technical contributor

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,25 @@
+# HUB_Optimus Acknowledgements
+
+This file records public contribution credit for HUB_Optimus.
+
+GitHub remains the source of truth for commits, pull requests, reviews, and repository authority. This acknowledgement is descriptive only and does not change repository permissions, CODEOWNERS, governance ownership, licensing, roadmap authority, or Kernel authority.
+
+## Trusted Technical Contributors
+
+### Rodrigo / @itteamrod
+
+**Role:** Trusted Technical Contributor — Interface & Semantic Engine
+
+**Recognized contributions:**
+
+- Public landing interface restyle and static site presentation.
+- Semantic Engine structured case intake implementation.
+- Incremental, reviewable pull request execution aligned with HUB_Optimus repository discipline.
+
+**Authority boundary:**
+
+- This credit does not grant Kernel authority.
+- This credit does not grant governance ownership.
+- This credit does not change CODEOWNERS.
+- This credit does not change branch protection, rulesets, repository settings, or permission levels.
+- Repository authority remains controlled through GitHub issues, pull requests, CODEOWNERS, protected settings, and governed RFC process.


### PR DESCRIPTION
## Summary

Adds `ACKNOWLEDGEMENTS.md` with project contributor acknowledgement.

## Scope

- Documentation only.
- Adds one Markdown file.
- Records trusted technical contribution credit.
- No runtime, CI, schema, benchmark, CODEOWNERS, settings, permission, or governance ownership changes.

## Validation

- Single Markdown file added.
- Manual diff review confirms the change is descriptive only.

## Review focus

Confirm contributor name, handle, role wording, contribution summary, and authority boundary.