### PR TITLE
site: harden operator local analyze handoff

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -937,7 +937,7 @@
 
       <section class="panel full">
         <h2>Local analyze handoff</h2>
-        <p>Generate a copy/paste command for the secured EC2/local backend. This PWA does not call the backend directly and does not expose the API publicly.</p>
+        <p>Generate a copy/paste command for the secured EC2/local backend. The command validates the case JSON, checks local API health, saves the backend response, validates that analysis_result exists, and prints JSON ready for the output viewer. This PWA does not call the backend directly and does not expose the API publicly.</p>
         <div class="actions">
           <button class="primary" id="build_analyze_command" type="button">Build local analyze command</button>
           <button id="copy_analyze_command" type="button">Copy command</button>
@@ -1141,14 +1141,35 @@
       const payloadJson = JSON.stringify(buildPayload(), null, 2);
 
       return [
-        "cat > /tmp/hub-optimus-operator-case.json <<'JSON'",
+        "set -euo pipefail",
+        "",
+        "CASE_FILE=\"/tmp/hub-optimus-operator-case.json\"",
+        "RESPONSE_FILE=\"/tmp/hub-optimus-operator-response.json\"",
+        "",
+        "cat > \"$CASE_FILE\" <<'JSON'",
         payloadJson,
         "JSON",
         "",
-        "curl -sS -X POST http://127.0.0.1:8080/analyze \\",
+        "python3 -m json.tool \"$CASE_FILE\" >/dev/null",
+        "curl -fsS http://127.0.0.1:8080/health >/dev/null",
+        "",
+        "curl -fsS -X POST http://127.0.0.1:8080/analyze \\",
         "  -H 'Content-Type: application/json' \\",
-        "  --data-binary @/tmp/hub-optimus-operator-case.json"
-      ].join("\n");
+        "  --data-binary @\"$CASE_FILE\" \\",
+        "  -o \"$RESPONSE_FILE\"",
+        "",
+        "python3 - <<'PY_CHECK'",
+        "import json",
+        "from pathlib import Path",
+        "path = Path('/tmp/hub-optimus-operator-response.json')",
+        "data = json.loads(path.read_text(encoding='utf-8'))",
+        "if 'analysis_result' not in data:",
+        "    raise SystemExit('Missing analysis_result in backend response')",
+        "print('[OK] response saved to {}'.format(path))",
+        "print(json.dumps(data, indent=2, ensure_ascii=False))",
+        "PY_CHECK"
+      ].join("
+");
     }
 
     function updateAnalyzeCommand() {

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "hub-optimus-operator-v0-4";
+const CACHE_NAME = "hub-optimus-operator-v0-5";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./manifest.webmanifest",


### PR DESCRIPTION
## Summary

Hardens the Operator PWA local analyze handoff so the generated EC2/local command validates inputs, checks local API health, saves the backend response, verifies `analysis_result`, and prints JSON ready for the output viewer.

## Scope

- Updates `site/operator/index.html`.
- Improves the generated local analyze command.
- Adds JSON validation for the generated case file.
- Adds local `/health` preflight before `/analyze`.
- Saves the backend response to `/tmp/hub-optimus-operator-response.json`.
- Verifies that the response contains `analysis_result`.
- Bumps the Operator service worker cache to `v0-5`.

## Non-goals

This PR does not add:

- browser-side backend calls
- public API exposure
- URL fetching
- scraping
- GitHub tokens in browser
- authentication
- nginx
- DNS/domain changes
- analytics
- cookies
- external JavaScript
- frontend framework
- truth verdicts

## Validation

Local validation:

- hardened command strings present
- local `/health` preflight string present
- response file path present
- `analysis_result` guard present
- service worker cache bumped to `v0-5`
- no browser `fetch()` added
- no external script tag
- no form tag
- PWA manifest parses as JSON
- `python -m pytest -q`

## Risk

Low. This strengthens the existing static Operator handoff without exposing the backend or changing analysis semantics.
