### PR TITLE
site: make operator sharing readable

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -965,7 +965,7 @@
 
       <div class="actions memory-actions">
         <button id="save_memory_result" type="button" disabled>Save memory</button>
-        <button id="share_memory_link" type="button" disabled>Copy share link</button>
+        <button id="share_memory_link" type="button" disabled>Copy share summary</button>
         <button id="share_memory_whatsapp" type="button" disabled>WhatsApp</button>
       </div>
       <p class="memory-status" id="memory_status">Run an analysis to unlock memory and sharing.</p>
@@ -2414,17 +2414,44 @@
       return currentMemoryRecord || saveCurrentMemoryResult();
     }
 
+    function buildCleanOperatorUrl() {
+      return `${window.location.origin}${window.location.pathname}`;
+    }
+
+    function buildHumanShareText(record) {
+      const lines = [
+        "HUB_Optimus Operator memory",
+        "",
+        `Dominio: ${record.signal_domain_label || "not detected"}`,
+        `Señal: ${record.operational_signal || "triage"}`,
+        "",
+        `Resumen: ${compactText(record.summary, 280)}`,
+        "",
+        `Afirmación: ${compactText(record.claim, 320)}`,
+        "",
+        `Incertidumbre: ${compactText(record.uncertainty, 260)}`,
+        "",
+        `Siguiente acción: ${compactText(record.safe_next_action, 220)}`,
+        "",
+        "Límite: señal no verificada; no es veredicto de verdad.",
+        record.source_url ? `Fuente: ${compactText(record.source_url, 240)}` : "",
+        `Abrir Operator: ${buildCleanOperatorUrl()}`
+      ];
+
+      return lines.filter(Boolean).join("\n");
+    }
+
     async function shareMemoryLink() {
       const record = currentShareableMemory();
       if (!record) return;
 
-      const url = buildMemoryShareUrl(record);
+      const shareText = buildHumanShareText(record);
 
       try {
-        await navigator.clipboard.writeText(url);
-        renderMemoryStatus("Share link copied. It contains a compact result snapshot.", true);
+        await navigator.clipboard.writeText(shareText);
+        renderMemoryStatus("Resumen legible copiado. Sin URL codificada.", true);
       } catch {
-        renderMemoryStatus(url, true);
+        renderMemoryStatus("No se pudo copiar el resumen. Use WhatsApp o seleccione el resultado manualmente.", false);
       }
     }
 
@@ -2432,16 +2459,10 @@
       const record = currentShareableMemory();
       if (!record) return;
 
-      const url = buildMemoryShareUrl(record);
-      const shareText = [
-        "HUB_Optimus Operator memory",
-        record.signal_domain_label,
-        record.claim,
-        url
-      ].filter(Boolean).join("\n\n");
+      const shareText = buildHumanShareText(record);
 
       window.open(`https://wa.me/?text=${encodeURIComponent(shareText)}`, "_blank", "noopener,noreferrer");
-      renderMemoryStatus("WhatsApp share opened with compact memory snapshot.", true);
+      renderMemoryStatus("WhatsApp abierto con resumen legible. Sin URL codificada.", true);
     }
 
     function renderSharedMemorySnapshot(snapshot) {

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "hub-optimus-operator-v0-15";
+const CACHE_NAME = "hub-optimus-operator-v0-16";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./manifest.webmanifest",

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -38,7 +38,7 @@ def test_operator_product_loader_pacing_present():
     assert "runMelonLoaderPlan" in html
     assert "assembling possible scenarios" in html
     assert "rendering final output" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
 
 
 def test_operator_source_intelligence_v2_present():
@@ -51,7 +51,7 @@ def test_operator_source_intelligence_v2_present():
     assert "operator-source-intelligence-v0.2" in html
     assert "HUB_Optimus procedure" in html
     assert "evidence lock" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
 
 
 def test_operator_memory_share_snapshot_present():
@@ -60,14 +60,14 @@ def test_operator_memory_share_snapshot_present():
 
     assert "hub_optimus_operator_memory_v1" in html
     assert "Save memory" in html
-    assert "Copy share link" in html
+    assert "Copy share summary" in html
     assert "WhatsApp" in html
     assert "candidate-signal-not-canonical" in html
     assert "buildMemoryShareUrl" in html
     assert "loadSharedMemoryFromHash" in html
     assert "https://wa.me/" in html
     assert "og:title" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
     assert "./og.svg" in sw
 
 
@@ -78,7 +78,7 @@ def test_operator_install_icon_reactor_mark_present():
     assert "Melon nuke reactor icon" in icon
     assert "url(#segment)" in icon
     assert ">HO</text>" in icon
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
 
 
 def test_operator_product_ux_controls_are_gated():
@@ -95,7 +95,7 @@ def test_operator_product_ux_controls_are_gated():
     assert "Result ready. Memory and sharing are available." in html
     assert ".status-strip" in html
     assert ".reactor-band" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
 
 
 def test_operator_url_only_fallback_message_present():
@@ -109,7 +109,7 @@ def test_operator_url_only_fallback_message_present():
     assert "readControlledUrlText" in html
     assert "renderUrlIntakeFallback" in html
     assert "Ready to read URL from controlled intake" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
 
 
 def test_operator_topic_aware_analysis_present():
@@ -126,7 +126,7 @@ def test_operator_topic_aware_analysis_present():
     assert "geopolítica / conflicto internacional" in html
     assert "topic_analysis_version" in html
     assert "operator-topic-analysis-v0.1" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
 
 
 def test_operator_geopolitical_conflict_analysis_is_specific():
@@ -143,4 +143,20 @@ def test_operator_geopolitical_conflict_analysis_is_specific():
     assert "alto el fuego" in html
     assert "Escenario B // escalada regional" in html
     assert "negociación bajo fuego" in html
-    assert "hub-optimus-operator-v0-15" in sw
+    assert "hub-optimus-operator-v0-16" in sw
+
+
+def test_operator_share_output_is_readable_without_encoded_snapshot_url():
+    html = INDEX.read_text(encoding="utf-8")
+    sw = SW.read_text(encoding="utf-8")
+
+    assert "Copy share summary" in html
+    assert "buildHumanShareText" in html
+    assert "buildCleanOperatorUrl" in html
+    assert "Resumen legible copiado. Sin URL codificada." in html
+    assert "WhatsApp abierto con resumen legible. Sin URL codificada." in html
+    assert "Límite: señal no verificada; no es veredicto de verdad." in html
+    assert "`Abrir Operator: ${buildCleanOperatorUrl()}`" in html
+    assert "const url = buildMemoryShareUrl(record);" not in html
+    assert "record.claim,\n        url" not in html
+    assert "hub-optimus-operator-v0-16" in sw


### PR DESCRIPTION
## Summary

Stops WhatsApp and copy-share actions from generating huge encoded `#memory=` URLs.

## Scope

- Adds readable human share text.
- Uses a clean Operator URL instead of an encoded snapshot URL.
- Changes the button label from `Copy share link` to `Copy share summary`.
- Keeps legacy `#memory=` reader support for old links, but no longer generates those links for sharing.
- Bumps Operator service worker cache to `v0-16`.
- Adds regression coverage to prevent reintroducing encoded snapshot URLs into WhatsApp/share output.

## Non-goals

This PR does not change:

- analysis logic
- backend
- URL intake
- memory storage
- legacy hash loading
- WhatsApp integration target
- public API exposure

## Validation

Local validation:

- readable share strings present
- no active `buildMemoryShareUrl(record)` call in share actions
- service worker bumped to `v0-16`
- `python -m pytest -q`

## Risk

Low. This is a UX correction for share output. Existing old `#memory=` links can still be read, but newly shared content becomes human-readable and no longer produces huge URLs.
