### PR TITLE
fix(benchmarks): align fixtures with isolated RNG

### DIFF
--- a/benchmarks/expected/ceasefire_basic.json
+++ b/benchmarks/expected/ceasefire_basic.json
@@ -1,9 +1,17 @@
 {
-  "detail": "Success criteria met at round 2",
+  "detail": "Success criteria met at round 4",
   "history": [
     {
       "Faction_A": {
         "offer": 1
+      },
+      "Faction_B": {
+        "offer": 1
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 3
       },
       "Faction_B": {
         "offer": 2
@@ -11,13 +19,21 @@
     },
     {
       "Faction_A": {
-        "offer": 4
+        "offer": 2
+      },
+      "Faction_B": {
+        "offer": 2
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 1
       },
       "Faction_B": {
         "offer": 5
       }
     }
   ],
-  "rounds": 2,
+  "rounds": 4,
   "status": "success"
 }

--- a/benchmarks/expected/ceasefire_failure.json
+++ b/benchmarks/expected/ceasefire_failure.json
@@ -6,20 +6,20 @@
         "offer": 1
       },
       "Faction_B": {
-        "offer": 2
-      }
-    },
-    {
-      "Faction_A": {
-        "offer": 4
-      },
-      "Faction_B": {
-        "offer": 5
+        "offer": 1
       }
     },
     {
       "Faction_A": {
         "offer": 3
+      },
+      "Faction_B": {
+        "offer": 2
+      }
+    },
+    {
+      "Faction_A": {
+        "offer": 2
       },
       "Faction_B": {
         "offer": 2

--- a/benchmarks/expected/ceasefire_fragile.json
+++ b/benchmarks/expected/ceasefire_fragile.json
@@ -1,29 +1,40 @@
 {
-  "detail": "Success criteria met at round 2",
+  "detail": "Success criteria met at round 3",
   "history": [
     {
       "Faction_A": {
         "offer": 1
       },
       "Faction_B": {
-        "offer": 2
+        "offer": 1
       },
       "Mediator": {
-        "offer": 4
+        "offer": 3
       }
     },
     {
       "Faction_A": {
-        "offer": 5
+        "offer": 2
       },
       "Faction_B": {
-        "offer": 3
+        "offer": 2
       },
       "Mediator": {
         "offer": 2
       }
+    },
+    {
+      "Faction_A": {
+        "offer": 1
+      },
+      "Faction_B": {
+        "offer": 5
+      },
+      "Mediator": {
+        "offer": 1
+      }
     }
   ],
-  "rounds": 2,
+  "rounds": 3,
   "status": "success"
 }


### PR DESCRIPTION
## Root cause

The final integration tree for #1770 retained the isolated RNG implementation and updated runtime contract but accidentally omitted the three frozen expected-output files that had been reviewed in the PR. Because the benchmark job is advisory, GitHub CI remained green while `python benchmarks/run_benchmarks.py` failed 0/3 on `main`.

## Scoped correction

- restore the reviewed seed-42 output for `ceasefire_basic` (success at round 4);
- restore the reviewed seed-42 output for `ceasefire_fragile` (success at round 3);
- restore the reviewed seed-42 action stream for `ceasefire_failure` (failure after 3 rounds).

No runtime, schema, CLI, policy, documentation, workflow, or governance behavior changes in this PR.

## Impact

The byte-for-byte benchmark guard again matches the isolated RNG behavior and the already-versioned runtime contract. This does not claim improved scenario quality; it only freezes the explicitly reviewed deterministic outputs.

## Validation

- `158 passed, 12 skipped` (skips require PowerShell 7, unavailable locally)
- scenario benchmarks: `3 passed, 0 failed`
- narrative benchmarks: `4 passed, 0 failed`
- mojibake: clean (273 Markdown files)
- narrative consistency: 0 errors, 0 warnings
- `git diff --check`: pass

Related to #1755.