### PR TITLE
site: add operator local memory and share snapshots

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -7,6 +7,13 @@
   <meta name="description" content="Installable HUB_Optimus operator console for composing structured cases and reviewing analysis outputs.">
   <meta name="theme-color" content="#020403">
   <link rel="manifest" href="./manifest.webmanifest">
+  <meta property="og:title" content="HUB_Optimus Operator">
+  <meta property="og:description" content="Signal intake, claim/evidence separation, uncertainty mapping, and safe operational scenarios.">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://huboptimus.dev/operator/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="theme-color" content="#b8ff5c">
+
   <style>
     :root {
       color-scheme: dark;
@@ -760,6 +767,21 @@
     }
 
 
+    .memory-actions {
+      margin-top: 1rem;
+    }
+
+    .memory-status {
+      color: var(--muted);
+      margin: 0.85rem 0 0;
+    }
+
+    .memory-status.ok {
+      color: var(--melon-nuke);
+      font-weight: 900;
+    }
+
+
   </style>
 </head>
 <body>
@@ -908,6 +930,13 @@
           <p class="empty">No signal analyzed yet.</p>
         </section>
       </div>
+
+      <div class="actions memory-actions">
+        <button id="save_memory_result" type="button">Save result memory</button>
+        <button id="share_memory_link" type="button">Share memory link</button>
+        <button id="share_memory_whatsapp" type="button">Share to WhatsApp</button>
+      </div>
+      <p class="memory-status" id="memory_status">No saved memory result yet.</p>
     </section>
 
     <details class="advanced-shell" id="advanced_operator_console">
@@ -1125,6 +1154,8 @@
   <script>
     const $ = (id) => document.getElementById(id);
     const storageKey = "hub_optimus_operator_case_v1";
+    const memoryKey = "hub_optimus_operator_memory_v1";
+    let currentMemoryRecord = null;
 
     let claims = [];
     let evidence = [];
@@ -1925,6 +1956,183 @@
       `;
     }
 
+    function loadMemoryRecords() {
+      try {
+        return JSON.parse(localStorage.getItem(memoryKey) || "[]");
+      } catch {
+        return [];
+      }
+    }
+
+    function saveMemoryRecords(records) {
+      localStorage.setItem(memoryKey, JSON.stringify(records.slice(0, 20)));
+    }
+
+    function hasShareableResult() {
+      const outputText = $("product_output").textContent.trim();
+
+      return Boolean(
+        outputText &&
+        !outputText.includes("No signal analyzed yet") &&
+        !outputText.includes("Input required")
+      );
+    }
+
+    function buildMemoryRecord() {
+      const payload = buildPayload();
+      const profile = buildSourceProfile(value("source_text"), value("signal_source_type") || "human-situation", value("source_url"));
+      const claim = payload.claims?.[0]?.text || "No claim generated.";
+      const evidenceText = payload.evidence?.[0]?.text || "No evidence generated.";
+
+      return {
+        version: "operator-memory-v0.1",
+        saved_at_utc: new Date().toISOString(),
+        source_url: value("product_source_url") || value("source_url") || null,
+        source_type: value("signal_source_type") || "human-situation",
+        signal_domain: profile.domain.id,
+        signal_domain_label: profile.domain.label,
+        actors: profile.actors,
+        operational_signal: payload.operational_signal || "triage",
+        summary: payload.input_summary || profile.summary,
+        claim: compactText(claim, 420),
+        evidence: compactText(evidenceText, 520),
+        uncertainty: compactText((payload.uncertainties || []).join(" "), 360),
+        amplification: compactText((payload.narrative_amplification || []).join(" "), 360),
+        safe_next_action: "Review primary sources, preserve uncertainty, and convert into a versioned claim only after human review.",
+        learning_status: "candidate-signal-not-canonical",
+        backend_run: false
+      };
+    }
+
+    function renderMemoryStatus(message, ok = false) {
+      const node = $("memory_status");
+      if (!node) return;
+      node.textContent = message;
+      node.classList.toggle("ok", Boolean(ok));
+    }
+
+    function saveCurrentMemoryResult() {
+      if (!hasShareableResult()) {
+        renderMemoryStatus("No result to save yet. Run Analyze with HUB_Optimus first.", false);
+        return null;
+      }
+
+      const record = buildMemoryRecord();
+      const records = loadMemoryRecords();
+      records.unshift(record);
+      saveMemoryRecords(records);
+
+      currentMemoryRecord = record;
+      renderMemoryStatus(`Saved memory result: ${record.saved_at_utc}`, true);
+
+      return record;
+    }
+
+    function base64UrlEncode(value) {
+      return btoa(unescape(encodeURIComponent(value)))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/g, "");
+    }
+
+    function base64UrlDecode(value) {
+      const padded = `${value}${"=".repeat((4 - value.length % 4) % 4)}`
+        .replace(/-/g, "+")
+        .replace(/_/g, "/");
+
+      return decodeURIComponent(escape(atob(padded)));
+    }
+
+    function buildShareSnapshot(record) {
+      return {
+        v: 1,
+        type: "hub-optimus-operator-memory",
+        saved_at_utc: record.saved_at_utc,
+        source_url: record.source_url,
+        domain: record.signal_domain_label,
+        actors: record.actors,
+        signal: record.operational_signal,
+        summary: compactText(record.summary, 300),
+        claim: compactText(record.claim, 360),
+        evidence: compactText(record.evidence, 360),
+        uncertainty: compactText(record.uncertainty, 260),
+        safe_next_action: compactText(record.safe_next_action, 240),
+        learning_status: record.learning_status
+      };
+    }
+
+    function buildMemoryShareUrl(record) {
+      const snapshot = base64UrlEncode(JSON.stringify(buildShareSnapshot(record)));
+      return `${window.location.origin}${window.location.pathname}#memory=${snapshot}`;
+    }
+
+    function currentShareableMemory() {
+      return currentMemoryRecord || saveCurrentMemoryResult();
+    }
+
+    async function shareMemoryLink() {
+      const record = currentShareableMemory();
+      if (!record) return;
+
+      const url = buildMemoryShareUrl(record);
+
+      try {
+        await navigator.clipboard.writeText(url);
+        renderMemoryStatus("Share link copied. It contains a compact result snapshot.", true);
+      } catch {
+        renderMemoryStatus(url, true);
+      }
+    }
+
+    function shareMemoryWhatsapp() {
+      const record = currentShareableMemory();
+      if (!record) return;
+
+      const url = buildMemoryShareUrl(record);
+      const shareText = [
+        "HUB_Optimus Operator memory",
+        record.signal_domain_label,
+        record.claim,
+        url
+      ].filter(Boolean).join("\n\n");
+
+      window.open(`https://wa.me/?text=${encodeURIComponent(shareText)}`, "_blank", "noopener,noreferrer");
+      renderMemoryStatus("WhatsApp share opened with compact memory snapshot.", true);
+    }
+
+    function renderSharedMemorySnapshot(snapshot) {
+      $("product_output").innerHTML = `
+        <section class="output-card full">
+          <h3>Shared HUB_Optimus memory</h3>
+          <p><b>Domain:</b> ${escapeHtml(snapshot.domain || "not provided")}</p>
+          <p><b>Actors:</b> ${escapeHtml((snapshot.actors || []).join(", ") || "not provided")}</p>
+          <p><b>Signal:</b> ${escapeHtml(snapshot.signal || "not provided")}</p>
+          <p><b>Summary:</b> ${escapeHtml(snapshot.summary || "not provided")}</p>
+          <p><b>Claim:</b> ${escapeHtml(snapshot.claim || "not provided")}</p>
+          <p><b>Evidence:</b> ${escapeHtml(snapshot.evidence || "not provided")}</p>
+          <p><b>Uncertainty:</b> ${escapeHtml(snapshot.uncertainty || "not provided")}</p>
+          <p><b>Safe next action:</b> ${escapeHtml(snapshot.safe_next_action || "not provided")}</p>
+          <p class="meta">learning_status=${escapeHtml(snapshot.learning_status || "candidate-signal-not-canonical")} · shared snapshot · no truth verdict</p>
+        </section>
+      `;
+
+      renderMemoryStatus("Shared memory snapshot loaded. It is not canonical until reviewed/versioned in GitHub.", true);
+      window.location.hash = "product_output";
+    }
+
+    function loadSharedMemoryFromHash() {
+      const match = window.location.hash.match(/memory=([^&]+)/);
+      if (!match) return;
+
+      try {
+        const snapshot = JSON.parse(base64UrlDecode(match[1]));
+        if (snapshot?.type !== "hub-optimus-operator-memory") return;
+        renderSharedMemorySnapshot(snapshot);
+      } catch {
+        renderMemoryStatus("Could not load shared memory snapshot.", false);
+      }
+    }
+
     async function runProductAnalyze() {
       const raw = value("product_source_text");
       const sourceUrl = value("product_source_url");
@@ -1976,6 +2184,7 @@
 
       await loaderTask;
       renderProductOutput();
+      currentMemoryRecord = saveCurrentMemoryResult();
 
       productStep("product_step_output", "done");
       $("product_wait_status").textContent = "Analysis draft ready. Backend analysis remains available in Advanced / Audit JSON.";
@@ -2200,6 +2409,9 @@
       "narrative_amplification"
     ].forEach((id) => $(id).addEventListener("input", updateJson));
 
+    $("save_memory_result").addEventListener("click", saveCurrentMemoryResult);
+    $("share_memory_link").addEventListener("click", shareMemoryLink);
+    $("share_memory_whatsapp").addEventListener("click", shareMemoryWhatsapp);
     $("product_analyze").addEventListener("click", runProductAnalyze);
     $("product_load_news_demo").addEventListener("click", loadProductNewsDemo);
     $("product_show_advanced").addEventListener("click", openAdvancedConsole);
@@ -2224,6 +2436,7 @@
     buildProductLoader();
     setProductLoader(0, "idle");
     updateJson();
+    loadSharedMemoryFromHash();
 
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/site/operator/og.svg
+++ b/site/operator/og.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="HUB Optimus Operator">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#b8ff5c" stop-opacity="0.42"/>
+      <stop offset="48%" stop-color="#06120d" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#020403" stop-opacity="1"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="#020403"/>
+  <rect x="48" y="48" width="1104" height="534" rx="34" fill="url(#g)" stroke="#b8ff5c" stroke-width="3"/>
+  <circle cx="930" cy="315" r="112" fill="none" stroke="#b8ff5c" stroke-width="18" stroke-dasharray="22 18"/>
+  <circle cx="930" cy="315" r="66" fill="#b8ff5c"/>
+  <text x="930" y="330" text-anchor="middle" font-family="monospace" font-size="38" font-weight="900" fill="#020403">HO</text>
+  <text x="92" y="180" font-family="monospace" font-size="34" font-weight="900" fill="#b8ff5c">HUB_OPTIMUS // OPERATOR_MEMORY</text>
+  <text x="92" y="282" font-family="monospace" font-size="76" font-weight="900" fill="#f3ffe8">Signal → Evidence</text>
+  <text x="92" y="368" font-family="monospace" font-size="76" font-weight="900" fill="#f3ffe8">Uncertainty → Action</text>
+  <text x="92" y="488" font-family="monospace" font-size="30" fill="#ccefb5">No truth verdict. Candidate signal until reviewed.</text>
+</svg>

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,8 +1,9 @@
-const CACHE_NAME = "hub-optimus-operator-v0-9";
+const CACHE_NAME = "hub-optimus-operator-v0-10";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./manifest.webmanifest",
-  "./icon.svg"
+  "./icon.svg",
+  "./og.svg"
 ];
 
 async function cacheStaticAssets() {

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -34,7 +34,7 @@ def test_operator_product_loader_pacing_present():
     assert "runMelonLoaderPlan" in html
     assert "assembling possible scenarios" in html
     assert "rendering final output" in html
-    assert "hub-optimus-operator-v0-9" in sw
+    assert "hub-optimus-operator-v0-10" in sw
 
 
 def test_operator_source_intelligence_v2_present():
@@ -47,4 +47,21 @@ def test_operator_source_intelligence_v2_present():
     assert "operator-source-intelligence-v0.2" in html
     assert "HUB_Optimus procedure" in html
     assert "evidence lock" in html
-    assert "hub-optimus-operator-v0-9" in sw
+    assert "hub-optimus-operator-v0-10" in sw
+
+
+def test_operator_memory_share_snapshot_present():
+    html = INDEX.read_text(encoding="utf-8")
+    sw = SW.read_text(encoding="utf-8")
+
+    assert "hub_optimus_operator_memory_v1" in html
+    assert "Save result memory" in html
+    assert "Share memory link" in html
+    assert "Share to WhatsApp" in html
+    assert "candidate-signal-not-canonical" in html
+    assert "buildMemoryShareUrl" in html
+    assert "loadSharedMemoryFromHash" in html
+    assert "https://wa.me/" in html
+    assert "og:title" in html
+    assert "hub-optimus-operator-v0-10" in sw
+    assert "./og.svg" in sw


### PR DESCRIPTION
## Summary

Adds local Operator memory and share snapshots for analyzed results.

## Scope

- Saves analyzed result memory locally after output exists.
- Adds `Save result memory`.
- Adds `Share memory link`.
- Adds `Share to WhatsApp`.
- Prevents sharing when no result memory exists.
- Encodes a compact share snapshot in the URL hash.
- Loads shared memory snapshots from the URL hash.
- Marks shared records as `candidate-signal-not-canonical`.
- Adds static Optimus Operator nuke-style OG metadata and image.
- Keeps backend private and does not upload memory to a server.
- Bumps Operator service worker cache to `v0-10`.

## Non-goals

This PR does not add:

- server-side storage
- public database
- dynamic OG per result
- automatic learning/training
- browser-side backend calls
- public API exposure
- URL fetching
- scraping
- GitHub tokens in browser
- authentication
- analytics
- cookies
- external JavaScript
- truth verdicts

## Validation

Local validation:

- memory/share strings present
- WhatsApp share intent present
- shared snapshot loader present
- candidate-signal marker present
- OG metadata/image present
- service worker cache bumped to `v0-10`
- no browser `fetch()` added
- no external script tag
- no form tag
- PWA manifest parses as JSON
- `python -m pytest -q`

## Risk

Medium. This introduces shareable local snapshots. The snapshot is intentionally compact and marked as non-canonical. Canonical learning still requires human review and versioning through GitHub.
