### PR TITLE
site: fix operator product button actions

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -1268,8 +1268,7 @@
         "print('[OK] response saved to {}'.format(path))",
         "print(json.dumps(data, indent=2, ensure_ascii=False))",
         "PY_CHECK"
-      ].join("
-");
+      ].join("\n");
     }
 
     function updateAnalyzeCommand() {
@@ -1618,7 +1617,18 @@
       const sourceUrl = value("product_source_url");
 
       if (!raw) {
-        alert("Text or situation is required. URL-only fetching is not performed in the browser.");
+        const message = sourceUrl
+          ? "URL reference captured, but browser URL fetching is intentionally not performed. Paste the article text or copied content to produce a meaningful analysis draft."
+          : "Text or situation is required. Paste article text, copied content, or describe the situation.";
+
+        $("product_output").innerHTML = `
+          <section class="output-card full">
+            <h3>Input required</h3>
+            <p>${escapeHtml(message)}</p>
+            <p class="meta">No browser fetch · no scraping · no backend exposed</p>
+          </section>
+        `;
+        $("product_wait_status").textContent = "Input required before analysis.";
         return;
       }
 

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "hub-optimus-operator-v0-6";
+const CACHE_NAME = "hub-optimus-operator-v0-7";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./manifest.webmanifest",

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "site" / "operator" / "index.html"
+SW = ROOT / "site" / "operator" / "sw.js"
+
+
+def test_operator_product_buttons_have_handlers_and_no_broken_join():
+    html = INDEX.read_text(encoding="utf-8")
+
+    assert '].join("\\n");' in html
+    assert '].join("\n");' not in html
+
+    assert '$("product_analyze").addEventListener("click", runProductAnalyze);' in html
+    assert '$("product_load_news_demo").addEventListener("click", loadProductNewsDemo);' in html
+    assert '$("product_show_advanced").addEventListener("click", openAdvancedConsole);' in html
+
+
+def test_operator_product_no_browser_backend_or_external_form():
+    html = INDEX.read_text(encoding="utf-8")
+
+    assert "fetch(" not in html
+    assert "<form" not in html
+    assert "<script src=" not in html
+
+
+def test_operator_service_worker_cache_bumped_for_button_fix():
+    sw = SW.read_text(encoding="utf-8")
+
+    assert "hub-optimus-operator-v0-7" in sw


### PR DESCRIPTION
## Summary

Fixes the Operator product buttons by correcting a broken JavaScript string join that prevented the script from parsing and stopped event handlers from being registered.

## Scope

- Fixes the malformed `join("\\n")` in `site/operator/index.html`.
- Restores product button actions for:
  - `Analyze with HUB_Optimus`
  - `Load example`
  - `Advanced / Audit JSON`
- Adds visible URL-only feedback instead of leaving the product action feeling inert.
- Adds a regression test for product button handler wiring and the broken join pattern.
- Bumps the Operator service worker cache to `v0-7`.

## Non-goals

This PR does not add:

- browser-side backend calls
- public API exposure
- URL fetching
- scraping
- GitHub tokens in browser
- authentication
- nginx
- DNS/domain changes
- analytics
- cookies
- external JavaScript
- frontend framework
- truth verdicts

## Validation

Local validation:

- fixed `join("\\n")` string present
- broken multiline join absent
- product button listeners present
- URL-only feedback present
- service worker cache bumped to `v0-7`
- no browser `fetch()` added
- no external script tag
- no form tag
- PWA manifest parses as JSON
- `python -m pytest -q`

## Risk

Low. This is a product-action bugfix and regression test. It does not expose the backend or change analysis semantics.
