### PR TITLE
ci: expand mojibake guard to repo markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       - name: Check docs encoding (mojibake guard)
-        run: python tools/check_mojibake.py v1_core docs README.md CONTRIBUTING.md
+        run: python tools/check_mojibake.py .
 
       - name: Narrative consistency check
         run: |

--- a/tests/test_check_mojibake.py
+++ b/tests/test_check_mojibake.py
@@ -83,3 +83,14 @@ class TestDirectoryScan:
     def test_nonexistent_target(self, tmp_path: Path) -> None:
         result = _run_guard(str(tmp_path / "does_not_exist"), cwd=tmp_path)
         assert result.returncode == 0  # no files found, no errors
+
+    def test_excluded_directories_are_ignored(self, tmp_path: Path) -> None:
+        for dirname in (".venv", "node_modules", "site", "out_report"):
+            excluded = tmp_path / dirname
+            excluded.mkdir()
+            bad = excluded / "ignored.md"
+            bad.write_text("Double encoded: ÃƒÂ¤\n", encoding="utf-8")
+
+        result = _run_guard(".", cwd=tmp_path)
+
+        assert result.returncode == 0

--- a/tools/check_mojibake.py
+++ b/tools/check_mojibake.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import argparse
+from fnmatch import fnmatch
 import re
 import sys
 from pathlib import Path
 
 
-DEFAULT_TARGETS = ("docs", "v1_core", "README.md", "CONTRIBUTING.md")
+DEFAULT_TARGETS = (".",)
+EXCLUDED_DIR_NAMES = {".git", ".venv", "node_modules", "site"}
+EXCLUDED_DIR_PATTERNS = ("out_*",)
 
 PATTERNS = (
     ("replacement_char", re.compile(r"\uFFFD")),
@@ -19,11 +22,23 @@ PATTERNS = (
 
 
 def iter_markdown_files(target: Path) -> list[Path]:
+    def is_excluded(path: Path) -> bool:
+        return any(
+            part in EXCLUDED_DIR_NAMES
+            or any(fnmatch(part, pattern) for pattern in EXCLUDED_DIR_PATTERNS)
+            for part in path.parts
+        )
+
     if target.is_file():
-        return [target.resolve()] if target.suffix.lower() == ".md" else []
+        resolved = target.resolve()
+        return [resolved] if resolved.suffix.lower() == ".md" and not is_excluded(resolved) else []
     if not target.exists():
         return []
-    return sorted(p.resolve() for p in target.rglob("*.md") if p.is_file())
+    return sorted(
+        p.resolve()
+        for p in target.rglob("*.md")
+        if p.is_file() and not is_excluded(p.resolve())
+    )
 
 
 def scan_file(path: Path, root: Path) -> list[str]:
@@ -49,7 +64,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "targets",
         nargs="*",
-        help="Files or directories to scan (default: docs README.md CONTRIBUTING.md).",
+        help=(
+            "Files or directories to scan (default: repo root). "
+            "Excludes .git, .venv, node_modules, site, and out_* directories."
+        ),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- Expand the mojibake guard to scan repository Markdown from `.` in CI.
- Add safe directory exclusions for `.git`, `.venv`, `node_modules`, `site`, and `out_*`.
- Add test coverage for excluded generated/local directories.

## Rationale
This continues the local branch unification pass by preserving the useful intent of `ci/mojibake-full-scope` while applying it against current `main` with test coverage.

## Files affected
- `.github/workflows/ci.yml`
- `tools/check_mojibake.py`
- `tests/test_check_mojibake.py`

## Risk / impact
- CI/tooling change; no runtime, schema, kernel docs, benchmark data, or dependencies changed.
- Expands CI scan scope, but local repo-root scan passes before PR creation.
- Exclusions avoid generated/local directories that should not define repository encoding health.

## Validation
- `python -m pytest tests/test_check_mojibake.py -q` -> 9 passed
- `git diff --check HEAD~1..HEAD`
- `python tools/check_mojibake.py .` -> 234 markdown files scanned
- `python -m pytest -q` -> 57 passed

## Local branch unification note
Source local branch intent: `ci/mojibake-full-scope` / commit `95895ec ci: expand mojibake check to all markdown`.