### PR TITLE
ops: sync hub-api launcher during deploy

### DIFF
--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -9,7 +9,7 @@ RELEASE_DIR="$APP_ROOT/releases/$RELEASE_ID"
 echo "[deploy] Starting HUB_Optimus deploy"
 echo "[deploy] Release: $RELEASE_ID"
 
-mkdir -p "$APP_ROOT/releases" "$APP_ROOT/shared/logs"
+mkdir -p "$APP_ROOT/releases" "$APP_ROOT/shared/logs" "$APP_ROOT/shared/bin"
 
 if [ -e "$RELEASE_DIR" ]; then
   echo "[deploy:error] Release directory already exists: $RELEASE_DIR"
@@ -37,6 +37,12 @@ deactivate
 echo "[deploy] Hiding local venv from git status"
 grep -qxF ".venv/" "$RELEASE_DIR/.git/info/exclude" || echo ".venv/" >> "$RELEASE_DIR/.git/info/exclude"
 
+echo "[deploy] Verifying hub-api launcher source"
+if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then
+  echo "[deploy:error] Missing hub-api launcher source: $RELEASE_DIR/ops/ec2/hub-api.sh"
+  exit 1
+fi
+
 if [ -L "$APP_ROOT/current" ]; then
   PREVIOUS="$(readlink -f "$APP_ROOT/current")"
   echo "$PREVIOUS" > "$APP_ROOT/shared/previous_release"
@@ -48,6 +54,9 @@ fi
 echo "[deploy] Switching current symlink"
 ln -sfn "$RELEASE_DIR" "$APP_ROOT/current.new"
 mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
+
+echo "[deploy] Syncing hub-api launcher"
+install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"
 
 cd "$APP_ROOT/current"
 

--- a/tests/test_ec2_deploy_hub_api_sync.py
+++ b/tests/test_ec2_deploy_hub_api_sync.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
+SERVICE = ROOT / "ops" / "ec2" / "hub-api.service"
+
+
+def test_deploy_syncs_hub_api_launcher_into_shared_bin():
+    text = DEPLOY.read_text(encoding="utf-8")
+
+    assert '"$APP_ROOT/shared/bin"' in text
+    assert "[deploy] Verifying hub-api launcher source" in text
+    assert 'if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then' in text
+    assert "[deploy:error] Missing hub-api launcher source" in text
+    assert "[deploy] Syncing hub-api launcher" in text
+    assert 'install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"' in text
+
+
+def test_deploy_syncs_launcher_after_current_symlink_switch():
+    text = DEPLOY.read_text(encoding="utf-8")
+
+    verify_source = text.index('if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then')
+    switch_current = text.index('echo "[deploy] Switching current symlink"')
+    move_current = text.index('mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"')
+    install_launcher = text.index('install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"')
+
+    assert verify_source < switch_current
+    assert move_current < install_launcher
+
+
+def test_systemd_execstart_uses_synced_shared_launcher():
+    text = SERVICE.read_text(encoding="utf-8")
+
+    assert "ExecStart=/opt/hub-optimus/shared/bin/hub-api" in text


### PR DESCRIPTION
## Summary

Ensures deploy syncs the versioned `hub-api` launcher into the shared path used by systemd.

## Scope

- Updates `ops/ec2/deploy-current.sh`.
- Ensures `$APP_ROOT/shared/bin` exists.
- Verifies the release contains `ops/ec2/hub-api.sh`.
- After switching `/opt/hub-optimus/current`, installs the current release launcher to `/opt/hub-optimus/shared/bin/hub-api`.
- Adds regression coverage for deploy/runtime alignment.

## Non-goals

This PR does not add:

- new API endpoints
- UI changes
- public API exposure
- nginx/DNS changes
- URL intake behavior changes
- service unit changes
- deployment architecture rewrite

## Validation

Local validation:

- deploy sync strings present
- `python -m pytest -q`

## Risk

Low. This only aligns the shared systemd launcher with the currently deployed release.
