### PR TITLE
fix(site): repair verified portfolio regressions

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -1056,8 +1056,20 @@
   const motionButton = document.getElementById("globe-motion");
   if (!canvas || !motionButton) return;
 
+  function disableGlobeInteraction() {
+    canvas.classList.remove("is-ready");
+    canvas.setAttribute("aria-hidden", "true");
+    canvas.removeAttribute("tabindex");
+    canvas.hidden = true;
+    if (document.activeElement === canvas) canvas.blur();
+    motionButton.hidden = true;
+  }
+
   const context = canvas.getContext("2d", { alpha: true });
-  if (!context) return;
+  if (!context) {
+    disableGlobeInteraction();
+    return;
+  }
 
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   globePaused = reduceMotion.matches;
@@ -1414,8 +1426,7 @@
 
   const geographicSource = canvas.dataset.geoSource;
   if (!geographicSource) {
-    canvas.setAttribute("aria-hidden", "true");
-    motionButton.hidden = true;
+    disableGlobeInteraction();
     return;
   }
 
@@ -1435,7 +1446,6 @@
       drawGlobe();
     })
     .catch(() => {
-      canvas.setAttribute("aria-hidden", "true");
-      motionButton.hidden = true;
+      disableGlobeInteraction();
     });
 })();

--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -1693,6 +1693,12 @@
       }
     }
 
+    function redirectCount(redirects) {
+      if (Array.isArray(redirects)) return redirects.length;
+      if (Number.isInteger(redirects) && redirects >= 0) return redirects;
+      return 0;
+    }
+
     function buildIntakeRecord(raw, sourceUrl, intakePayload = null) {
       if (intakePayload) {
         return {
@@ -1852,7 +1858,7 @@
           <p><b>Original URL:</b> ${escapeHtml(intakeRecord.original_url || "not provided")}</p>
           <p><b>Final URL:</b> ${escapeHtml(intakeRecord.final_url || "not retrieved")}</p>
           <p><b>Domain / title:</b> ${escapeHtml(intakeRecord.source_domain || "not established")} · ${escapeHtml(intakeRecord.title || "not provided")}</p>
-          <p><b>Retrieved:</b> ${escapeHtml(intakeRecord.retrieved_at || "not retrieved")} · redirects=${escapeHtml(intakeRecord.redirects ?? 0)}</p>
+          <p><b>Retrieved:</b> ${escapeHtml(intakeRecord.retrieved_at || "not retrieved")} · redirects=${escapeHtml(redirectCount(intakeRecord.redirects))}</p>
           <p><b>Content:</b> ${escapeHtml(intakeRecord.content_type || "unknown")} · truncated=${escapeHtml(Boolean(intakeRecord.truncated))}</p>
           <p><b>Status:</b> ${escapeHtml(intakeRecord.status || "unknown")} · verification=${escapeHtml(intakeRecord.verification_status || "unreviewed")}</p>
           ${attributionNotice}
@@ -2239,6 +2245,46 @@
       return `${window.location.origin}${window.location.pathname}`;
     }
 
+    // OPERATOR_SHARE_PROVENANCE_START
+    function shareProvenanceLines(record) {
+      const intakeRecord = record?.intake_record;
+      const sourceUrl = (
+        intakeRecord?.final_url ||
+        intakeRecord?.original_url ||
+        record?.source_url ||
+        null
+      );
+
+      if (intakeRecord?.mode === "controlled-url") {
+        return [
+          "Provenance: retrieved through controlled URL intake; retrieval metadata is recorded, while source truth remains unverified.",
+          sourceUrl ? `Retrieved URL: ${compactText(sourceUrl, 240)}` : ""
+        ];
+      }
+
+      if (
+        intakeRecord?.mode === "operator-pasted-text-with-url" ||
+        intakeRecord?.attribution === "operator-provided-url-not-fetched"
+      ) {
+        return [
+          "Provenance: operator supplied the text and URL together; Operator did not fetch the URL, so URL-to-text attribution remains unverified.",
+          sourceUrl ? `Supplied URL (not fetched): ${compactText(sourceUrl, 240)}` : ""
+        ];
+      }
+
+      if (sourceUrl) {
+        return [
+          "Provenance: retrieval mode is unavailable; URL-to-text attribution remains unverified.",
+          `Recorded URL (attribution unverified): ${compactText(sourceUrl, 240)}`
+        ];
+      }
+
+      return [
+        "Provenance: operator-supplied text; no URL retrieval is claimed."
+      ];
+    }
+    // OPERATOR_SHARE_PROVENANCE_END
+
     function buildHumanShareText(record) {
       const lines = [
         "HUB_Optimus Operator snapshot",
@@ -2256,7 +2302,7 @@
         "",
         "Boundary: unverified local draft; not a truth verdict or engine result.",
         "Memory: this summary travels in the message. The link opens a clean Operator and does not restore this draft.",
-        record.source_url ? `Source reference: ${compactText(record.source_url, 240)}` : "",
+        ...shareProvenanceLines(record),
         `Open clean Operator: ${buildCleanOperatorUrl()}`
       ];
 

--- a/site/operator/sw.js
+++ b/site/operator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "hub-optimus-operator-v0-19";
+const CACHE_NAME = "hub-optimus-operator-v0-20";
 const OFFLINE_FALLBACK = "./index.html";
 const STATIC_ASSETS = [
   "./",
@@ -8,6 +8,9 @@ const STATIC_ASSETS = [
   "./og.svg",
   "../assets/brand/hub-optimus-logo-lockup.png"
 ];
+const STATIC_ASSET_URLS = new Set(
+  STATIC_ASSETS.map((asset) => new URL(asset, self.location.href).href)
+);
 
 async function cacheStaticAssets() {
   const cache = await caches.open(CACHE_NAME);
@@ -86,7 +89,10 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  if (url.pathname.includes("/operator/")) {
+  if (
+    url.pathname.includes("/operator/") ||
+    STATIC_ASSET_URLS.has(url.href)
+  ) {
     event.respondWith(cacheFirst(event.request));
   }
 });

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -29,6 +29,17 @@ def _intake_record_helpers(html: str) -> str:
     return match.group(1)
 
 
+def _share_provenance_helpers(html: str) -> str:
+    match = re.search(
+        r"// OPERATOR_SHARE_PROVENANCE_START\n(.*?)\n"
+        r"    // OPERATOR_SHARE_PROVENANCE_END",
+        html,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group(1)
+
+
 def test_operator_product_buttons_keep_existing_handlers():
     html = _read(INDEX)
 
@@ -79,7 +90,7 @@ def test_operator_progress_is_immediate_and_has_no_fake_delay_plan():
     assert "runSignalLoaderPlan" not in html
     assert "runMelonLoaderPlan" not in html
     assert "await wait(" not in html
-    assert "hub-optimus-operator-v0-19" in sw
+    assert "hub-optimus-operator-v0-20" in sw
 
 
 def test_operator_triage_is_generic_and_conservative():
@@ -144,7 +155,10 @@ const fetched = buildIntakeRecord("", "https://origin.example/report", {
   source_domain: "final.example",
   title: "Report",
   retrieved_at_utc: "2026-07-28T10:00:00+00:00",
-  redirects: 2,
+  redirects: [
+    {from: "https://origin.example/report", to: "https://middle.example/report", status: 302},
+    {from: "https://middle.example/report", to: "https://final.example/report", status: 301}
+  ],
   content_type: "text/html",
   truncated: true,
   verification_status: "unreviewed",
@@ -154,7 +168,8 @@ if (fetched.original_url !== "https://origin.example/report") throw new Error("o
 if (fetched.final_url !== "https://final.example/report") throw new Error("final URL lost");
 if (fetched.source_domain !== "final.example") throw new Error("source domain lost");
 if (fetched.retrieved_at !== "2026-07-28T10:00:00+00:00") throw new Error("retrieval time lost");
-if (fetched.redirects !== 2 || fetched.truncated !== true) throw new Error("fetch metadata lost");
+if (!Array.isArray(fetched.redirects) || fetched.redirects.length !== 2) throw new Error("redirect chain lost");
+if (redirectCount(fetched.redirects) !== 2 || fetched.truncated !== true) throw new Error("fetch metadata lost");
 if (fetched.status !== "ok" || fetched.verification_status !== "unreviewed") throw new Error("status lost");
 if (sourceReferenceForIntake(fetched) !== "https://final.example/report") throw new Error("final source ref not used");
 
@@ -175,6 +190,13 @@ if (sourceReferenceForIntake(pasted) !== "operator-pasted-text-with-unverified-u
         check=False,
     )
     assert completed.returncode == 0, completed.stderr
+
+
+def test_operator_renders_redirect_chain_as_a_count():
+    html = _read(INDEX)
+
+    assert "redirects=${escapeHtml(redirectCount(intakeRecord.redirects))}" in html
+    assert "redirects=${escapeHtml(intakeRecord.redirects" not in html
 
 
 def test_operator_does_not_auto_save_or_duplicate_current_draft():
@@ -210,6 +232,62 @@ def test_operator_memory_and_sharing_controls_remain_compatible():
     assert "`Open clean Operator: ${buildCleanOperatorUrl()}`" in html
 
 
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for JavaScript validation")
+def test_share_text_preserves_pasted_text_and_url_provenance():
+    helpers = _share_provenance_helpers(_read(INDEX))
+    smoke = (
+        """
+function compactText(value, maxLength) {
+  const normalized = String(value || "").trim();
+  return normalized.length <= maxLength
+    ? normalized
+    : `${normalized.slice(0, maxLength - 1)}…`;
+}
+"""
+        + helpers
+        + """
+const pasted = shareProvenanceLines({
+  source_url: "https://example.com/source",
+  intake_record: {
+    mode: "operator-pasted-text-with-url",
+    original_url: "https://example.com/source",
+    final_url: null,
+    attribution: "operator-provided-url-not-fetched"
+  }
+});
+if (!pasted[0].includes("Operator did not fetch the URL")) {
+  throw new Error("pasted text and URL boundary lost");
+}
+if (pasted[1] !== "Supplied URL (not fetched): https://example.com/source") {
+  throw new Error("unfetched URL label lost");
+}
+
+const fetched = shareProvenanceLines({
+  source_url: "https://final.example/report",
+  intake_record: {
+    mode: "controlled-url",
+    original_url: "https://origin.example/report",
+    final_url: "https://final.example/report"
+  }
+});
+if (!fetched[0].includes("controlled URL intake")) {
+  throw new Error("controlled intake provenance lost");
+}
+if (fetched[1] !== "Retrieved URL: https://final.example/report") {
+  throw new Error("retrieved URL label lost");
+}
+"""
+    )
+    completed = subprocess.run(
+        [NODE, "-"],
+        input=smoke,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
 def test_operator_url_fallback_remains_actionable():
     html = _read(INDEX)
 
@@ -222,7 +300,7 @@ def test_operator_url_fallback_remains_actionable():
     assert "Ready to read URL from controlled intake" in html
 
 
-def test_operator_install_assets_use_institutional_mark_and_cache_v019():
+def test_operator_install_assets_use_institutional_mark_and_cache_v020():
     icon = _read(ICON)
     sw = _read(SW)
 
@@ -232,10 +310,85 @@ def test_operator_install_assets_use_institutional_mark_and_cache_v019():
         icon,
         re.IGNORECASE,
     ) is None
-    assert "hub-optimus-operator-v0-19" in sw
+    assert "hub-optimus-operator-v0-20" in sw
     assert "./index.html" in sw
     assert "../assets/brand/hub-optimus-logo-lockup.png" in sw
     assert "./og.svg" in sw
+    assert "STATIC_ASSET_URLS.has(url.href)" in sw
+    assert "event.respondWith(cacheFirst(event.request))" in sw
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for JavaScript validation")
+def test_operator_service_worker_serves_precached_brand_asset_offline():
+    smoke = (
+        """
+const handlers = {};
+globalThis.self = {
+  location: {
+    origin: "https://huboptimus.dev",
+    href: "https://huboptimus.dev/operator/sw.js"
+  },
+  addEventListener(name, handler) {
+    handlers[name] = handler;
+  },
+  skipWaiting() {},
+  clients: {claim() {}}
+};
+globalThis.caches = {
+  async match(request) {
+    if (request.url === "https://huboptimus.dev/assets/brand/hub-optimus-logo-lockup.png") {
+      return {source: "precache"};
+    }
+    return null;
+  },
+  async open() {
+    return {
+      async addAll() {},
+      async put() {}
+    };
+  },
+  async keys() {
+    return [];
+  },
+  async delete() {
+    return true;
+  }
+};
+globalThis.fetch = async () => {
+  throw new Error("offline");
+};
+"""
+        + _read(SW)
+        + """
+(async () => {
+  let responsePromise = null;
+  handlers.fetch({
+    request: {
+      method: "GET",
+      mode: "no-cors",
+      url: "https://huboptimus.dev/assets/brand/hub-optimus-logo-lockup.png"
+    },
+    respondWith(value) {
+      responsePromise = value;
+    }
+  });
+  if (!responsePromise) throw new Error("brand request bypassed service worker");
+  const response = await responsePromise;
+  if (response?.source !== "precache") throw new Error("precache response not used");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+"""
+    )
+    completed = subprocess.run(
+        [NODE, "-"],
+        input=smoke,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_operator_result_copy_matches_local_draft_semantics():

--- a/tests/test_public_portfolio.py
+++ b/tests/test_public_portfolio.py
@@ -686,6 +686,10 @@ def test_globe_uses_real_geojson_with_attribution_and_accessible_controls():
     assert "@media (prefers-reduced-motion: reduce)" in css
     assert "touch-action: none" in css
     assert ".no-js #world-globe" in css
+    assert "function disableGlobeInteraction()" in app
+    assert 'canvas.removeAttribute("tabindex")' in app
+    assert "canvas.hidden = true" in app
+    assert app.count("disableGlobeInteraction();") == 3
 
 
 def test_public_files_exclude_rejected_branding_and_aggressive_language():


### PR DESCRIPTION
## Verified regressions

The merged portfolio exposed four behavior gaps that static link checks did not cover:

- a redirect-chain array rendered as `[object Object]` instead of a count;
- the Operator service worker precached the institutional logo but did not route that URL through its cache-first handler offline;
- globe initialization/data failures removed the accessible label but left an invisible focusable canvas;
- copied and WhatsApp summaries collapsed retrieved-URL provenance and operator-pasted text+URL provenance into the same generic source label.

## Scoped correction

- render redirect metadata through a defensive `redirectCount()` helper;
- serve every declared static precache URL through the service worker and bump the cache to `v0-20`;
- hide, unfocus and remove keyboard access from a globe canvas that cannot render;
- preserve explicit retrieved / supplied-not-fetched / unverified-attribution language in shared summaries;
- add executable Node-backed regressions, including an offline service-worker simulation.

No runtime, Semantic Engine, URL retrieval policy, translation claim, deployment, governance or globe-renderer implementation changes here. The WebGL globe is a separate review lane.

## Validation

- 170 Python tests passed; 12 skipped because PowerShell 7 is unavailable locally
- 33 focused web/PWA tests passed
- scenario benchmarks 3/3
- narrative benchmarks 4/4
- mojibake and narrative consistency clean
- JavaScript syntax and `git diff --check` pass

Related to #1736.