### PR TITLE
fix: preserve operator record identity and evidence links

### DIFF
--- a/.github/workflows/pr-safety-check.yml
+++ b/.github/workflows/pr-safety-check.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   safety-label:
@@ -15,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Classify PR risk level
         env:

--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -1073,6 +1073,57 @@
     let claims = [];
     let evidence = [];
 
+    // OPERATOR_RECORD_INTEGRITY_START
+    let recordSequences = { claim: 0, evidence: 0 };
+
+    function recordSequenceNumber(prefix, recordId) {
+      const match = new RegExp("^" + prefix + "-([0-9]+)$").exec(String(recordId || ""));
+      return match ? Number(match[1]) : 0;
+    }
+
+    function syncRecordSequences() {
+      claims.forEach((record) => {
+        recordSequences.claim = Math.max(
+          recordSequences.claim,
+          recordSequenceNumber("claim", record?.claim_id)
+        );
+      });
+      evidence.forEach((record) => {
+        recordSequences.evidence = Math.max(
+          recordSequences.evidence,
+          recordSequenceNumber("evidence", record?.evidence_id)
+        );
+      });
+    }
+
+    function nextRecordId(prefix) {
+      if (!Object.prototype.hasOwnProperty.call(recordSequences, prefix)) {
+        throw new Error("Unknown record ID prefix: " + prefix);
+      }
+
+      recordSequences[prefix] += 1;
+      return prefix + "-" + String(recordSequences[prefix]).padStart(3, "0");
+    }
+
+    function removeClaimAt(index) {
+      const [removedClaim] = claims.splice(index, 1);
+      if (removedClaim?.claim_id) {
+        evidence = evidence.map((item) => ({
+          ...item,
+          supports_claim_ids: Array.isArray(item.supports_claim_ids)
+            ? item.supports_claim_ids.filter((id) => id !== removedClaim.claim_id)
+            : [],
+          contradicts_claim_ids: Array.isArray(item.contradicts_claim_ids)
+            ? item.contradicts_claim_ids.filter((id) => id !== removedClaim.claim_id)
+            : []
+        }));
+      }
+
+      renderClaims();
+      renderEvidence();
+    }
+    // OPERATOR_RECORD_INTEGRITY_END
+
     function escapeHtml(value) {
       return String(value ?? "").replace(/[&<>"']/g, (char) => ({
         "&": "&amp;",
@@ -1093,10 +1144,6 @@
 
     function splitComma(raw) {
       return raw.split(",").map((item) => item.trim()).filter(Boolean);
-    }
-
-    function nextId(prefix, count) {
-      return `${prefix}-${String(count + 1).padStart(3, "0")}`;
     }
 
     function buildPayload() {
@@ -1192,7 +1239,7 @@
       }
 
       claims.push({
-        claim_id: nextId("claim", claims.length),
+        claim_id: nextRecordId("claim"),
         text,
         source_ref: value("claim_source") || "operator-submission",
         claim_type: value("claim_type") || "unknown",
@@ -1213,7 +1260,7 @@
       }
 
       evidence.push({
-        evidence_id: nextId("evidence", evidence.length),
+        evidence_id: nextRecordId("evidence"),
         text,
         source_ref: value("evidence_source") || "operator-submission",
         source_type: value("evidence_type") || "unknown",
@@ -1336,6 +1383,7 @@
 
       claims = Array.isArray(payload.claims) ? payload.claims : [];
       evidence = Array.isArray(payload.evidence) ? payload.evidence : [];
+      syncRecordSequences();
 
       $("inferences").value = Array.isArray(payload.inferences) ? payload.inferences.join("\n") : "";
       $("uncertainties").value = Array.isArray(payload.uncertainties) ? payload.uncertainties.join("\n") : "";
@@ -1739,6 +1787,7 @@
       $("intake_channel").value = "operator-pwa";
       claims = [];
       evidence = [];
+      recordSequences = { claim: 0, evidence: 0 };
       renderClaims();
       renderEvidence();
       $("result_input").value = "";
@@ -1862,8 +1911,7 @@
 
     document.addEventListener("click", (event) => {
       if (event.target.dataset.removeClaim !== undefined) {
-        claims.splice(Number(event.target.dataset.removeClaim), 1);
-        renderClaims();
+        removeClaimAt(Number(event.target.dataset.removeClaim));
       }
 
       if (event.target.dataset.removeEvidence !== undefined) {

--- a/tests/test_operator_pwa_record_integrity.py
+++ b/tests/test_operator_pwa_record_integrity.py
@@ -1,0 +1,136 @@
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "site" / "operator" / "index.html"
+NODE = shutil.which("node")
+
+
+def _inline_script(html: str) -> str:
+    match = re.search(r"<script>\s*(.*?)\s*</script>", html, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _record_integrity_helpers(html: str) -> str:
+    match = re.search(
+        r"// OPERATOR_RECORD_INTEGRITY_START\n(.*?)\n"
+        r"    // OPERATOR_RECORD_INTEGRITY_END",
+        html,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def _run_node(source: str, *args: str) -> subprocess.CompletedProcess[str]:
+    assert NODE is not None
+    return subprocess.run(
+        [NODE, *args],
+        input=source,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_operator_record_integrity_helpers_are_wired():
+    html = INDEX.read_text(encoding="utf-8")
+
+    assert 'claim_id: nextRecordId("claim")' in html
+    assert 'evidence_id: nextRecordId("evidence")' in html
+    assert "syncRecordSequences();" in html
+    assert "recordSequences = { claim: 0, evidence: 0 };" in html
+    assert "removeClaimAt(Number(event.target.dataset.removeClaim));" in html
+
+    removal = re.search(
+        r"function removeClaimAt\(index\) \{(.*?)\n    \}",
+        html,
+        re.DOTALL,
+    )
+    assert removal is not None
+    assert "supports_claim_ids" in removal.group(1)
+    assert "contradicts_claim_ids" in removal.group(1)
+    assert "renderClaims();" in removal.group(1)
+    assert "renderEvidence();" in removal.group(1)
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for JavaScript validation")
+def test_operator_inline_javascript_parses():
+    completed = _run_node(
+        _inline_script(INDEX.read_text(encoding="utf-8")),
+        "--check",
+        "-",
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for JavaScript validation")
+def test_operator_record_ids_and_claim_references_remain_consistent():
+    helpers = _record_integrity_helpers(INDEX.read_text(encoding="utf-8"))
+    smoke = (
+        """
+function renderClaims() {}
+function renderEvidence() {}
+
+let claims = [
+  {claim_id: "claim-001"},
+  {claim_id: "claim-002"}
+];
+let evidence = [
+  {
+    evidence_id: "evidence-001",
+    supports_claim_ids: ["claim-001", "claim-002", "claim-999"],
+    contradicts_claim_ids: ["claim-001", "claim-002"]
+  },
+  {
+    evidence_id: "evidence-004",
+    supports_claim_ids: ["claim-002"],
+    contradicts_claim_ids: []
+  }
+];
+"""
+        + helpers
+        + """
+syncRecordSequences();
+if (nextRecordId("claim") !== "claim-003") {
+  throw new Error("claim ID did not advance from the highest existing ID");
+}
+if (nextRecordId("evidence") !== "evidence-005") {
+  throw new Error("evidence ID did not advance from the highest existing ID");
+}
+
+removeClaimAt(0);
+if (claims.length !== 1 || claims[0].claim_id !== "claim-002") {
+  throw new Error("claim removal did not preserve the remaining claim");
+}
+if (evidence[0].supports_claim_ids.join(",") !== "claim-002,claim-999") {
+  throw new Error("stale support reference survived claim removal");
+}
+if (evidence[0].contradicts_claim_ids.join(",") !== "claim-002") {
+  throw new Error("stale contradiction reference survived claim removal");
+}
+
+claims = [];
+if (nextRecordId("claim") !== "claim-004") {
+  throw new Error("claim ID was reused after records were removed");
+}
+
+claims = [{claim_id: "claim-009"}];
+evidence = [{evidence_id: "evidence-007", supports_claim_ids: [], contradicts_claim_ids: []}];
+syncRecordSequences();
+if (nextRecordId("claim") !== "claim-010") {
+  throw new Error("loaded claim IDs did not advance the sequence baseline");
+}
+if (nextRecordId("evidence") !== "evidence-008") {
+  throw new Error("loaded evidence IDs did not advance the sequence baseline");
+}
+"""
+    )
+    completed = _run_node(smoke, "-")
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
## Summary

- keep claim/evidence IDs monotonic for the active operator session
- sync counters from loaded payloads without reusing deleted IDs
- prune deleted claim IDs from evidence support/contradiction links
- add executable regression coverage and full inline-script parsing
- make PR Safety Check resolve diffs reliably on PR checkouts

## Validation

- local full suite: `63 passed`
- `node --check` on the full inline script
- Node behavioral smoke for add/delete/load flows
- mojibake check and `git diff --check`
- GitHub Actions: CI, PR Safety Check, Kernel Guard, and Link Check all green