### PR TITLE
fix(operator): make intake state canonical

### DIFF
--- a/site/operator/index.html
+++ b/site/operator/index.html
@@ -884,6 +884,22 @@
           <input id="product_source_url" placeholder="https://example.com/news-or-github-source">
           <p class="field-hint">Used for controlled URL intake. If the source blocks access, paste the article text below.</p>
         </div>
+        <div class="field">
+          <label for="signal_source_type">Source type</label>
+          <select id="signal_source_type">
+            <option value="automatic">automatic from URL/text</option>
+            <option value="external-source">external source</option>
+            <option value="news-article">news article</option>
+            <option value="github-issue">GitHub issue</option>
+            <option value="github-pr">GitHub PR</option>
+            <option value="ci-failure">CI/runtime signal</option>
+            <option value="review-friction">review friction</option>
+            <option value="documentation-drift">documentation drift</option>
+            <option value="human-situation">human situation</option>
+            <option value="public-service-friction">public-service friction</option>
+          </select>
+          <p class="field-hint">Automatic classification is conservative. Select an explicit type here when the operator has a more accurate classification.</p>
+        </div>
       </div>
 
       <div class="field">
@@ -950,32 +966,21 @@
     <div class="grid">
       <section class="panel full" id="source_normalizer">
         <h2>Source-aware normalizer</h2>
-        <p>Paste a news URL, GitHub signal, copied article text, or human situation. HUB_Optimus will convert it into a structured, editable case without deciding whether the source is true.</p>
+        <p>This technical view uses the primary intake above. Its source projection is read-only here so URL, text, and source type cannot diverge from the material used to prepare the draft.</p>
 
-        <div class="row">
-          <div class="field">
-            <label for="signal_source_type">Source type</label>
-            <select id="signal_source_type">
-              <option value="external-source">external source</option>
-              <option value="news-article">news article</option>
-              <option value="github-issue">GitHub issue</option>
-              <option value="github-pr">GitHub PR</option>
-              <option value="ci-failure">CI/runtime signal</option>
-              <option value="review-friction">review friction</option>
-              <option value="documentation-drift">documentation drift</option>
-              <option value="human-situation">human situation</option>
-              <option value="public-service-friction">public-service friction</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="source_url">Source URL, optional</label>
-            <input id="source_url" placeholder="https://example.com/article-or-github-link">
-          </div>
+        <div class="row" aria-label="Canonical intake audit projection">
+          <article class="mini-card">
+            <h3>Source type</h3>
+            <p id="audit_source_type">external-source</p>
+          </article>
+          <article class="mini-card">
+            <h3>Source URL</h3>
+            <p id="audit_source_url">not provided</p>
+          </article>
         </div>
-
-        <div class="field">
-          <label for="source_text">Source text / copied article / situation</label>
-          <textarea id="source_text" placeholder="Paste the article text, GitHub issue body, PR description, CI failure excerpt, or human situation here."></textarea>
+        <div class="mini-card">
+          <h3>Source text</h3>
+          <pre id="audit_source_text">not provided</pre>
         </div>
 
         <div class="actions">
@@ -1755,9 +1760,11 @@
     // OPERATOR_INTAKE_RECORD_END
 
     function buildNormalizedPayload() {
-      const raw = value("source_text");
-      const sourceType = value("signal_source_type") || "human-situation";
-      const sourceUrl = value("source_url");
+      const {
+        sourceText: raw,
+        sourceType,
+        sourceUrl
+      } = canonicalIntakeState();
       const claimType = sourceTypeToClaimType(sourceType);
       const signal = sourceTypeToSignal(sourceType);
 
@@ -1970,6 +1977,7 @@
       setProductLoader(0, "idle");
     }
 
+    // OPERATOR_CANONICAL_INTAKE_START
     function inferProductSourceType(sourceUrl, raw) {
       if (!sourceUrl) return raw ? "human-situation" : "external-source";
 
@@ -1987,6 +1995,69 @@
 
       return "external-source";
     }
+
+    function canonicalIntakeState() {
+      const sourceUrl = value("product_source_url");
+      const sourceText = value("product_source_text");
+      const selectedSourceType = value("signal_source_type");
+
+      return {
+        sourceUrl,
+        sourceText,
+        sourceType: (
+          selectedSourceType && selectedSourceType !== "automatic"
+            ? selectedSourceType
+            : inferProductSourceType(sourceUrl, sourceText)
+        )
+      };
+    }
+
+    function syncAuditIntakeView(intakeState = canonicalIntakeState()) {
+      $("audit_source_type").textContent = intakeState.sourceType;
+      $("audit_source_url").textContent = intakeState.sourceUrl || "not provided";
+      $("audit_source_text").textContent = intakeState.sourceText
+        ? `${intakeState.sourceText.length} characters supplied in primary intake`
+        : "not provided";
+    }
+
+    function syncProductInputState({
+      resetIntakeRecord = true
+    } = {}) {
+      const analyzeButton = $("product_analyze");
+      const intakeState = canonicalIntakeState();
+
+      if (resetIntakeRecord) currentIntakeRecord = null;
+      currentMemoryRecord = null;
+      setMemoryActionsEnabled(false);
+      syncAuditIntakeView(intakeState);
+
+      if (!analyzeButton) return;
+
+      if (intakeState.sourceText) {
+        analyzeButton.disabled = false;
+        $("product_wait_status").textContent = intakeState.sourceUrl
+          ? "Ready to prepare a draft. Text-to-URL attribution will be marked as operator-provided and unverified."
+          : "Ready to prepare a local draft from operator-provided text.";
+        return;
+      }
+
+      if (intakeState.sourceUrl) {
+        analyzeButton.disabled = false;
+        $("product_wait_status").textContent = "Ready to read URL from controlled intake. If the source blocks access, paste the article text.";
+        return;
+      }
+
+      analyzeButton.disabled = true;
+      $("product_wait_status").textContent = "Paste a URL, paste text, or load the example to begin.";
+    }
+
+    function setCanonicalIntake(sourceUrl, sourceText, sourceType = null) {
+      $("product_source_url").value = sourceUrl;
+      $("product_source_text").value = sourceText;
+      $("signal_source_type").value = sourceType || "automatic";
+      syncProductInputState();
+    }
+    // OPERATOR_CANONICAL_INTAKE_END
 
     function reviewChecklistCard() {
       return `
@@ -2016,8 +2087,13 @@
     function renderProductOutput() {
       const output = $("product_output");
       const resultView = $("result_view");
+      const intakeState = canonicalIntakeState();
 
-      const profile = buildSourceProfile(value("source_text"), value("signal_source_type") || "human-situation", value("source_url"));
+      const profile = buildSourceProfile(
+        intakeState.sourceText,
+        intakeState.sourceType,
+        intakeState.sourceUrl
+      );
 
       output.innerHTML = `
         ${resultView.innerHTML}
@@ -2052,7 +2128,12 @@
 
     function buildMemoryRecord() {
       const payload = buildPayload();
-      const profile = buildSourceProfile(value("source_text"), value("signal_source_type") || "human-situation", value("source_url"));
+      const intakeState = canonicalIntakeState();
+      const profile = buildSourceProfile(
+        intakeState.sourceText,
+        intakeState.sourceType,
+        intakeState.sourceUrl
+      );
       const claim = payload.claims?.[0]?.text || "No claim generated.";
       const evidenceText = payload.evidence?.[0]?.text || "No evidence generated.";
 
@@ -2062,7 +2143,7 @@
         saved_at_utc: null,
         source_url: currentIntakeRecord?.final_url || currentIntakeRecord?.original_url || null,
         intake_record: currentIntakeRecord,
-        source_type: value("signal_source_type") || "human-situation",
+        source_type: intakeState.sourceType,
         signal_domain: profile.domain.id,
         signal_domain_label: profile.domain.label,
         actors: profile.actors,
@@ -2097,34 +2178,6 @@
     }
 
     const CONTROLLED_URL_INTAKE_ENDPOINT = "https://api.huboptimus.dev/intake/url";
-
-    function syncProductInputState() {
-      const raw = value("product_source_text");
-      const sourceUrl = value("product_source_url");
-      const analyzeButton = $("product_analyze");
-
-      if (!analyzeButton) return;
-      currentIntakeRecord = null;
-      currentMemoryRecord = null;
-      setMemoryActionsEnabled(false);
-
-      if (raw) {
-        analyzeButton.disabled = false;
-        $("product_wait_status").textContent = sourceUrl
-          ? "Ready to prepare a draft. Text-to-URL attribution will be marked as operator-provided and unverified."
-          : "Ready to prepare a local draft from operator-provided text.";
-        return;
-      }
-
-      if (sourceUrl) {
-        analyzeButton.disabled = false;
-        $("product_wait_status").textContent = "Ready to read URL from controlled intake. If the source blocks access, paste the article text.";
-        return;
-      }
-
-      analyzeButton.disabled = true;
-      $("product_wait_status").textContent = "Paste a URL, paste text, or load the example to begin.";
-    }
 
     function renderUrlIntakeFallback(sourceUrl, detail = "") {
       const detailLine = detail ? `<p class="meta">${escapeHtml(detail)}</p>` : "";
@@ -2368,8 +2421,9 @@
     }
 
     async function runProductAnalyze() {
-      let raw = value("product_source_text");
-      const sourceUrl = value("product_source_url");
+      const initialIntakeState = canonicalIntakeState();
+      let raw = initialIntakeState.sourceText;
+      const sourceUrl = initialIntakeState.sourceUrl;
       const analyzeButton = $("product_analyze");
 
       if (!raw && !sourceUrl) {
@@ -2400,6 +2454,7 @@
           raw = intake.text;
           currentIntakeRecord = buildIntakeRecord(raw, sourceUrl, intake);
           $("product_source_text").value = raw;
+          syncAuditIntakeView();
           $("product_wait_status").textContent = "URL retrieved. Preparing a provenance-aware draft…";
         } catch (error) {
           productStep("product_step_capture", "done");
@@ -2414,9 +2469,7 @@
         currentIntakeRecord = buildIntakeRecord(raw, sourceUrl);
       }
 
-      $("source_url").value = sourceUrl;
-      $("source_text").value = raw;
-      $("signal_source_type").value = inferProductSourceType(sourceUrl, raw);
+      syncAuditIntakeView();
 
       productStep("product_step_capture", "running");
       $("product_wait_status").textContent = "1/4 Capturing signal…";
@@ -2449,28 +2502,34 @@
     }
 
     function loadProductNewsDemo() {
-      $("product_source_url").value = "https://example.com/news-report";
-      $("product_source_text").value = "A news report says a public institution has introduced an automated decision system. The article says affected users may not receive clear explanations when decisions are made. The report cites complaints from several users but does not include the full administrative record or official technical documentation.";
-      syncProductInputState();
+      setCanonicalIntake(
+        "https://example.com/news-report",
+        "A news report says a public institution has introduced an automated decision system. The article says affected users may not receive clear explanations when decisions are made. The report cites complaints from several users but does not include the full administrative record or official technical documentation."
+      );
     }
 
     function openAdvancedConsole() {
       const advanced = $("advanced_operator_console");
       if (!advanced) return;
+      syncAuditIntakeView();
       advanced.open = true;
       advanced.scrollIntoView({ behavior: "smooth", block: "start" });
     }
 
     function loadNewsDemo() {
-      $("signal_source_type").value = "news-article";
-      $("source_url").value = "https://example.com/news-report";
-      $("source_text").value = "A news report says a public institution has introduced an automated decision system. The article says affected users may not receive clear explanations when decisions are made. The report cites complaints from several users but does not include the full administrative record or official technical documentation.";
+      setCanonicalIntake(
+        "https://example.com/news-report",
+        "A news report says a public institution has introduced an automated decision system. The article says affected users may not receive clear explanations when decisions are made. The report cites complaints from several users but does not include the full administrative record or official technical documentation.",
+        "news-article"
+      );
     }
 
     function loadGithubDemo() {
-      $("signal_source_type").value = "github-issue";
-      $("source_url").value = "https://github.com/Voxterrae/HUB_Optimus/issues/example";
-      $("source_text").value = "A contributor reports that the current workflow is unclear because the documentation says to use Related to #N while the PR template still suggests an auto-closing keyword. This may create contributor friction and accidental issue closure risk.";
+      setCanonicalIntake(
+        "https://github.com/Voxterrae/HUB_Optimus/issues/example",
+        "A contributor reports that the current workflow is unclear because the documentation says to use Related to #N while the PR template still suggests an auto-closing keyword. This may create contributor friction and accidental issue closure risk.",
+        "github-issue"
+      );
     }
 
     function loadDemo() {
@@ -2519,6 +2578,7 @@
       $("claim_requires").checked = true;
       $("case_id").value = "operator-case-001";
       $("core_version_ref").value = "main";
+      $("signal_source_type").value = "automatic";
       $("operational_signal").value = "none";
       $("intake_channel").value = "operator-pwa";
       claims = [];
@@ -2532,6 +2592,7 @@
       $("result_view").innerHTML = "";
       setMemoryActionsEnabled(false);
       resetProductProgress();
+      syncProductInputState();
       updateJson();
     }
 
@@ -2673,6 +2734,11 @@
 
     ["product_source_url", "product_source_text"].forEach((id) => {
       $(id).addEventListener("input", syncProductInputState);
+    });
+    $("signal_source_type").addEventListener("change", () => {
+      syncProductInputState({
+        resetIntakeRecord: false
+      });
     });
     $("save_memory_result").addEventListener("click", saveCurrentMemoryResult);
     $("share_memory_link").addEventListener("click", shareMemoryLink);

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -40,6 +40,17 @@ def _share_provenance_helpers(html: str) -> str:
     return match.group(1)
 
 
+def _canonical_intake_helpers(html: str) -> str:
+    match = re.search(
+        r"// OPERATOR_CANONICAL_INTAKE_START\n(.*?)\n"
+        r"    // OPERATOR_CANONICAL_INTAKE_END",
+        html,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group(1)
+
+
 def test_operator_product_buttons_keep_existing_handlers():
     html = _read(INDEX)
 
@@ -48,6 +59,134 @@ def test_operator_product_buttons_keep_existing_handlers():
     assert '$("product_analyze").addEventListener("click", runProductAnalyze);' in html
     assert '$("product_load_news_demo").addEventListener("click", loadProductNewsDemo);' in html
     assert '$("product_show_advanced").addEventListener("click", openAdvancedConsole);' in html
+
+
+def test_operator_has_one_editable_canonical_intake_surface():
+    html = _read(INDEX)
+    primary, advanced = html.split(
+        '<details class="advanced-shell" id="advanced_operator_console">',
+        maxsplit=1,
+    )
+
+    assert primary.count('id="product_source_url"') == 1
+    assert primary.count('id="product_source_text"') == 1
+    assert primary.count('id="signal_source_type"') == 1
+    assert 'id="source_url"' not in advanced
+    assert 'id="source_text"' not in advanced
+    assert 'id="signal_source_type"' not in advanced
+    assert 'id="audit_source_url"' in advanced
+    assert 'id="audit_source_text"' in advanced
+    assert 'id="audit_source_type"' in advanced
+    assert re.search(
+        r"<(?:input|textarea|select)[^>]+id=\"audit_source_",
+        advanced,
+    ) is None
+    assert 'value("source_url")' not in html
+    assert 'value("source_text")' not in html
+    assert '$("source_url")' not in html
+    assert '$("source_text")' not in html
+    assert "setCanonicalIntake(" in html
+    for helper_name in ("loadNewsDemo", "loadGithubDemo"):
+        helper = re.search(
+            rf"function {helper_name}\(\) \{{(.*?)\n    \}}",
+            html,
+            re.DOTALL,
+        )
+        assert helper is not None
+        assert "setCanonicalIntake(" in helper.group(1)
+    assert '$("signal_source_type").addEventListener("change"' in html
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js is required for JavaScript validation")
+def test_canonical_intake_syncs_audit_and_invalidates_stale_drafts():
+    helpers = _canonical_intake_helpers(_read(INDEX))
+    smoke = (
+        """
+const fields = {
+  product_source_url: {value: "https://github.com/Voxterrae/HUB_Optimus/issues/1736"},
+  product_source_text: {value: "Synthetic issue report for canonical intake testing."},
+  signal_source_type: {value: "automatic"},
+  audit_source_type: {textContent: ""},
+  audit_source_url: {textContent: ""},
+  audit_source_text: {textContent: ""},
+  product_analyze: {disabled: true},
+  product_wait_status: {textContent: ""}
+};
+const $ = (id) => fields[id];
+function value(id) {
+  return $(id).value.trim();
+}
+let currentIntakeRecord = {mode: "operator-pasted-text"};
+let currentMemoryRecord = {stale: true};
+let memoryActionsEnabled = true;
+function setMemoryActionsEnabled(enabled) {
+  memoryActionsEnabled = enabled;
+}
+"""
+        + helpers
+        + """
+syncProductInputState();
+if (fields.signal_source_type.value !== "automatic") {
+  throw new Error("automatic source-type mode was not preserved");
+}
+if (
+  fields.audit_source_type.textContent !== "github-issue" ||
+  fields.audit_source_url.textContent !== fields.product_source_url.value ||
+  fields.audit_source_text.textContent !== `${fields.product_source_text.value.length} characters supplied in primary intake`
+) {
+  throw new Error("advanced audit projection diverged from canonical intake");
+}
+if (currentIntakeRecord !== null || currentMemoryRecord !== null) {
+  throw new Error("changed canonical input retained stale prepared state");
+}
+if (memoryActionsEnabled || fields.product_analyze.disabled) {
+  throw new Error("changed canonical input did not reset actions correctly");
+}
+
+currentIntakeRecord = {mode: "controlled-url", original_url: fields.product_source_url.value};
+currentMemoryRecord = {stale: true};
+memoryActionsEnabled = true;
+fields.signal_source_type.value = "documentation-drift";
+syncProductInputState({resetIntakeRecord: false});
+if (fields.audit_source_type.textContent !== "documentation-drift") {
+  throw new Error("operator source-type correction was not projected to audit");
+}
+if (currentIntakeRecord?.mode !== "controlled-url") {
+  throw new Error("source-type correction discarded valid retrieval provenance");
+}
+if (currentMemoryRecord !== null || memoryActionsEnabled) {
+  throw new Error("source-type correction retained stale shareable output");
+}
+
+setCanonicalIntake(
+  "https://example.com/report",
+  "Synthetic advanced demo source text.",
+  "news-article"
+);
+if (
+  fields.product_source_url.value !== "https://example.com/report" ||
+  fields.product_source_text.value !== "Synthetic advanced demo source text." ||
+  fields.signal_source_type.value !== "news-article"
+) {
+  throw new Error("advanced action did not update the canonical public intake");
+}
+if (
+  fields.audit_source_url.textContent !== "https://example.com/report" ||
+  fields.audit_source_text.textContent !== "36 characters supplied in primary intake" ||
+  fields.audit_source_type.textContent !== "news-article"
+) {
+  throw new Error("advanced action left a stale audit projection");
+}
+"""
+    )
+    completed = subprocess.run(
+        [NODE, "-"],
+        input=smoke,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_operator_uses_only_controlled_url_intake_fetch():


### PR DESCRIPTION
Related to #1736.

## Verified problem

The public Operator and the Advanced/Audit console exposed separate editable URL/text fields. Those duplicate sources could diverge, so the draft, provenance display, and saved result were not guaranteed to describe the same operator input.

## Scoped correction

- keep URL, source text, and source type in one canonical public intake;
- move the source-type control beside that intake, with conservative automatic inference and an explicit operator override;
- render Advanced/Audit provenance as a derived, read-only projection;
- make both demo entry points update the canonical intake;
- invalidate stale generated/share state when material input changes;
- preserve a valid controlled-URL intake record when only the classification is corrected.

No intake endpoint, runtime contract, claims policy, or semantic capability changed.

## Validation

- focused web tests: 36 passed;
- complete repository suite: 207 passed, 12 skipped because PowerShell 7 is unavailable in the validation environment;
- scenarios: 3/3;
- narrative benchmarks: 4/4;
- consistency checker: 0 errors, 0 warnings;
- mojibake scan: 273 documents clean;
- `git diff --check`: clean.

## Review boundary

This PR is only an interface/state-integrity fix. Translation wording and the remaining runtime intake consolidation are reviewed separately so that claims and behavior stay traceable.