### PR TITLE
site: fix operator PWA cache refresh

### DIFF
--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,15 +1,52 @@
-const CACHE_NAME = "hub-optimus-operator-v0-1";
-const ASSETS = [
-  "./",
-  "./index.html",
+const CACHE_NAME = "hub-optimus-operator-v0-2";
+const OFFLINE_FALLBACK = "./index.html";
+const STATIC_ASSETS = [
   "./manifest.webmanifest",
   "./icon.svg"
 ];
 
+async function cacheStaticAssets() {
+  const cache = await caches.open(CACHE_NAME);
+  await cache.addAll(STATIC_ASSETS);
+}
+
+async function networkFirst(request) {
+  const cache = await caches.open(CACHE_NAME);
+
+  try {
+    const response = await fetch(request, { cache: "no-store" });
+
+    if (response && response.ok) {
+      await cache.put(request, response.clone());
+
+      if (request.mode === "navigate") {
+        await cache.put(OFFLINE_FALLBACK, response.clone());
+      }
+    }
+
+    return response;
+  } catch {
+    return caches.match(request).then((cached) => (
+      cached || caches.match(OFFLINE_FALLBACK)
+    ));
+  }
+}
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+  if (response && response.ok) {
+    const cache = await caches.open(CACHE_NAME);
+    await cache.put(request, response.clone());
+  }
+
+  return response;
+}
+
 self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
-  );
+  event.waitUntil(cacheStaticAssets());
   self.skipWaiting();
 });
 
@@ -21,23 +58,29 @@ self.addEventListener("activate", (event) => {
         .map((key) => caches.delete(key))
     ))
   );
+
   self.clients.claim();
 });
 
 self.addEventListener("fetch", (event) => {
   if (event.request.method !== "GET") return;
 
-  event.respondWith(
-    caches.match(event.request).then((cached) => {
-      if (cached) return cached;
+  const url = new URL(event.request.url);
 
-      return fetch(event.request)
-        .then((response) => {
-          const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
-          return response;
-        })
-        .catch(() => caches.match("./index.html"));
-    })
-  );
+  if (url.origin !== self.location.origin) return;
+
+  if (url.pathname.endsWith("/operator/sw.js")) return;
+
+  if (
+    event.request.mode === "navigate" ||
+    url.pathname.endsWith("/operator/") ||
+    url.pathname.endsWith("/operator/index.html")
+  ) {
+    event.respondWith(networkFirst(event.request));
+    return;
+  }
+
+  if (url.pathname.includes("/operator/")) {
+    event.respondWith(cacheFirst(event.request));
+  }
 });


### PR DESCRIPTION
## Summary

Fixes the Operator PWA cache strategy so visual/UI updates are not trapped behind a stale cached `index.html`.

## Scope

- Updates `site/operator/sw.js` only.
- Bumps the Operator PWA cache name from `v0-1` to `v0-2`.
- Removes `./` and `./index.html` from primary pre-cache assets.
- Uses network-first behavior for navigations and `index.html`.
- Keeps cached `index.html` only as offline fallback.
- Keeps static operator assets cacheable.

## Non-goals

This PR does not add:

- visual redesign
- normalizer logic
- backend changes
- public API exposure
- external JavaScript
- analytics
- cookies
- frontend framework
- nginx
- DNS/domain changes

## Validation

Local validation:

- cache strategy strings present
- stale cache-first HTML pattern removed from navigation path
- PWA manifest parses as JSON
- `python -m pytest -q`

## Risk

Low. This is a service-worker cache strategy correction for the existing static Operator PWA. The visible effect is that future UI updates should load from network first instead of requiring a manual hard refresh.
