### PR TITLE
site: unify operator melon nuke style

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -10,27 +10,33 @@
   <style>
     :root {
       color-scheme: dark;
-      --bg: #020403;
-      --panel: #06120d;
-      --panel-2: #091a12;
-      --text: #eaffea;
-      --muted: #a6c9a8;
-      --dim: #6a8f70;
-      --phosphor: #b8ff5c;
-      --cyan: #64f4ff;
-      --amber: #ffe066;
-      --red: #ff5f7a;
-      --border: rgba(184, 255, 92, 0.36);
-      --strong: rgba(184, 255, 92, 0.72);
-      --shadow: rgba(184, 255, 92, 0.16);
-      --max: 86rem;
-      --melon-soft: #d7ff8a;
-      --melon-deep: #8fe83d;
+      --melon-nuke-rgb: 184, 255, 92;
+      --melon-nuke: rgb(var(--melon-nuke-rgb));
+      --melon-nuke-bg: #020403;
+      --melon-nuke-bg-2: #031008;
+      --melon-nuke-panel: #06120d;
+      --melon-nuke-panel-2: #091a12;
+      --melon-nuke-text: #f3ffe8;
+      --melon-nuke-muted: #ccefb5;
+      --melon-nuke-dim: #89aa71;
+      --melon-nuke-border: rgba(var(--melon-nuke-rgb), 0.36);
+      --melon-nuke-strong: rgba(var(--melon-nuke-rgb), 0.72);
+      --melon-nuke-shadow: rgba(var(--melon-nuke-rgb), 0.16);
+      --melon-nuke-soft: rgba(var(--melon-nuke-rgb), 0.12);
+      --melon-nuke-faint: rgba(var(--melon-nuke-rgb), 0.08);
+      --melon-nuke-glow: rgba(var(--melon-nuke-rgb), 0.22);
+
+      --bg: var(--melon-nuke-bg);
+      --panel: var(--melon-nuke-panel);
+      --panel-2: var(--melon-nuke-panel-2);
+      --text: var(--melon-nuke-text);
+      --muted: var(--melon-nuke-muted);
+      --dim: var(--melon-nuke-dim);
+      --border: var(--melon-nuke-border);
+      --strong: var(--melon-nuke-strong);
+      --shadow: var(--melon-nuke-shadow);
       --glass: rgba(6, 18, 13, 0.76);
-      --reactor-core: rgba(184, 255, 92, 0.22);
-      --reactor-core-soft: rgba(215, 255, 138, 0.12);
-      --reactor-amber: rgba(255, 224, 102, 0.18);
-      --containment: rgba(255, 224, 102, 0.38);
+      --max: 86rem;
     }
 
     * {
@@ -48,10 +54,10 @@
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       color: var(--text);
       background:
-        radial-gradient(circle at 50% -10%, rgba(184, 255, 92, 0.18), transparent 30rem),
-        radial-gradient(circle at 12% 8%, rgba(255, 224, 102, 0.12), transparent 24rem),
-        radial-gradient(circle at 92% 10%, rgba(100, 244, 255, 0.10), transparent 24rem),
-        radial-gradient(circle at 50% 110%, rgba(184, 255, 92, 0.09), transparent 34rem),
+        radial-gradient(circle at 50% -10%, rgba(var(--melon-nuke-rgb), 0.18), transparent 30rem),
+        radial-gradient(circle at 12% 8%, rgba(var(--melon-nuke-rgb), 0.12), transparent 24rem),
+        radial-gradient(circle at 92% 10%, rgba(var(--melon-nuke-rgb), 0.10), transparent 24rem),
+        radial-gradient(circle at 50% 110%, rgba(var(--melon-nuke-rgb), 0.09), transparent 34rem),
         linear-gradient(180deg, #020403 0%, #031008 48%, #020403 100%);
       line-height: 1.55;
     }
@@ -62,8 +68,8 @@
       inset: 0;
       pointer-events: none;
       background:
-        linear-gradient(rgba(184, 255, 92, 0.028) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(184, 255, 92, 0.02) 1px, transparent 1px);
+        linear-gradient(rgba(var(--melon-nuke-rgb), 0.028) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(var(--melon-nuke-rgb), 0.02) 1px, transparent 1px);
       background-size: 2.6rem 2.6rem;
       mask-image: radial-gradient(circle at center, black 0%, transparent 84%);
     }
@@ -85,12 +91,12 @@
     }
 
     a {
-      color: var(--phosphor);
+      color: var(--melon-nuke);
       text-decoration: none;
     }
 
     a:hover {
-      color: var(--cyan);
+      color: var(--melon-nuke);
     }
 
     button,
@@ -105,7 +111,7 @@
     textarea:focus-visible,
     select:focus-visible,
     a:focus-visible {
-      outline: 3px solid var(--cyan);
+      outline: 3px solid var(--melon-nuke);
       outline-offset: 3px;
     }
 
@@ -123,7 +129,7 @@
       gap: 0.75rem;
       flex-wrap: wrap;
       padding: 0.75rem 0 1rem;
-      border-bottom: 1px solid rgba(184, 255, 92, 0.18);
+      border-bottom: 1px solid rgba(var(--melon-nuke-rgb), 0.18);
       color: var(--dim);
       font-size: 0.72rem;
       letter-spacing: 0.12em;
@@ -136,7 +142,7 @@
       border: 1px solid var(--strong);
       border-radius: 1rem;
       background:
-        linear-gradient(135deg, rgba(184, 255, 92, 0.12), transparent 28%),
+        linear-gradient(135deg, rgba(var(--melon-nuke-rgb), 0.12), transparent 28%),
         linear-gradient(180deg, rgba(9, 26, 18, 0.96), rgba(3, 12, 8, 0.98));
       box-shadow: 0 0 3rem var(--shadow);
     }
@@ -159,7 +165,7 @@
       background:
         repeating-conic-gradient(
           from 0deg,
-          rgba(184, 255, 92, 0.10) 0deg 8deg,
+          rgba(var(--melon-nuke-rgb), 0.10) 0deg 8deg,
           transparent 8deg 18deg
         );
       opacity: 0.18;
@@ -174,23 +180,23 @@
       pointer-events: none;
       border-radius: inherit;
       box-shadow:
-        inset 0 0 2.2rem rgba(184, 255, 92, 0.10),
-        inset 0 0 0 1px rgba(255, 224, 102, 0.08);
+        inset 0 0 2.2rem rgba(var(--melon-nuke-rgb), 0.10),
+        inset 0 0 0 1px rgba(var(--melon-nuke-rgb), 0.08);
     }
 
     .reactor-core {
       display: grid;
       place-items: center;
       min-height: 16rem;
-      border: 1px solid rgba(184, 255, 92, 0.32);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.32);
       border-radius: 1rem;
       background:
-        radial-gradient(circle at 50% 50%, rgba(215, 255, 138, 0.30), transparent 0 22%),
-        radial-gradient(circle at 50% 50%, rgba(184, 255, 92, 0.12), transparent 0 42%),
+        radial-gradient(circle at 50% 50%, rgba(var(--melon-nuke-rgb), 0.30), transparent 0 22%),
+        radial-gradient(circle at 50% 50%, rgba(var(--melon-nuke-rgb), 0.12), transparent 0 42%),
         linear-gradient(180deg, rgba(2, 8, 5, 0.72), rgba(2, 8, 5, 0.92));
       box-shadow:
-        inset 0 0 2rem rgba(184, 255, 92, 0.16),
-        0 0 2rem rgba(184, 255, 92, 0.10);
+        inset 0 0 2rem rgba(var(--melon-nuke-rgb), 0.16),
+        0 0 2rem rgba(var(--melon-nuke-rgb), 0.10);
     }
 
     .core-glyph {
@@ -199,14 +205,14 @@
       display: grid;
       place-items: center;
       border-radius: 999px;
-      border: 1px solid rgba(255, 224, 102, 0.44);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.44);
       background:
         repeating-conic-gradient(
-          rgba(255, 224, 102, 0.22) 0deg 16deg,
+          rgba(var(--melon-nuke-rgb), 0.22) 0deg 16deg,
           transparent 16deg 32deg
         ),
-        radial-gradient(circle, rgba(184, 255, 92, 0.36), rgba(184, 255, 92, 0.08) 42%, transparent 43%);
-      box-shadow: 0 0 2.4rem rgba(184, 255, 92, 0.18);
+        radial-gradient(circle, rgba(var(--melon-nuke-rgb), 0.36), rgba(var(--melon-nuke-rgb), 0.08) 42%, transparent 43%);
+      box-shadow: 0 0 2.4rem rgba(var(--melon-nuke-rgb), 0.18);
     }
 
     .core-glyph b {
@@ -216,10 +222,10 @@
       aspect-ratio: 1;
       border-radius: 999px;
       color: #031008;
-      background: var(--phosphor);
+      background: var(--melon-nuke);
       font-size: 1.35rem;
       letter-spacing: -0.08em;
-      box-shadow: 0 0 1.4rem rgba(184, 255, 92, 0.32);
+      box-shadow: 0 0 1.4rem rgba(var(--melon-nuke-rgb), 0.32);
     }
 
     .reactor-band {
@@ -228,26 +234,26 @@
       gap: 0.65rem;
       margin-top: 1rem;
       padding: 0.75rem;
-      border: 1px solid rgba(255, 224, 102, 0.28);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.28);
       border-radius: 1rem;
       background:
-        linear-gradient(90deg, rgba(255, 224, 102, 0.10), transparent 32%),
+        linear-gradient(90deg, rgba(var(--melon-nuke-rgb), 0.10), transparent 32%),
         linear-gradient(180deg, rgba(6, 18, 13, 0.78), rgba(2, 8, 5, 0.84));
     }
 
     .reactor-cell {
       min-height: 5rem;
       padding: 0.75rem;
-      border: 1px solid rgba(184, 255, 92, 0.22);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.22);
       border-radius: 0.85rem;
       background:
-        linear-gradient(180deg, rgba(184, 255, 92, 0.06), transparent),
+        linear-gradient(180deg, rgba(var(--melon-nuke-rgb), 0.06), transparent),
         rgba(2, 8, 5, 0.68);
     }
 
     .reactor-cell b {
       display: block;
-      color: var(--amber);
+      color: var(--melon-nuke);
       font-size: 0.68rem;
       letter-spacing: 0.14em;
       text-transform: uppercase;
@@ -256,7 +262,7 @@
     .reactor-cell span {
       display: block;
       margin-top: 0.35rem;
-      color: var(--melon-soft);
+      color: var(--melon-nuke);
       font-weight: 900;
       letter-spacing: 0.08em;
       text-transform: uppercase;
@@ -268,10 +274,10 @@
       gap: 0.45rem;
       margin-top: 1rem;
       padding: 0.55rem 0.75rem;
-      border: 1px solid rgba(255, 224, 102, 0.44);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.44);
       border-radius: 999px;
-      color: var(--amber);
-      background: rgba(255, 224, 102, 0.08);
+      color: var(--melon-nuke);
+      background: rgba(var(--melon-nuke-rgb), 0.08);
       font-size: 0.72rem;
       font-weight: 900;
       letter-spacing: 0.12em;
@@ -280,13 +286,13 @@
 
     .warning-tag::before {
       content: "△";
-      color: var(--phosphor);
+      color: var(--melon-nuke);
     }
 
 
     .kicker {
       margin: 0 0 0.8rem;
-      color: var(--cyan);
+      color: var(--melon-nuke);
       font-size: 0.78rem;
       font-weight: 800;
       letter-spacing: 0.16em;
@@ -295,11 +301,11 @@
 
     h1 {
       margin: 0;
-      color: var(--phosphor);
+      color: var(--melon-nuke);
       font-size: clamp(2rem, 9vw, 5rem);
       line-height: 0.92;
       letter-spacing: -0.08em;
-      text-shadow: 0 0 1.5rem rgba(184, 255, 92, 0.34);
+      text-shadow: 0 0 1.5rem rgba(var(--melon-nuke-rgb), 0.34);
     }
 
     .lead {
@@ -322,8 +328,8 @@
       border: 1px solid var(--border);
       background: linear-gradient(180deg, rgba(9, 26, 18, 0.92), rgba(3, 10, 7, 0.94));
       box-shadow:
-        0 0 1.2rem rgba(184, 255, 92, 0.07),
-        inset 0 0 0 1px rgba(255, 224, 102, 0.035);
+        0 0 1.2rem rgba(var(--melon-nuke-rgb), 0.07),
+        inset 0 0 0 1px rgba(var(--melon-nuke-rgb), 0.035);
     }
 
     .chip {
@@ -342,7 +348,7 @@
     .chip span {
       display: block;
       margin-top: 0.2rem;
-      color: var(--phosphor);
+      color: var(--melon-nuke);
       font-weight: 800;
     }
 
@@ -352,10 +358,10 @@
       gap: 0.75rem;
       margin-top: 1rem;
       padding: 0.8rem;
-      border: 1px solid rgba(184, 255, 92, 0.24);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.24);
       border-radius: 1rem;
       background:
-        linear-gradient(135deg, rgba(184, 255, 92, 0.08), transparent 32%),
+        linear-gradient(135deg, rgba(var(--melon-nuke-rgb), 0.08), transparent 32%),
         rgba(2, 8, 5, 0.68);
     }
 
@@ -363,7 +369,7 @@
       position: relative;
       min-height: 7rem;
       padding: 0.85rem;
-      border: 1px solid rgba(184, 255, 92, 0.22);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.22);
       border-radius: 0.9rem;
       background: rgba(6, 18, 13, 0.72);
       overflow: hidden;
@@ -374,16 +380,16 @@
       position: absolute;
       inset: auto 0 0;
       height: 0.22rem;
-      background: rgba(184, 255, 92, 0.18);
+      background: rgba(var(--melon-nuke-rgb), 0.18);
     }
 
     .flow-step.is-active {
-      border-color: rgba(184, 255, 92, 0.72);
-      box-shadow: 0 0 1.35rem rgba(184, 255, 92, 0.13);
+      border-color: rgba(var(--melon-nuke-rgb), 0.72);
+      box-shadow: 0 0 1.35rem rgba(var(--melon-nuke-rgb), 0.13);
     }
 
     .flow-step.is-active::after {
-      background: linear-gradient(90deg, var(--melon-deep), var(--melon-soft));
+      background: linear-gradient(90deg, var(--melon-nuke), var(--melon-nuke));
     }
 
     .flow-step span {
@@ -393,7 +399,7 @@
       height: 2rem;
       border-radius: 999px;
       color: #031008;
-      background: var(--phosphor);
+      background: var(--melon-nuke);
       font-weight: 900;
     }
 
@@ -414,14 +420,14 @@
     .operator-note {
       margin-top: 1rem;
       padding: 0.9rem;
-      border: 1px dashed rgba(184, 255, 92, 0.34);
+      border: 1px dashed rgba(var(--melon-nuke-rgb), 0.34);
       border-radius: 0.85rem;
       color: var(--muted);
       background: rgba(2, 8, 5, 0.55);
     }
 
     .operator-note b {
-      color: var(--melon-soft);
+      color: var(--melon-nuke);
     }
 
     .grid {
@@ -447,7 +453,7 @@
 
     h2 {
       margin: 0 0 0.7rem;
-      color: var(--phosphor);
+      color: var(--melon-nuke);
       font-size: 0.92rem;
       letter-spacing: 0.13em;
       text-transform: uppercase;
@@ -455,7 +461,7 @@
 
     h3 {
       margin: 0 0 0.45rem;
-      color: var(--cyan);
+      color: var(--melon-nuke);
       font-size: 0.82rem;
       letter-spacing: 0.1em;
       text-transform: uppercase;
@@ -485,10 +491,10 @@
     textarea,
     select {
       width: 100%;
-      border: 1px solid rgba(184, 255, 92, 0.30);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.30);
       border-radius: 0.65rem;
       background:
-        linear-gradient(180deg, rgba(184, 255, 92, 0.035), transparent),
+        linear-gradient(180deg, rgba(var(--melon-nuke-rgb), 0.035), transparent),
         rgba(2, 8, 5, 0.82);
       color: var(--text);
       padding: 0.75rem;
@@ -513,10 +519,10 @@
     }
 
     button {
-      border: 1px solid rgba(184, 255, 92, 0.48);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.48);
       border-radius: 999px;
       background:
-        linear-gradient(180deg, rgba(184, 255, 92, 0.07), transparent),
+        linear-gradient(180deg, rgba(var(--melon-nuke-rgb), 0.07), transparent),
         rgba(2, 8, 5, 0.9);
       color: var(--text);
       cursor: pointer;
@@ -526,24 +532,24 @@
 
     button.primary {
       color: #031008;
-      background: var(--phosphor);
-      border-color: var(--phosphor);
+      background: var(--melon-nuke);
+      border-color: var(--melon-nuke);
     }
 
     button.warn {
-      color: var(--amber);
+      color: var(--melon-nuke);
       border-color: rgba(255, 209, 102, 0.55);
     }
 
     button:hover {
-      border-color: var(--cyan);
-      color: var(--cyan);
+      border-color: var(--melon-nuke);
+      color: var(--melon-nuke);
       box-shadow: 0 0 1rem rgba(77, 238, 255, 0.12);
     }
 
     button.primary:hover {
       color: #031008;
-      box-shadow: 0 0 1.2rem rgba(184, 255, 92, 0.28);
+      box-shadow: 0 0 1.2rem rgba(var(--melon-nuke-rgb), 0.28);
     }
 
     .list {
@@ -569,7 +575,7 @@
     .mini-card .remove {
       margin-top: 0.55rem;
       padding: 0.45rem 0.7rem;
-      color: var(--red);
+      color: var(--melon-nuke);
       border-color: rgba(255, 95, 122, 0.5);
     }
 
@@ -579,7 +585,7 @@
       word-break: break-word;
       color: var(--text);
       background: rgba(2, 8, 5, 0.86);
-      border: 1px solid rgba(184, 255, 92, 0.26);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.26);
       border-radius: 0.8rem;
       padding: 0.9rem;
       max-height: 28rem;
@@ -599,7 +605,7 @@
     }
 
     .output-card {
-      border: 1px solid rgba(184, 255, 92, 0.26);
+      border: 1px solid rgba(var(--melon-nuke-rgb), 0.26);
       border-radius: 0.85rem;
       padding: 0.8rem;
       background: rgba(2, 8, 5, 0.68);
@@ -616,7 +622,7 @@
       flex-wrap: wrap;
       margin-top: 1rem;
       padding-top: 1rem;
-      border-top: 1px solid rgba(184, 255, 92, 0.18);
+      border-top: 1px solid rgba(var(--melon-nuke-rgb), 0.18);
       color: var(--dim);
       font-size: 0.72rem;
       letter-spacing: 0.1em;
@@ -624,11 +630,11 @@
     }
 
     .ok {
-      color: var(--phosphor);
+      color: var(--melon-nuke);
     }
 
     .hold {
-      color: var(--amber);
+      color: var(--melon-nuke);
     }
 
     @media (max-width: 980px) {

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "hub-optimus-operator-v0-2";
+const CACHE_NAME = "hub-optimus-operator-v0-3";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./manifest.webmanifest",


### PR DESCRIPTION
## Summary

Unifies the Operator PWA visual palette into a single green melon nuke style.

## Scope

- Updates `site/operator/index.html`.
- Removes legacy mixed palette tokens such as phosphor/cyan/amber/melon-soft/melon-deep.
- Replaces raw mixed green/yellow/cyan rgba accents with one `--melon-nuke-rgb` system.
- Keeps the Operator PWA static and local.
- Bumps the Operator service worker cache name to `v0-3` so the corrected style is not trapped behind the prior shell cache.

## Non-goals

This PR does not add:

- normalizer logic
- backend changes
- public API exposure
- external JavaScript
- analytics
- cookies
- frontend framework
- nginx
- DNS/domain changes

## Validation

Local validation:

- `--melon-nuke-rgb` present
- service worker cache bumped to `v0-3`
- legacy mixed palette tokens absent
- no external script tag
- no form tag
- PWA manifest parses as JSON
- `python -m pytest -q`

## Risk

Low. This is a visual consistency and cache-version fix for the existing static Operator PWA.
