### PR TITLE
docs: fix EN architecture mojibake

### DIFF
--- a/v1_core/languages/en/02_arquitectura_base.md
+++ b/v1_core/languages/en/02_arquitectura_base.md
@@ -87,7 +87,7 @@ The architecture is intentionally:
 - incentive adjustment proposals (remove reward for instability),
 - timing recommendations (use windows of opportunity).
 
-**Inputs:** Layer 3 activation (risk â†‘ + window open)  
+**Inputs:** Layer 3 activation (risk ↑ + window open)
 **Outputs:** discreet mediation briefs, options, corrective paths
 
 **Rule:** no public spectacle; preserve channels; minimize escalation.
@@ -116,7 +116,7 @@ The architecture is intentionally:
 4. **Layer 3** evaluates against Kernel criteria
 5. **Layer 5** contrasts with recurring historical patterns
 6. **Layer 0** validates coherence and blocks drift/capture
-7. If risk â†‘ and window open â†’ **Layer 4** activates preventive mediation
+7. If risk ↑ and window open → **Layer 4** activates preventive mediation
 8. Outputs are recorded and fed back into **Layer 5** (memory strengthening)
 
 ## 4) Hard constraints (what the architecture forbids)
@@ -139,5 +139,4 @@ This document is part of the Kernel baseline. Any change must:
 - preserve Layer 0 principles,
 - keep layer numbering stable,
 - be synchronized across languages.
-
 


### PR DESCRIPTION
## Summary
- Cherry-pick the useful local branch fix from `docs/fix-mojibake-architecture-base`.
- Repair two remaining mojibake arrow sequences in `v1_core/languages/en/02_arquitectura_base.md`.
- Remove trailing Markdown whitespace introduced on one corrected line.

## Rationale
This is the first small branch-unification slice from the local branch audit. It preserves the canonical Spanish kernel and only repairs English parity/reference text encoding.

## Files affected
- `v1_core/languages/en/02_arquitectura_base.md`

## Risk / impact
- Kernel-adjacent because it touches `v1_core/languages/en`.
- No semantic change intended; punctuation/arrow mojibake only.
- No runtime, schema, workflow, benchmark, or dependency changes.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python tools/check_mojibake.py v1_core docs README.md CONTRIBUTING.md`
- `python -m pytest -q` -> 56 passed

## Local branch unification note
Source local commit: `f0072a0 docs: fix mojibake in 02_arquitectura_base.md`.