### PR TITLE
fix(runner): control scenario read errors

### DIFF
--- a/run_scenario.py
+++ b/run_scenario.py
@@ -19,6 +19,10 @@ SCHEMA_PATH = Path(__file__).parent / "scenario.schema.json"
 INPUT_ERROR_EXIT_CODE = 2
 
 
+class ScenarioInputError(Exception):
+    """A controlled failure while reading the user-supplied scenario file."""
+
+
 def _load_schema() -> dict[str, Any]:
     return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
@@ -35,7 +39,12 @@ def validate_scenario_payload(payload: object) -> list[str]:
 
 def load_validated_scenario(scenario_path: Path) -> Scenario:
     try:
-        payload: Any = json.loads(scenario_path.read_text(encoding="utf-8"))
+        source = scenario_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ScenarioInputError(f"cannot read scenario file: {exc}") from exc
+
+    try:
+        payload: Any = json.loads(source)
     except json.JSONDecodeError as exc:
         raise ValueError(
             f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
@@ -113,6 +122,9 @@ def main() -> int:
 
     try:
         scenario = load_validated_scenario(scenario_path)
+    except ScenarioInputError as exc:
+        print(f"[input-error] {exc}", file=sys.stderr)
+        return INPUT_ERROR_EXIT_CODE
     except ValueError as exc:
         print(f"[schema-error] {exc}", file=sys.stderr)
         return INPUT_ERROR_EXIT_CODE

--- a/tests/test_run_scenario_cli.py
+++ b/tests/test_run_scenario_cli.py
@@ -6,6 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+import run_scenario
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUN_SCENARIO = REPO_ROOT / "run_scenario.py"
@@ -119,6 +123,46 @@ def test_invalid_json_returns_schema_error(tmp_path: Path) -> None:
     assert proc.returncode == 2
     assert "[schema-error]" in proc.stderr
     assert "Invalid JSON" in proc.stderr
+
+
+def test_invalid_utf8_returns_input_error(tmp_path: Path) -> None:
+    invalid_utf8 = tmp_path / "invalid_utf8.json"
+    invalid_utf8.write_bytes(b"\xff\xfe\x00")
+
+    proc = _run_cli("--scenario", str(invalid_utf8))
+
+    assert proc.returncode == 2
+    assert "[input-error]" in proc.stderr
+    assert "cannot read scenario file" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+
+def test_permission_error_uses_controlled_input_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    scenario_path = tmp_path / "blocked.json"
+    scenario_path.write_text("{}", encoding="utf-8")
+
+    def deny_read(_scenario_path: Path) -> run_scenario.Scenario:
+        raise run_scenario.ScenarioInputError(
+            "cannot read scenario file: permission denied"
+        )
+
+    monkeypatch.setattr(run_scenario, "load_validated_scenario", deny_read)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run_scenario.py", "--scenario", str(scenario_path)],
+    )
+
+    assert run_scenario.main() == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("[input-error]")
+    assert "permission denied" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_schema_file_defines_required_contract() -> None:


### PR DESCRIPTION
Related to #1760.

## Root cause

The CLI only converted JSON/schema validation failures into its stable error contract. File reads could still raise `OSError` or Unicode decoding errors after the initial `is_file()` check, producing a traceback and exit code 1.

## Change

- add a dedicated `ScenarioInputError` for failures while reading user-supplied scenario bytes;
- classify filesystem and UTF-8 read failures as `[input-error]` with exit code 2;
- keep invalid JSON and schema violations under `[schema-error]`;
- add subprocess coverage for invalid UTF-8 and a controlled permission-denied path test.

Successful output and simulator behavior are unchanged.

## Validation

- focused runner/regression tests: 19 passed;
- full suite: 85 passed;
- scenario benchmarks: 3/3 passed;
- direct `/proc/1/mem` reproduction now returns exit 2 and a single controlled input error;
- `git diff --check` passed.

`docs/context/AI_HANDOFF.md` is unchanged because the documented contract already required this behavior; the PR restores implementation parity.