### PR TITLE
security: trust main before maintenance credentials

### DIFF
--- a/.github/workflows/repo_maintenance_bot.yml
+++ b/.github/workflows/repo_maintenance_bot.yml
@@ -2,147 +2,86 @@
 name: Repo maintenance bot
 
 "on":
-  workflow_dispatch:
-    inputs:
-      mode:
-        description: "Scope"
-        required: true
-        default: "full"
-        type: choice
-        options: [hygiene, i18n, full]
-      allow_kernel_changes:
-        description: "Allow changes in docs/governance and v1_core/languages/es"
-        required: true
-        default: "false"
-        type: choice
-        options: ["false", "true"]
+  # Manual dispatch is intentionally disabled by issue #1740. Restore it only
+  # through a reviewed change that binds this job to a protected Environment
+  # with required reviewers and rejects every ref except the trusted default
+  # branch before Environment secrets are released.
   schedule:
     - cron: "15 6 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   maintenance:
     runs-on: ubuntu-latest
     env:
-      MAINT_MODE: ${{ github.event.inputs.mode || 'full' }}
-      ALLOW_KERNEL_CHANGES: ${{ github.event.inputs.allow_kernel_changes || 'false' }}
+      MAINT_MODE: full
 
     steps:
-      - name: Check required secrets
-        id: secrets
-        env:
-          GH_APP_ID: ${{ secrets.GH_APP_ID }}
-          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
-        run: |
-          if [ -z "${GH_APP_ID}" ] || [ -z "${GH_APP_PRIVATE_KEY}" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping maintenance bot: GH_APP_ID or GH_APP_PRIVATE_KEY is not configured."
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create GitHub App token
-        id: app-token
-        if: steps.secrets.outputs.available == 'true'
-        uses: actions/create-github-app-token@v3
+      - name: Checkout trusted default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: Voxterrae
-          repositories: HUB_Optimus
-
-      - name: Checkout
-        if: steps.secrets.outputs.available == 'true'
-        uses: actions/checkout@v7
-        with:
-          token: ${{ steps.app-token.outputs.token }}
+          ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
-        if: steps.secrets.outputs.available == 'true'
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
       - name: Create working branch
         id: vars
-        if: steps.secrets.outputs.available == 'true'
         run: |
-          echo "BRANCH=chore/maintenance-${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+            echo "::error::Checkout is not the trusted origin/main commit."
+            exit 1
+          fi
+          echo "BRANCH=chore/maintenance-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
           git config user.name "hub-optimus-maintainer[bot]"
           git config user.email "hub-optimus-maintainer[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
-          git reset --hard origin/main
-          SCRIPT_SHA=${GITHUB_SHA}
-          mkdir -p tools
-          git show "$SCRIPT_SHA:tools/maintenance_bot.py" > tools/maintenance_bot.py
-          git show "$SCRIPT_SHA:tools/kernel_guard.py" > tools/kernel_guard.py
-          git show "$SCRIPT_SHA:tools/pr_pro.py" > tools/pr_pro.py
           git checkout -b "chore/maintenance-${GITHUB_RUN_NUMBER}"
 
       - name: Run maintenance bot
-        if: steps.secrets.outputs.available == 'true'
         run: |
           python tools/maintenance_bot.py "${MAINT_MODE}"
 
       - name: Kernel guard (block protected changes unless allowed)
-        if: steps.secrets.outputs.available == 'true'
         run: |
-          if [ "${ALLOW_KERNEL_CHANGES}" = "true" ]; then
-            python tools/kernel_guard.py --allow-kernel-changes
-          else
-            python tools/kernel_guard.py
-          fi
+          python tools/kernel_guard.py
 
       - name: Commit changes if any
         id: commit
-        if: steps.secrets.outputs.available == 'true'
         run: |
           git add -A
           if git diff --cached --quiet; then
-            echo "NO_CHANGES=true" >> $GITHUB_OUTPUT
+            echo "NO_CHANGES=true" >> "$GITHUB_OUTPUT"
             echo "No changes to commit."
             exit 0
           fi
           git commit -m "chore: automated maintenance (${MAINT_MODE})"
-          echo "NO_CHANGES=false" >> $GITHUB_OUTPUT
+          echo "NO_CHANGES=false" >> "$GITHUB_OUTPUT"
 
-      - name: Push branch
-        if: steps.secrets.outputs.available == 'true' && steps.commit.outputs.NO_CHANGES == 'false'
-        run: |
-          git push -u origin "${{ steps.vars.outputs.BRANCH }}"
+      - name: Create short-lived GitHub App token
+        id: app-token
+        if: steps.commit.outputs.NO_CHANGES == 'false'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: Voxterrae
+          repositories: HUB_Optimus
+          permission-contents: write
 
-      - name: Create PR automatically
-        if: steps.secrets.outputs.available == 'true' && steps.commit.outputs.NO_CHANGES == 'false'
+      - name: Push maintenance branch with ephemeral App token
+        if: steps.commit.outputs.NO_CHANGES == 'false'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          BRANCH="${{ steps.vars.outputs.BRANCH }}"
-          TITLE="chore: automated maintenance (${MAINT_MODE})"
-          BODY="Automated maintenance PR.\n\n"
-          BODY+="Mode: ${MAINT_MODE}\n"
-          BODY+="allow_kernel_changes: ${ALLOW_KERNEL_CHANGES}\n"
-          gh pr create --base main --head "$BRANCH" --title "$TITLE" --body "$BODY" || true
-          PR_NUMBER=$(gh pr view "$BRANCH" --json number --jq .number)
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
-
-      - name: "PRO: labels + summary comment"
-        if: steps.secrets.outputs.available == 'true' && steps.commit.outputs.NO_CHANGES == 'false'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-          MODE: ${{ env.MAINT_MODE }}
-          ALLOW_KERNEL: ${{ env.ALLOW_KERNEL_CHANGES }}
-        run: |
-          git fetch origin main
-          python tools/pr_pro.py
-
-      - name: Skip summary
-        if: steps.secrets.outputs.available != 'true'
-        run: echo "Maintenance workflow skipped cleanly due to missing secrets."
+          auth_header="$(printf 'x-access-token:%s' "${GH_APP_TOKEN}" | base64 | tr -d '\n')"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${auth_header}"
+          git push origin "HEAD:refs/heads/${{ steps.vars.outputs.BRANCH }}"
+          unset GIT_CONFIG_VALUE_0 auth_header

--- a/tests/test_repo_maintenance_workflow.py
+++ b/tests/test_repo_maintenance_workflow.py
@@ -1,0 +1,92 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "repo_maintenance_bot.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _step(text: str, name: str) -> str:
+    start = text.index(f"      - name: {name}")
+    end = text.find("\n      - name:", start + 1)
+    return text[start:] if end == -1 else text[start:end]
+
+
+def test_maintenance_workflow_is_schedule_only_and_read_only_by_default():
+    text = _workflow_text()
+
+    assert "workflow_dispatch:" not in text
+    assert re.search(r"^permissions:\n  contents: read$", text, re.MULTILINE)
+    assert "\n  contents: write\n" not in text
+    assert "\n  pull-requests: write\n" not in text
+    assert "\n  issues: write\n" not in text
+    assert "protected Environment" in text
+    assert "required reviewers" in text
+    assert "trusted default" in text
+
+
+def test_maintenance_workflow_checks_out_only_trusted_main_without_credentials():
+    text = _workflow_text()
+    checkout = _step(text, "Checkout trusted default branch")
+
+    assert (
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+        in checkout
+    )
+    assert "ref: main" in checkout
+    assert "persist-credentials: false" in checkout
+    assert "token:" not in checkout
+    assert 'git rev-parse HEAD)" != "$(git rev-parse origin/main)' in text
+    assert "GITHUB_SHA" not in text
+    assert "SCRIPT_SHA" not in text
+    assert "git show" not in text
+
+
+def test_maintenance_workflow_creates_write_token_only_after_local_checks():
+    text = _workflow_text()
+    run_bot = text.index("      - name: Run maintenance bot")
+    guard = text.index("      - name: Kernel guard")
+    commit = text.index("      - name: Commit changes if any")
+    create_token = text.index("      - name: Create short-lived GitHub App token")
+    push = text.index("      - name: Push maintenance branch")
+
+    assert run_bot < guard < commit < create_token < push
+    assert "secrets." not in text[:create_token]
+    assert text.count("${{ secrets.GH_APP_ID }}") == 1
+    assert text.count("${{ secrets.GH_APP_PRIVATE_KEY }}") == 1
+    assert text.count("${{ steps.app-token.outputs.token }}") == 1
+    assert "${{ steps.app-token.outputs.token }}" not in text[:push]
+
+    token_step = _step(text, "Create short-lived GitHub App token")
+    assert "if: steps.commit.outputs.NO_CHANGES == 'false'" in token_step
+    assert "permission-contents: write" in token_step
+
+    push_step = _step(text, "Push maintenance branch with ephemeral App token")
+    assert "GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}" in push_step
+    assert "GIT_CONFIG_VALUE_0" in push_step
+    assert 'git push origin "HEAD:refs/heads/${{ steps.vars.outputs.BRANCH }}"' in push_step
+
+    assert "GH_TOKEN" not in text
+    assert "gh pr create" not in text
+    assert "pr_pro.py" not in text
+
+
+def test_maintenance_workflow_actions_are_pinned_to_full_commit_shas():
+    text = _workflow_text()
+    actions = re.findall(
+        r"^\s+uses:\s+([^@\s]+)@([^\s]+)",
+        text,
+        re.MULTILINE,
+    )
+
+    assert actions
+    assert all(re.fullmatch(r"[0-9a-f]{40}", ref) for _, ref in actions)
+    assert "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" in text
+    assert (
+        "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"
+        in text
+    )


### PR DESCRIPTION
Related to #1740.

## Summary

- remove branch-selectable manual dispatch and run maintenance only on schedule;
- check out trusted `main` with read-only permissions and no persisted credentials;
- run maintenance, Kernel Guard, and the local commit before requesting any write token;
- scope the short-lived GitHub App token to repository contents and expose it only to the final push step;
- pin every Action used by this workflow to a verified full commit SHA;
- add regression tests for the trusted-ref and credential boundaries.

## Operational change

The workflow now pushes the generated maintenance branch but does not automatically create, label, or comment on a PR. Reintroducing manual operation requires a separate reviewed change using a protected Environment with required reviewers and a trusted-default-branch gate.

## Validation

- `4 passed` — maintenance workflow security tests
- `87 passed` — complete repository suite
- maintenance dry-run passed
- workflow YAML validation passed
- Kernel Guard passed
- `git diff --check` passed

`docs/context/AI_HANDOFF.md` is unchanged because this is a narrowly scoped workflow hardening change.