### PR TITLE
fix(tooling): make PR enrichment fail closed

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -62,6 +62,23 @@ If this file is not updated, say why in the PR body.
 
 Return to controlled observation. Act only when a new regression, architecture ambiguity, contributor friction, documentation drift, CI/runtime signal, governance risk, or explicit user request is recorded in GitHub.
 
+## PR Enrichment Helper Boundary
+
+Issue #1762 keeps `tools/pr_pro.py` as a supported, optional helper for an
+existing PR. It is not a PR creator, merge authority, or authentication
+provider.
+
+Operational boundary:
+
+- Write mode requires an existing PR target and the GitHub CLI.
+- The helper uses the caller's existing authentication and scopes; it does
+  not create, persist, exchange, or expand tokens.
+- Failed GitHub or required local diff commands return non-zero and cannot
+  emit the success status.
+- `--dry-run` invokes no GitHub commands and performs no GitHub mutation.
+- The active workflow file, not this helper or chat context, determines
+  whether scheduled maintenance invokes it.
+
 ## Meta-learning Follow-up
 
 - `.github/copilot-instructions.md` currently identifies `v1_core/workflow/05_meta_learning.md` as the meta-learning update location.

--- a/docs/context/WORKFLOWS.md
+++ b/docs/context/WORKFLOWS.md
@@ -97,6 +97,24 @@ powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1
   - Creates a maintenance branch, runs `tools/maintenance_bot.py`, runs `tools/kernel_guard.py`, commits changes, pushes the branch, opens a PR, then runs `tools/pr_pro.py`.
 - Writes to repo: yes, only through an explicit maintenance PR branch.
 
+#### `tools/pr_pro.py` support boundary
+
+- Status: supported as an optional helper for enriching an existing PR with
+  governed labels and a changed-file summary. It does not create or merge PRs
+  and is not an authentication or authorization boundary.
+- Write mode requires the GitHub CLI and uses only the authentication and
+  token scopes already supplied by the caller. The tool does not create,
+  exchange, persist, or expand tokens.
+- Every failed `gh` operation is terminal and returns a non-zero status. A
+  success message is emitted only after all required label, edit, and comment
+  operations succeed.
+- `--dry-run` performs the local Git diff and prints the planned target,
+  labels, and comment. It does not invoke `gh` and therefore performs no
+  GitHub read or write.
+- The versioned workflow file remains authoritative for whether a workflow
+  invokes this optional helper. A draft PR or chat statement does not change
+  the active workflow.
+
 ### repo-health-summary.yml
 
 - Triggers:

--- a/tests/test_pr_pro.py
+++ b/tests/test_pr_pro.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+
+import pytest
+
+from tools import pr_pro
+
+
+CommandFake = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _result(
+    args: list[str],
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+
+@pytest.fixture(autouse=True)
+def _clean_pr_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "PR_NUMBER",
+        "GITHUB_HEAD_REF",
+        "BRANCH_NAME",
+        "MODE",
+        "ALLOW_KERNEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _existing_labels_or_success(
+    calls: list[list[str]],
+    *,
+    edit_result: subprocess.CompletedProcess[str] | None = None,
+    comment_result: subprocess.CompletedProcess[str] | None = None,
+) -> CommandFake:
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return _result(cmd, stdout=f"{cmd[3]}\n")
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return _result(cmd, stdout="docs/governance/policy.md\nnotes.md\n")
+        if cmd[:3] == ["gh", "label", "list"]:
+            for name in ("maintenance", "kernel-change", "i18n"):
+                if f'"{name}"' in cmd[-1]:
+                    return _result(cmd, stdout=f"{name}\n")
+        if cmd[:3] == ["gh", "pr", "edit"]:
+            return edit_result or _result(cmd)
+        if cmd[:3] == ["gh", "pr", "comment"]:
+            return comment_result or _result(cmd)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return fake
+
+
+def test_missing_gh_is_explicit_and_runs_no_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: None)
+
+    def unexpected(_cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("no external command should run when gh is missing")
+
+    monkeypatch.setattr(pr_pro, "run_command", unexpected)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == (
+        "[pr-pro-error] GitHub CLI 'gh' is required for write mode"
+    )
+
+
+def test_missing_target_fails_before_any_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    def unexpected(_cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("target validation must precede external commands")
+
+    monkeypatch.setattr(pr_pro, "run_command", unexpected)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "PR_NUMBER or GITHUB_HEAD_REF/BRANCH_NAME is required" in captured.err
+    assert "pr_pro done" not in captured.out
+
+
+def test_dry_run_never_invokes_gh(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setenv("MODE", "i18n")
+    calls: list[list[str]] = []
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        assert cmd[0] == "git"
+        return _result(cmd, stdout="docs/es/00_start_here.md\n")
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: None)
+
+    assert pr_pro.main(["--dry-run"]) == 0
+    captured = capsys.readouterr()
+    assert calls == [["git", "diff", "--name-only", "origin/main...HEAD"]]
+    assert "[dry-run] target: PR #42" in captured.out
+    assert "[dry-run] add labels: maintenance, i18n" in captured.out
+    assert "no GitHub commands executed" in captured.out
+    assert "pr_pro done" not in captured.out
+
+
+def test_failed_label_listing_stops_without_mutation_or_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return _result(cmd, stdout="42\n")
+        if cmd[0] == "git":
+            return _result(cmd, stdout="README.md\n")
+        if cmd[:3] == ["gh", "label", "list"]:
+            return _result(cmd, 1, stderr="API unavailable")
+        raise AssertionError(f"unexpected command after label-list failure: {cmd}")
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "list label 'maintenance' failed (1): API unavailable" in captured.err
+    assert not any(cmd[:3] == ["gh", "label", "create"] for cmd in calls)
+    assert not any(cmd[:3] == ["gh", "pr", "edit"] for cmd in calls)
+    assert "pr_pro done" not in captured.out
+
+
+def test_failed_label_creation_stops_with_nonzero_status(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return _result(cmd, stdout="42\n")
+        if cmd[0] == "git":
+            return _result(cmd, stdout="README.md\n")
+        if cmd[:3] == ["gh", "label", "list"]:
+            return _result(cmd)
+        if cmd[:3] == ["gh", "label", "create"]:
+            return _result(cmd, 1, stderr="permission denied")
+        raise AssertionError(f"unexpected command after label-create failure: {cmd}")
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "create label 'maintenance' failed (1): permission denied" in captured.err
+    assert "pr_pro done" not in captured.out
+
+
+def test_failed_pr_edit_prevents_comment_and_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+    edit_failure = _result(
+        ["gh", "pr", "edit"],
+        1,
+        stderr="GraphQL mutation failed",
+    )
+    monkeypatch.setattr(
+        pr_pro,
+        "run_command",
+        _existing_labels_or_success(calls, edit_result=edit_failure),
+    )
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "add labels to PR #42 failed (1): GraphQL mutation failed" in captured.err
+    assert not any(cmd[:3] == ["gh", "pr", "comment"] for cmd in calls)
+    assert "pr_pro done" not in captured.out
+
+
+def test_failed_pr_comment_returns_nonzero_without_success_message(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+    comment_failure = _result(
+        ["gh", "pr", "comment"],
+        1,
+        stderr="comment rejected",
+    )
+    monkeypatch.setattr(
+        pr_pro,
+        "run_command",
+        _existing_labels_or_success(calls, comment_result=comment_failure),
+    )
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "comment on PR #42 failed (1): comment rejected" in captured.err
+    assert "pr_pro done" not in captured.out
+
+
+def test_git_diff_failure_is_controlled_without_weaker_local_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return _result(cmd, stdout="42\n")
+        if cmd == ["git", "diff", "--name-only", "origin/main...HEAD"]:
+            return _result(cmd, 128, stderr="unknown revision")
+        raise AssertionError(f"unexpected GitHub mutation after diff failure: {cmd}")
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "read changed files against origin/main failed" in captured.err
+    assert calls == [
+        ["gh", "pr", "view", "42", "--json", "number", "--jq", ".number"],
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+    ]
+    assert "pr_pro done" not in captured.out
+
+
+def test_numeric_pr_is_validated_before_any_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PR_NUMBER", "404")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        assert cmd[:3] == ["gh", "pr", "view"]
+        return _result(cmd, 1, stderr="no pull requests found")
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "validate PR #404 failed (1): no pull requests found" in captured.err
+    assert len(calls) == 1
+    assert "pr_pro done" not in captured.out
+
+
+def test_branch_is_resolved_before_supported_write_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("BRANCH_NAME", "chore/maintenance-7")
+    monkeypatch.setenv("MODE", "full")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+
+    base_fake = _existing_labels_or_success(calls)
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if cmd[:3] == ["gh", "pr", "view"]:
+            calls.append(cmd)
+            return _result(cmd, stdout="73\n")
+        return base_fake(cmd)
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+
+    assert pr_pro.main([]) == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "pr_pro done"
+    assert calls[0] == [
+        "gh",
+        "pr",
+        "view",
+        "chore/maintenance-7",
+        "--json",
+        "number",
+        "--jq",
+        ".number",
+    ]
+    edit = next(cmd for cmd in calls if cmd[:3] == ["gh", "pr", "edit"])
+    assert edit[3:6] == ["73", "--add-label", "maintenance,i18n,kernel-change"]
+
+
+def test_branch_resolution_failure_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("BRANCH_NAME", "chore/missing-pr")
+    monkeypatch.setattr(pr_pro.shutil, "which", lambda _name: "/usr/bin/gh")
+    calls: list[list[str]] = []
+
+    def fake(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return _result(cmd, 1, stderr="no pull requests found")
+
+    monkeypatch.setattr(pr_pro, "run_command", fake)
+
+    assert pr_pro.main([]) == pr_pro.ERROR_EXIT_CODE
+    captured = capsys.readouterr()
+    assert "resolve PR for branch 'chore/missing-pr' failed" in captured.err
+    assert len(calls) == 1
+    assert calls[0][:3] == ["gh", "pr", "view"]
+    assert "pr_pro done" not in captured.out
+
+
+def test_external_command_oserror_becomes_controlled_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_oserror(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("missing executable")
+
+    monkeypatch.setattr(pr_pro.subprocess, "run", raise_oserror)
+    with pytest.raises(pr_pro.PrProError, match="cannot execute git"):
+        pr_pro.run_command(["git", "status"])

--- a/tools/pr_pro.py
+++ b/tools/pr_pro.py
@@ -1,64 +1,152 @@
 #!/usr/bin/env python3
+"""Fail-closed label and summary enrichment for an existing GitHub PR.
+
+Support status: supported as a small, optional repository utility.  It is not
+a PR creator, merge authority, or authentication provider.  Write mode uses
+the caller's existing ``gh`` authentication and scopes.  ``--dry-run`` runs
+the local diff only and never invokes ``gh``.
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
+import shutil
 import subprocess
 import sys
+from collections.abc import Sequence
 
 
-def run(cmd):
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    return result.returncode, result.stdout.strip(), result.stderr.strip()
+ERROR_EXIT_CODE = 2
 
 
-def ensure_label(name, color="0E8A16", description=""):
-    code, out, _ = run(
+class PrProError(RuntimeError):
+    """A concise, expected failure that must stop PR enrichment."""
+
+
+def _concise_detail(*values: str, limit: int = 240) -> str:
+    detail = " ".join(" ".join(value.split()) for value in values if value.strip())
+    if not detail:
+        return "no diagnostic output"
+    return detail if len(detail) <= limit else f"{detail[: limit - 3]}..."
+
+
+def run_command(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run one external command without a shell and preserve its result."""
+    try:
+        return subprocess.run(
+            list(cmd),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except OSError as exc:
+        raise PrProError(f"cannot execute {cmd[0]}: {exc}") from exc
+
+
+def _require_success(
+    result: subprocess.CompletedProcess[str],
+    operation: str,
+) -> str:
+    if result.returncode != 0:
+        detail = _concise_detail(result.stderr, result.stdout)
+        raise PrProError(f"{operation} failed ({result.returncode}): {detail}")
+    return result.stdout.strip()
+
+
+def ensure_label(
+    name: str,
+    color: str = "0E8A16",
+    description: str = "",
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Ensure one label exists, or report the mutation in dry-run mode."""
+    if dry_run:
+        print(f"[dry-run] ensure label: {name}")
+        return
+
+    listed = run_command(
         [
             "gh",
             "label",
             "list",
+            "--limit",
+            "1000",
             "--json",
             "name",
             "--jq",
             f'.[] | select(.name=="{name}") | .name',
         ]
     )
-    if code == 0 and out == name:
+    output = _require_success(listed, f"list label {name!r}")
+    if name in output.splitlines():
         return
-    run(["gh", "label", "create", name, "--color", color, "--description", description])
 
-
-def get_changed_files():
-    code, out, _ = run(["git", "diff", "--name-only", "origin/main...HEAD"])
-    if code != 0:
-        code, out, _ = run(["git", "diff", "--name-only"])
-        if code != 0:
-            return []
-    return [line for line in out.splitlines() if line.strip()]
-
-
-def main():
-    pr_number = os.environ.get("PR_NUMBER", "").strip()
-    mode = os.environ.get("MODE", "full")
-    allow_kernel = os.environ.get("ALLOW_KERNEL", "false")
-
-    ensure_label("maintenance", "0E8A16", "Automated maintenance PR")
-    ensure_label(
-        "kernel-change",
-        "B60205",
-        "Touches Kernel/Governance protected files",
+    created = run_command(
+        [
+            "gh",
+            "label",
+            "create",
+            name,
+            "--color",
+            color,
+            "--description",
+            description,
+        ]
     )
-    ensure_label("i18n", "1D76DB", "Language mirror / translation structure updates")
+    _require_success(created, f"create label {name!r}")
 
-    files = get_changed_files()
 
-    labels = ["maintenance"]
-    if mode in ("i18n", "full"):
-        labels.append("i18n")
-    if any(
-        path.startswith("docs/governance/") or path.startswith("v1_core/languages/en/")
-        for path in files
-    ):
-        labels.append("kernel-change")
+def get_changed_files() -> list[str]:
+    """Return branch changes against main, without a weaker local fallback."""
+    against_main = run_command(
+        ["git", "diff", "--name-only", "origin/main...HEAD"]
+    )
+    output = _require_success(
+        against_main,
+        "read changed files against origin/main",
+    )
+    return [line for line in output.splitlines() if line.strip()]
 
+
+def _validated_pr_number(value: str) -> str:
+    if not value.isdigit() or int(value) < 1:
+        raise PrProError(f"invalid PR_NUMBER: {value!r}")
+    return value
+
+
+def resolve_pr_target(
+    pr_number: str,
+    branch: str,
+    *,
+    dry_run: bool,
+) -> tuple[str | None, str]:
+    """Resolve an existing PR number, without using GitHub in dry-run mode."""
+    if pr_number:
+        validated = _validated_pr_number(pr_number)
+        if dry_run:
+            return None, f"PR #{validated}"
+        selector = validated
+        operation = f"validate PR #{validated}"
+    else:
+        if not branch:
+            raise PrProError("PR_NUMBER or GITHUB_HEAD_REF/BRANCH_NAME is required")
+        if dry_run:
+            return None, f"PR for branch {branch!r}"
+        selector = branch
+        operation = f"resolve PR for branch {branch!r}"
+
+    viewed = run_command(
+        ["gh", "pr", "view", selector, "--json", "number", "--jq", ".number"]
+    )
+    resolved = _require_success(viewed, operation)
+    return _validated_pr_number(resolved), f"PR #{resolved}"
+
+
+def _build_comment(files: list[str], mode: str, allow_kernel: str) -> str:
     body_lines = [
         "### Automated maintenance summary",
         f"- Mode: `{mode}`",
@@ -66,24 +154,108 @@ def main():
         "",
         "#### Changed files",
     ]
-    for path in files[:200]:
-        body_lines.append(f"- `{path}`")
+    body_lines.extend(f"- `{path}`" for path in files[:200])
     if len(files) > 200:
         body_lines.append(f"- ...and {len(files) - 200} more")
+    return "\n".join(body_lines)
 
-    comment = "\n".join(body_lines)
 
-    if pr_number:
-        run(["gh", "pr", "edit", pr_number, "--add-label"] + labels)
-        run(["gh", "pr", "comment", pr_number, "--body", comment])
-    else:
-        branch = os.environ.get("GITHUB_HEAD_REF") or os.environ.get("BRANCH_NAME")
-        if not branch:
-            print("No PR_NUMBER or branch ref available.")
-            sys.exit(0)
+def _labels_for(files: list[str], mode: str) -> list[str]:
+    labels = ["maintenance"]
+    if mode in ("i18n", "full"):
+        labels.append("i18n")
+    if any(
+        path.startswith("docs/governance/")
+        or path.startswith("v1_core/languages/en/")
+        for path in files
+    ):
+        labels.append("kernel-change")
+    return labels
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Add governed labels and a changed-file summary to an existing PR."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned PR enrichment without invoking any gh command.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    pr_number = os.environ.get("PR_NUMBER", "").strip()
+    branch = (
+        os.environ.get("GITHUB_HEAD_REF")
+        or os.environ.get("BRANCH_NAME")
+        or ""
+    ).strip()
+    mode = os.environ.get("MODE", "full")
+    allow_kernel = os.environ.get("ALLOW_KERNEL", "false")
+
+    try:
+        if not args.dry_run and shutil.which("gh") is None:
+            raise PrProError("GitHub CLI 'gh' is required for write mode")
+
+        resolved_pr, target_description = resolve_pr_target(
+            pr_number,
+            branch,
+            dry_run=args.dry_run,
+        )
+        files = get_changed_files()
+        labels = _labels_for(files, mode)
+        comment = _build_comment(files, mode, allow_kernel)
+
+        label_specs = (
+            ("maintenance", "0E8A16", "Automated maintenance PR"),
+            ("kernel-change", "B60205", "Touches Kernel/Governance protected files"),
+            ("i18n", "1D76DB", "Language mirror / translation structure updates"),
+        )
+        for name, color, description in label_specs:
+            ensure_label(
+                name,
+                color,
+                description,
+                dry_run=args.dry_run,
+            )
+
+        if args.dry_run:
+            print(f"[dry-run] target: {target_description}")
+            print(f"[dry-run] add labels: {', '.join(labels)}")
+            print("[dry-run] post comment:")
+            print(comment)
+            print("pr_pro dry-run complete; no GitHub commands executed")
+            return 0
+
+        if resolved_pr is None:  # Defensive: normal mode always resolves a number.
+            raise PrProError("internal error: PR target was not resolved")
+
+        edited = run_command(
+            [
+                "gh",
+                "pr",
+                "edit",
+                resolved_pr,
+                "--add-label",
+                ",".join(labels),
+            ]
+        )
+        _require_success(edited, f"add labels to PR #{resolved_pr}")
+
+        commented = run_command(
+            ["gh", "pr", "comment", resolved_pr, "--body", comment]
+        )
+        _require_success(commented, f"comment on PR #{resolved_pr}")
+    except PrProError as exc:
+        print(f"[pr-pro-error] {exc}", file=sys.stderr)
+        return ERROR_EXIT_CODE
 
     print("pr_pro done")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Make `tools/pr_pro.py` fail closed and define it as an optional helper for enriching an existing pull request.

## Behavior

- require and validate an existing PR target before any GitHub mutation;
- fail explicitly when `gh` is unavailable in write mode;
- check every label-list, label-create, PR-edit and PR-comment result;
- require the semantic `origin/main...HEAD` diff instead of falling back to a weaker local diff;
- emit `pr_pro done` only after every required operation succeeds;
- add `--dry-run`, which performs the local diff but invokes no `gh` command and performs no GitHub read or write;
- preserve caller-provided authentication and token scopes;
- leave workflows unchanged.

## Support boundary

`tools/pr_pro.py` remains supported as an optional repository utility. It does not create or merge PRs, provide authentication, expand permissions, or act as a security boundary. The versioned workflow remains authoritative for whether scheduled maintenance invokes it.

## Validation

- focused mocked tests: 12 passed;
- full suite: 95 passed;
- runtime benchmarks: 3/3;
- narrative benchmarks: 4/4;
- actual missing-`gh` path: controlled exit 2;
- no-`gh` dry-run: exit 0 with no GitHub command;
- Python compilation and `git diff --check`: passed.

## Residual risk

GitHub mutations are not transactional: an earlier label/edit may succeed before a later required action fails. The tool now returns nonzero and never reports success in that state, but it does not attempt rollback. A retry immediately after a successful comment could duplicate that comment.

## AI handoff

Updated because this PR establishes the maintained support and operational failure boundary of a repository automation helper.

Related to #1762.