### PR TITLE
fix(api): separate intake and analysis body limits

### DIFF
--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -31,6 +31,7 @@ SHARED = APP_ROOT / "shared"
 
 MAX_URL_LENGTH = 2048
 MAX_URL_BODY_LENGTH = 4096
+MAX_ANALYZE_BODY_LENGTH = 64_000
 MAX_URL_BYTES = 1_000_000
 MAX_EXTRACTED_TEXT_CHARS = 24_000
 MAX_REDIRECTS = 3
@@ -394,14 +395,38 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(encoded)
 
-    def read_json_body(self) -> dict | None:
-        length = int(self.headers.get("Content-Length", "0"))
+    def read_json_body(self, max_body_length: int) -> dict | None:
+        content_length = self.headers.get("Content-Length")
 
-        if length > MAX_URL_BODY_LENGTH:
-            self.send_json(413, {"error": "request body too large"})
+        if content_length is None:
+            self.send_json(411, {"error": "Content-Length header is required"})
             return None
 
-        raw = self.rfile.read(length).decode("utf-8")
+        try:
+            length = int(content_length)
+        except ValueError:
+            self.send_json(400, {"error": "Content-Length header must be an integer"})
+            return None
+
+        if length < 0:
+            self.send_json(400, {"error": "Content-Length header must not be negative"})
+            return None
+
+        if length > max_body_length:
+            self.send_json(
+                413,
+                {
+                    "error": "request body too large",
+                    "limit_bytes": max_body_length,
+                },
+            )
+            return None
+
+        try:
+            raw = self.rfile.read(length).decode("utf-8")
+        except UnicodeDecodeError:
+            self.send_json(400, {"error": "request body must be valid UTF-8"})
+            return None
 
         try:
             payload = json.loads(raw)
@@ -416,7 +441,7 @@ class Handler(BaseHTTPRequestHandler):
         return payload
 
     def handle_url_intake(self) -> None:
-        payload = self.read_json_body()
+        payload = self.read_json_body(MAX_URL_BODY_LENGTH)
         if payload is None:
             return
 
@@ -440,7 +465,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_json(200, result)
 
     def handle_analyze(self) -> None:
-        payload = self.read_json_body()
+        payload = self.read_json_body(MAX_ANALYZE_BODY_LENGTH)
         if payload is None:
             return
 

--- a/tests/test_hub_api_controlled_url_intake.py
+++ b/tests/test_hub_api_controlled_url_intake.py
@@ -1,8 +1,28 @@
+import io
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 API_SCRIPT = ROOT / "ops" / "ec2" / "hub-api.sh"
+
+
+def load_embedded_api_namespace() -> dict:
+    script = API_SCRIPT.read_text(encoding="utf-8")
+    embedded = script.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    namespace = {"__name__": "hub_api_contract_test"}
+    exec(compile(embedded, str(API_SCRIPT), "exec"), namespace)
+    return namespace
+
+
+def make_body_reader(namespace: dict, content_length: str | None, body: bytes):
+    handler = object.__new__(namespace["Handler"])
+    handler.headers = {}
+    if content_length is not None:
+        handler.headers["Content-Length"] = content_length
+    handler.rfile = io.BytesIO(body)
+    responses = []
+    handler.send_json = lambda status, payload: responses.append((status, payload))
+    return handler, responses
 
 
 def test_hub_api_controlled_url_intake_endpoint_present():
@@ -13,9 +33,70 @@ def test_hub_api_controlled_url_intake_endpoint_present():
     assert "def fetch_url_text" in text
     assert "controlled_url_intake" in text
     assert "MAX_URL_BYTES = 1_000_000" in text
+    assert "MAX_URL_BODY_LENGTH = 4096" in text
+    assert "MAX_ANALYZE_BODY_LENGTH = 64_000" in text
     assert "MAX_REDIRECTS = 3" in text
     assert "URL_TIMEOUT_SECONDS = 8" in text
     assert "HUB_Optimus-Operator-URL-Intake/0.1" in text
+
+
+def test_url_and_analyze_handlers_use_separate_bounded_body_limits():
+    text = API_SCRIPT.read_text(encoding="utf-8")
+
+    assert "self.read_json_body(MAX_URL_BODY_LENGTH)" in text
+    assert "self.read_json_body(MAX_ANALYZE_BODY_LENGTH)" in text
+
+
+def test_analysis_limit_accepts_representative_operator_payload():
+    namespace = load_embedded_api_namespace()
+    body = ('{"case_id":"operator-case","raw_text":"' + ("evidence " * 700) + '"}').encode()
+    assert len(body) > namespace["MAX_URL_BODY_LENGTH"]
+    assert len(body) < namespace["MAX_ANALYZE_BODY_LENGTH"]
+
+    handler, responses = make_body_reader(namespace, str(len(body)), body)
+
+    payload = handler.read_json_body(namespace["MAX_ANALYZE_BODY_LENGTH"])
+
+    assert payload is not None
+    assert payload["case_id"] == "operator-case"
+    assert responses == []
+
+
+def test_url_limit_rejects_same_representative_operator_payload():
+    namespace = load_embedded_api_namespace()
+    body = ('{"raw_text":"' + ("evidence " * 700) + '"}').encode()
+    handler, responses = make_body_reader(namespace, str(len(body)), body)
+
+    payload = handler.read_json_body(namespace["MAX_URL_BODY_LENGTH"])
+
+    assert payload is None
+    assert responses == [
+        (
+            413,
+            {
+                "error": "request body too large",
+                "limit_bytes": namespace["MAX_URL_BODY_LENGTH"],
+            },
+        )
+    ]
+
+
+def test_json_body_reader_rejects_missing_invalid_and_negative_lengths():
+    namespace = load_embedded_api_namespace()
+
+    for content_length, expected_status in ((None, 411), ("invalid", 400), ("-1", 400)):
+        handler, responses = make_body_reader(namespace, content_length, b"{}")
+
+        assert handler.read_json_body(namespace["MAX_URL_BODY_LENGTH"]) is None
+        assert responses[0][0] == expected_status
+
+
+def test_json_body_reader_rejects_invalid_utf8_without_traceback():
+    namespace = load_embedded_api_namespace()
+    handler, responses = make_body_reader(namespace, "2", b"\xff\xfe")
+
+    assert handler.read_json_body(namespace["MAX_URL_BODY_LENGTH"]) is None
+    assert responses == [(400, {"error": "request body must be valid UTF-8"})]
 
 
 def test_hub_api_controlled_url_intake_security_boundary_present():


### PR DESCRIPTION
Related to #1738.

## Problem

The local API applied the 4 KiB controlled-URL request limit to `/analyze` as well. Representative Operator case records can exceed that size, so the repository's own handoff could return HTTP 413.

## Change

- keep `/intake/url` bounded at 4 KiB;
- bound `/analyze` separately at 64 KiB;
- make each handler pass its explicit limit to the shared reader;
- return controlled responses for missing, invalid, negative, oversized, or non-UTF-8 request bodies;
- add behavioral contract tests using the embedded API module.

## Validation

- `bash -n ops/ec2/hub-api.sh`
- `pytest -q tests/test_hub_api_controlled_url_intake.py tests/test_ec2_operator_api_proxy_config.py` — 12 passed
- full repository suite — 88 passed
- `git diff --check`

## Boundaries

This does not expose `/analyze`, change Semantic Engine contracts, migrate providers, redesign SSRF handling, or alter deployment/authentication/retention.