### PR TITLE
ops: add controlled Operator API proxy config

### DIFF
--- a/ops/ec2/nginx/operator-api.conf
+++ b/ops/ec2/nginx/operator-api.conf
@@ -1,0 +1,76 @@
+# HUB_Optimus Operator controlled public API proxy.
+#
+# Intended install path:
+#   /etc/nginx/conf.d/hub-optimus-operator-api.conf
+#
+# DNS requirement:
+#   api.huboptimus.dev -> EC2 public IPv4
+#
+# TLS requirement:
+#   Use certbot/nginx after DNS resolves.
+#
+# Boundary:
+#   Publicly expose only controlled URL intake and health.
+#   Do not expose /analyze, /status, runs, files, shell, or arbitrary backend paths.
+
+limit_req_zone $binary_remote_addr zone=hub_optimus_url_intake:10m rate=12r/m;
+
+map $http_origin $hub_optimus_cors_origin {
+    default "";
+    "https://huboptimus.dev" $http_origin;
+    "https://www.huboptimus.dev" $http_origin;
+}
+
+server {
+    listen 80;
+    server_name api.huboptimus.dev;
+
+    client_max_body_size 8k;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+
+    location = /health {
+        proxy_pass http://127.0.0.1:8080/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location = /intake/url {
+        if ($request_method !~ ^(POST|OPTIONS)$) {
+            return 405;
+        }
+
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $hub_optimus_cors_origin always;
+            add_header Access-Control-Allow-Methods "POST, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Content-Type" always;
+            add_header Access-Control-Max-Age 600 always;
+            add_header Vary "Origin" always;
+            return 204;
+        }
+
+        limit_req zone=hub_optimus_url_intake burst=6 nodelay;
+
+        add_header Access-Control-Allow-Origin $hub_optimus_cors_origin always;
+        add_header Access-Control-Allow-Methods "POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type" always;
+        add_header Vary "Origin" always;
+
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 15s;
+        proxy_send_timeout 15s;
+
+        proxy_pass http://127.0.0.1:8080/intake/url;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/tests/test_ec2_operator_api_proxy_config.py
+++ b/tests/test_ec2_operator_api_proxy_config.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "ops" / "ec2" / "nginx" / "operator-api.conf"
+
+
+def test_operator_api_proxy_exposes_only_controlled_intake_and_health():
+    text = CONFIG.read_text(encoding="utf-8")
+
+    assert "server_name api.huboptimus.dev;" in text
+    assert "location = /intake/url" in text
+    assert "proxy_pass http://127.0.0.1:8080/intake/url;" in text
+    assert "location = /health" in text
+    assert "proxy_pass http://127.0.0.1:8080/health;" in text
+    assert "location /" in text
+    assert "return 404;" in text
+    assert "location = /analyze" not in text
+    assert "location /analyze" not in text
+    assert "proxy_pass http://127.0.0.1:8080/analyze" not in text
+    assert "location = /status" not in text
+    assert "location /status" not in text
+    assert "proxy_pass http://127.0.0.1:8080/status" not in text
+
+
+def test_operator_api_proxy_has_cors_boundary_for_operator_origin():
+    text = CONFIG.read_text(encoding="utf-8")
+
+    assert '"https://huboptimus.dev" $http_origin;' in text
+    assert '"https://www.huboptimus.dev" $http_origin;' in text
+    assert "Access-Control-Allow-Origin $hub_optimus_cors_origin" in text
+    assert 'Access-Control-Allow-Methods "POST, OPTIONS"' in text
+    assert 'Access-Control-Allow-Headers "Content-Type"' in text
+    assert 'Vary "Origin"' in text
+
+
+def test_operator_api_proxy_has_abuse_and_size_limits():
+    text = CONFIG.read_text(encoding="utf-8")
+
+    assert "limit_req_zone $binary_remote_addr zone=hub_optimus_url_intake:10m rate=12r/m;" in text
+    assert "limit_req zone=hub_optimus_url_intake burst=6 nodelay;" in text
+    assert "client_max_body_size 8k;" in text
+    assert "proxy_connect_timeout 3s;" in text
+    assert "proxy_read_timeout 15s;" in text
+    assert "proxy_send_timeout 15s;" in text
+
+
+def test_operator_api_proxy_documents_dns_tls_and_boundary():
+    text = CONFIG.read_text(encoding="utf-8")
+
+    assert "DNS requirement:" in text
+    assert "api.huboptimus.dev -> EC2 public IPv4" in text
+    assert "TLS requirement:" in text
+    assert "Publicly expose only controlled URL intake and health." in text
+    assert "Do not expose /analyze" in text


### PR DESCRIPTION
## Summary

Adds a versioned nginx config for a controlled public Operator API proxy.

## Scope

- Adds `ops/ec2/nginx/operator-api.conf`.
- Defines `api.huboptimus.dev` as the public API host.
- Proxies only:
  - `/health`
  - `/intake/url`
- Keeps `/analyze`, `/status`, runs, files, and arbitrary backend paths private.
- Adds CORS only for `https://huboptimus.dev` and `https://www.huboptimus.dev`.
- Adds request size, timeout, and rate-limit boundaries.
- Adds regression tests for proxy boundary, CORS, and abuse controls.

## Non-goals

This PR does not add:

- UI changes
- DNS changes
- TLS certificate issuance
- nginx installation
- public exposure of `/analyze`
- backend logic changes
- crawler behavior
- scraping expansion
- storage changes

## Validation

Local validation:

- proxy boundary strings present
- `python -m pytest -q`

## Post-merge deployment notes

After merge, runtime setup still requires:

1. DNS A record: `api.huboptimus.dev -> EC2 public IPv4`.
2. nginx installed on EC2.
3. config installed under `/etc/nginx/conf.d/`.
4. TLS issued with certbot/nginx.
5. smoke test:
   - `https://api.huboptimus.dev/health`
   - `POST https://api.huboptimus.dev/intake/url`

## Risk

Medium. This prepares public ingress, but keeps the public surface intentionally narrow and does not expose analysis or internal status.
