### PR TITLE
site: enable URL-only controlled intake fallback

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -903,20 +903,20 @@
 
     <section class="panel full product-intake" id="product_intake">
       <h2>Analyze with HUB_Optimus</h2>
-      <p class="product-lede">Paste a source and HUB_Optimus will separate claim, evidence, inference, uncertainty, narrative amplification, and safe next action. URL reading is handled as a controlled backend step; for now, paste the article text or situation below.</p>
+      <p class="product-lede">Paste a URL or article text. HUB_Optimus will try controlled URL intake first, then separate claim, evidence, inference, uncertainty, narrative amplification, and safe next action. If a source blocks controlled intake, paste the article text below.</p>
 
       <div class="row">
         <div class="field">
           <label for="product_source_url">Source URL</label>
           <input id="product_source_url" placeholder="https://example.com/news-or-github-source">
-          <p class="field-hint">Used as source reference. Controlled URL reading is the next backend step; the browser does not scrape pages.</p>
+          <p class="field-hint">Used for controlled URL intake. If the source blocks access, paste the article text below.</p>
         </div>
       </div>
 
       <div class="field">
         <label for="product_source_text">Article text or situation to analyze</label>
         <textarea id="product_source_text" placeholder="Paste the article text, copied post, GitHub issue body, CI failure excerpt, or describe the situation here."></textarea>
-        <p class="field-hint">Required for analysis until controlled URL intake is added.</p>
+        <p class="field-hint">Optional when a URL is available. Required only if the URL cannot be read from controlled intake.</p>
       </div>
 
       <div class="actions">
@@ -2054,6 +2054,8 @@
       });
     }
 
+    const CONTROLLED_URL_INTAKE_ENDPOINT = "https://api.huboptimus.dev/intake/url";
+
     function syncProductInputState() {
       const raw = value("product_source_text");
       const sourceUrl = value("product_source_url");
@@ -2067,10 +2069,58 @@
         return;
       }
 
+      if (sourceUrl) {
+        analyzeButton.disabled = false;
+        $("product_wait_status").textContent = "Ready to read URL from controlled intake. If the source blocks access, paste the article text.";
+        return;
+      }
+
       analyzeButton.disabled = true;
-      $("product_wait_status").textContent = sourceUrl
-        ? "URL captured. Paste the article text below to analyze."
-        : "Paste text or load the example to begin.";
+      $("product_wait_status").textContent = "Paste a URL, paste text, or load the example to begin.";
+    }
+
+    function renderUrlIntakeFallback(sourceUrl, detail = "") {
+      const detailLine = detail ? `<p class="meta">${escapeHtml(detail)}</p>` : "";
+      $("product_output").innerHTML = `
+        <section class="output-card full">
+          <h3>URL not accessible from controlled intake</h3>
+          <p>The URL could not be read from the controlled HUB_Optimus origin. Paste the article text or relevant excerpt below and run Analyze again.</p>
+          <p>This does not mean the source is false or invalid. Some sources block automated access, DNS may not be ready, or the origin may reject cross-origin requests.</p>
+          ${detailLine}
+          <p class="meta">No browser scraping · no paywall bypass · source remains unreviewed</p>
+        </section>
+      `;
+      $("product_wait_status").textContent = "URL unavailable from controlled intake. Paste text to analyze.";
+      $("product_source_text").focus();
+      setMemoryActionsEnabled(false);
+    }
+
+    async function readControlledUrlText(sourceUrl) {
+      let response;
+      try {
+        response = await fetch(CONTROLLED_URL_INTAKE_ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ url: sourceUrl })
+        });
+      } catch (error) {
+        throw new Error(`Controlled intake service is unreachable: ${error.message}`);
+      }
+
+      let payload;
+      try {
+        payload = await response.json();
+      } catch {
+        throw new Error(`Controlled intake returned HTTP ${response.status} without readable JSON.`);
+      }
+
+      if (!response.ok || payload.status !== "ok" || !payload.text) {
+        throw new Error(payload.message || payload.error || `Controlled intake returned HTTP ${response.status}.`);
+      }
+
+      return payload;
     }
 
     function saveCurrentMemoryResult() {
@@ -2198,22 +2248,18 @@
     }
 
     async function runProductAnalyze() {
-      const raw = value("product_source_text");
+      let raw = value("product_source_text");
       const sourceUrl = value("product_source_url");
 
-      if (!raw) {
-        const message = sourceUrl
-          ? "URL reference captured, but browser URL fetching is intentionally not performed. Paste the article text or copied content to produce a meaningful analysis draft."
-          : "Text or situation is required. Paste article text, copied content, or describe the situation.";
-
+      if (!raw && !sourceUrl) {
         $("product_output").innerHTML = `
           <section class="output-card full">
             <h3>Input required</h3>
-            <p>${escapeHtml(message)}</p>
-            <p class="meta">No browser fetch · no scraping · no backend exposed</p>
+            <p>Paste a URL, article text, copied content, or describe the situation.</p>
+            <p class="meta">No browser scraping · no paywall bypass · no truth verdict</p>
           </section>
         `;
-        $("product_wait_status").textContent = "Paste text to enable analysis.";
+        $("product_wait_status").textContent = "Paste a URL or text to enable analysis.";
         setMemoryActionsEnabled(false);
         return;
       }
@@ -2221,6 +2267,23 @@
       resetProductProgress();
       setMemoryActionsEnabled(false);
       currentMemoryRecord = null;
+
+      if (!raw && sourceUrl) {
+        productStep("product_step_capture", "running");
+        $("product_wait_status").textContent = "Reading URL through controlled intake…";
+        setProductLoader(1, "controlled URL intake");
+
+        try {
+          const intake = await readControlledUrlText(sourceUrl);
+          raw = intake.text;
+          $("product_source_text").value = raw;
+          $("product_wait_status").textContent = "URL read successfully. Preparing analysis…";
+        } catch (error) {
+          productStep("product_step_capture", "done");
+          renderUrlIntakeFallback(sourceUrl, error.message);
+          return;
+        }
+      }
 
       $("source_url").value = sourceUrl;
       $("source_text").value = raw;

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "hub-optimus-operator-v0-12";
+const CACHE_NAME = "hub-optimus-operator-v0-13";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./manifest.webmanifest",

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -17,10 +17,14 @@ def test_operator_product_buttons_have_handlers_and_no_broken_join():
     assert '$("product_show_advanced").addEventListener("click", openAdvancedConsole);' in html
 
 
-def test_operator_product_no_browser_backend_or_external_form():
+def test_operator_product_uses_only_controlled_url_intake_fetch_and_no_external_form():
     html = INDEX.read_text(encoding="utf-8")
 
-    assert "fetch(" not in html
+    assert "CONTROLLED_URL_INTAKE_ENDPOINT" in html
+    assert "https://api.huboptimus.dev/intake/url" in html
+    assert "fetch(CONTROLLED_URL_INTAKE_ENDPOINT" in html
+    assert "fetch(sourceUrl" not in html
+    assert "fetch(url" not in html
     assert "<form" not in html
     assert "<script src=" not in html
 
@@ -34,7 +38,7 @@ def test_operator_product_loader_pacing_present():
     assert "runMelonLoaderPlan" in html
     assert "assembling possible scenarios" in html
     assert "rendering final output" in html
-    assert "hub-optimus-operator-v0-12" in sw
+    assert "hub-optimus-operator-v0-13" in sw
 
 
 def test_operator_source_intelligence_v2_present():
@@ -47,7 +51,7 @@ def test_operator_source_intelligence_v2_present():
     assert "operator-source-intelligence-v0.2" in html
     assert "HUB_Optimus procedure" in html
     assert "evidence lock" in html
-    assert "hub-optimus-operator-v0-12" in sw
+    assert "hub-optimus-operator-v0-13" in sw
 
 
 def test_operator_memory_share_snapshot_present():
@@ -63,7 +67,7 @@ def test_operator_memory_share_snapshot_present():
     assert "loadSharedMemoryFromHash" in html
     assert "https://wa.me/" in html
     assert "og:title" in html
-    assert "hub-optimus-operator-v0-12" in sw
+    assert "hub-optimus-operator-v0-13" in sw
     assert "./og.svg" in sw
 
 
@@ -74,7 +78,7 @@ def test_operator_install_icon_reactor_mark_present():
     assert "Melon nuke reactor icon" in icon
     assert "url(#segment)" in icon
     assert ">HO</text>" in icon
-    assert "hub-optimus-operator-v0-12" in sw
+    assert "hub-optimus-operator-v0-13" in sw
 
 
 def test_operator_product_ux_controls_are_gated():
@@ -87,8 +91,22 @@ def test_operator_product_ux_controls_are_gated():
     assert 'id="share_memory_whatsapp" type="button" disabled' in html
     assert "setMemoryActionsEnabled" in html
     assert "syncProductInputState" in html
-    assert "URL captured. Paste the article text below to analyze." in html
+    assert "Ready to read URL from controlled intake. If the source blocks access, paste the article text." in html
     assert "Result ready. Memory and sharing are available." in html
     assert ".status-strip" in html
     assert ".reactor-band" in html
-    assert "hub-optimus-operator-v0-12" in sw
+    assert "hub-optimus-operator-v0-13" in sw
+
+
+def test_operator_url_only_fallback_message_present():
+    html = INDEX.read_text(encoding="utf-8")
+    sw = SW.read_text(encoding="utf-8")
+
+    assert "URL not accessible from controlled intake" in html
+    assert "Paste the article text or relevant excerpt below and run Analyze again." in html
+    assert "Some sources block automated access" in html
+    assert "Controlled intake service is unreachable" in html
+    assert "readControlledUrlText" in html
+    assert "renderUrlIntakeFallback" in html
+    assert "Ready to read URL from controlled intake" in html
+    assert "hub-optimus-operator-v0-13" in sw


### PR DESCRIPTION
## Summary

Enables the Operator Analyze button when a URL is present and adds a controlled-intake fallback when the URL cannot be read.

## Scope

- Allows URL-only input to activate Analyze.
- Adds a single controlled intake endpoint constant: `https://api.huboptimus.dev/intake/url`.
- Calls only the controlled HUB_Optimus intake endpoint, never the user-provided URL directly from the browser.
- If controlled intake succeeds, uses extracted text for the existing local analysis flow.
- If controlled intake fails because DNS/CORS/origin/source blocks access, renders a clear message asking the user to paste article text.
- Updates copy so users understand that source blocking does not mean the source is false.
- Bumps Operator service worker cache to `v0-13`.
- Adds regression coverage for the URL-only and fallback behavior.

## Non-goals

This PR does not add browser scraping, public exposure of `/analyze`, backend changes, nginx/DNS/TLS changes, storage changes, crawler behavior, paywall bypass, or truth verdicts.

## Validation

Local validation:

- controlled endpoint strings present
- fallback message strings present
- no arbitrary `fetch(sourceUrl)` or `fetch(url)` call
- no form tag
- no external script tag
- `python -m pytest -q`

## Risk

Medium-low. This changes UI behavior and introduces one controlled API call, but keeps arbitrary URL retrieval server-side and preserves the fallback path for blocked sources.
