### PR TITLE
fix(intake): enforce authoritative scenario loading

### DIFF
--- a/SIMULATION_README.md
+++ b/SIMULATION_README.md
@@ -8,9 +8,9 @@ Este documento explica cómo utilizar el núcleo de simulación prototípico que
 
 | Archivo                      | Descripción                                                                                                      |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| `hub_optimus_simulator.py`  | Módulo que define las clases `Scenario`, `Actor` y `Simulator`, así como políticas sencillas de ejemplo.  Ejecuta rondas de negociación sobre escenarios ya validados. |
-| `run_scenario.py`           | Script de línea de comandos que valida un escenario JSON estricto e invoca el simulador para devolver un informe JSON.   |
-| `scenario.schema.json`      | Contrato JSON Schema canónico para los archivos de escenario ejecutables.                                         |
+| `hub_optimus_simulator.py`  | Módulo que define las clases `Scenario`, `Actor` y `Simulator`, así como políticas sencillas de ejemplo. Ejecuta rondas de negociación sobre escenarios ya validados. |
+| `run_scenario.py`           | Cargador canónico y script de línea de comandos que validan un escenario JSON estricto antes de invocar el simulador. |
+| `scenario.schema.json`      | Contrato estructural JSON Schema para los archivos de escenario ejecutables. |
 | `example_scenario.json`     | Escenario de ejemplo donde dos facciones negocian un alto el fuego parcial.                                        |
 | `i18n_sync.py`              | Utilidad para comprobar la coherencia de traducciones en la documentación (ver sección 5).                        |
 
@@ -51,7 +51,16 @@ python scripts/bootstrap.py --runtime-only --check
 
 ## 2. Estructura de un escenario
 
-Los escenarios ejecutables se describen mediante un archivo JSON que debe validar contra `scenario.schema.json`. El contrato actual es estricto: no se aceptan campos extra en la raíz del documento ni dentro de `roles[]`.
+Los escenarios ejecutables se describen mediante un archivo JSON que debe
+validar contra `scenario.schema.json`. El contrato actual es estricto: no se
+aceptan campos extra en la raíz del documento ni dentro de `roles[]`, y el
+decodificador rechaza las constantes no estándar `NaN`, `Infinity` y
+`-Infinity`. Solo se admite JSON; el runtime no implementa carga YAML.
+
+El JSON Schema valida la estructura de cada registro. El cargador canónico
+`run_scenario.load_validated_scenario()` aplica además la invariancia entre
+registros que exige nombres de actor únicos. `Scenario.from_json()` delega en
+ese mismo cargador y no introduce valores predeterminados permisivos.
 
 ```json
 {
@@ -67,7 +76,7 @@ Los escenarios ejecutables se describen mediante un archivo JSON que debe valida
 ```
 
 * `title` y `description` proporcionan contexto humano mínimo para el runtime.
-* `roles` define los actores que participarán en la negociación.  Cada elemento debe contener solo `name` y `role`.
+* `roles` define los actores que participarán en la negociación. Cada elemento debe contener solo `name` y `role`, y cada `name` debe ser único dentro del escenario.
 * `success_criteria` es un mapa de clave/valor.  La simulación se detiene cuando cualquier actor emite una acción que coincida con una clave y valor del criterio (por ejemplo, `{"offer": 5}`).
 * `max_rounds` limita el número máximo de rondas para evitar bucles infinitos.
 

--- a/docs/architecture/runtime_contract.md
+++ b/docs/architecture/runtime_contract.md
@@ -13,12 +13,12 @@ This document describes the technical architecture of the HUB_Optimus simulation
                  │ validates against
 ┌────────────────▼────────────────────────────┐
 │  scenario.schema.json   (contract)          │
-│  JSON Schema Draft 2020-12, strict          │
+│  JSON Schema Draft 2020-12, structural      │
 └────────────────┬────────────────────────────┘
                  │ accepted by
 ┌────────────────▼────────────────────────────┐
 │  run_scenario.py        (CLI runner)        │
-│  fail-fast validation, deterministic output │
+│  strict JSON + identity invariants           │
 └────────────────┬────────────────────────────┘
                  │ delegates to
 ┌────────────────▼────────────────────────────┐
@@ -44,7 +44,11 @@ File: `scenario.schema.json`
 - **Minimums:** `minLength: 1` on strings, `minItems: 1` on roles, `minimum: 1` on `max_rounds`
 - **Required fields:** `title`, `description`, `roles`, `success_criteria`, `max_rounds`
 
-The schema is the single source of input truth. No validation logic lives outside it.
+The schema is the source of truth for document and field structure. The
+authoritative loader in `run_scenario.py` applies cross-record invariants that
+JSON Schema does not express here: actor names must be unique within one
+scenario. The schema and loader together define executable scenario input
+validity; neither layer verifies real-world truth.
 
 ---
 
@@ -53,9 +57,13 @@ The schema is the single source of input truth. No validation logic lives outsid
 File: `run_scenario.py`
 
 ### Input handling
-- Reads scenario JSON → validates against schema → rejects with `[schema-error]` prefix
+- Decodes standard JSON and rejects `NaN`, `Infinity`, and `-Infinity`
+- Validates document structure against `scenario.schema.json`
+- Rejects duplicate actor names before constructing the runtime scenario
+- `Scenario.from_json()` delegates to this same authoritative loader
 - File/path errors → rejects with `[input-error]` prefix
-- All rejections use **exit code 2** (constant `INPUT_ERROR_EXIT_CODE`)
+- JSON, schema, identity, and file/path rejections use **exit code 2**
+  (constant `INPUT_ERROR_EXIT_CODE`)
 - Write failures (permissions, bad path, disk full) → caught as `OSError`, reported cleanly
 
 ### Output guarantees
@@ -71,7 +79,8 @@ File: `run_scenario.py`
 File: `hub_optimus_simulator.py`
 
 ### Components
-- **`Scenario`** — data container loaded from validated JSON
+- **`Scenario`** — data container for validated values; its compatibility
+  `from_json()` method delegates to the authoritative loader
 - **`Actor`** — wraps a role with a policy function; default policy: `{"offer": random.randint(1, 5)}`
 - **`Simulator`** — executes rounds, passes per-round `Random` instance to each actor, checks `success_criteria`
 
@@ -97,6 +106,7 @@ File: `hub_optimus_simulator.py`
 |---|---|
 | `tests/test_smoke.py` | Basic happy path |
 | `tests/test_run_scenario_cli.py` | CLI contract: happy path, determinism, error modes, schema guard |
+| `tests/test_scenario_loading.py` | Strict JSON, actor identity, and loader-entry-point parity |
 | `tests/test_regression_runner.py` | Whitespace rejection, additional properties, write errors, output format |
 | `tests/test_check_mojibake.py` | Mojibake detection: clean files, known patterns, directory recursion |
 

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -171,6 +171,30 @@ The boundary section of `docs/lab_state.md` is regenerated from the isolated
 simulator. Other mutation, gradient, and frontier observations remain
 historical until issue #1775 regenerates them.
 
+## Scenario Input Integrity Boundary
+
+Issue #1790 defines one authoritative external scenario-loading path:
+`run_scenario.load_validated_scenario`.
+
+Operational boundary:
+
+- the decoder accepts standard JSON and rejects the non-standard constants
+  `NaN`, `Infinity`, and `-Infinity`;
+- `scenario.schema.json` remains the structural field contract;
+- the authoritative loader additionally enforces unique actor names before
+  runtime construction, preventing dictionary-key collapse in simulation
+  history;
+- the supported CLI and the retained `Scenario.from_json()` convenience
+  method use that same loader and required-field behavior;
+- `Scenario.from_json()` supplies no permissive defaults and claims no YAML
+  support;
+- direct construction of `Scenario` remains an internal data-container path
+  for already validated or test-controlled values, not an external file
+  loader.
+
+These checks validate executable input integrity. They do not verify evidence,
+real-world claims, policy quality, or predictions.
+
 ## Telemetry Input Boundary
 
 Issue #1757 records that malformed scenario files could crash telemetry or

--- a/hub_optimus_simulator.py
+++ b/hub_optimus_simulator.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import copy
 import inspect
-import json
 import random
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 
@@ -72,8 +72,9 @@ def get_policy(name: str) -> NegotiationPolicy:
 class Scenario:
     """Data container for a negotiation scenario.
 
-    A scenario describes the context, participating actors and the success criteria for a negotiation.
-    It can be loaded from a JSON or YAML file (YAML support requires pyyaml).
+    A scenario describes the context, participating actors and the success
+    criteria for a negotiation. External JSON files must pass the authoritative
+    validation path exposed by ``run_scenario.load_validated_scenario``.
     """
 
     def __init__(
@@ -92,22 +93,22 @@ class Scenario:
 
     @classmethod
     def from_json(cls, filepath: str) -> "Scenario":
-        """Load a scenario from a JSON file.
+        """Load a strictly validated scenario from a JSON file.
 
-        Args:
-            filepath: Path to the scenario JSON file.
-
-        Returns:
-            A Scenario instance populated from the JSON data.
+        This compatibility method delegates to the same loader used by the
+        supported CLI. It does not supply defaults or support YAML.
         """
-        with open(filepath, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        from run_scenario import load_validated_scenario
+
+        scenario = load_validated_scenario(Path(filepath))
+        if cls is Scenario:
+            return scenario
         return cls(
-            title=data.get("title", "Unnamed scenario"),
-            description=data.get("description", ""),
-            roles=data.get("roles", []),
-            success_criteria=data.get("success_criteria", {}),
-            max_rounds=data.get("max_rounds", 5),
+            title=scenario.title,
+            description=scenario.description,
+            roles=scenario.roles,
+            success_criteria=scenario.success_criteria,
+            max_rounds=scenario.max_rounds,
         )
 
 

--- a/run_scenario.py
+++ b/run_scenario.py
@@ -1,5 +1,5 @@
 """
-Command-line utility to run negotiation scenarios with fail-fast input validation.
+Authoritative scenario loader and CLI with fail-fast input validation.
 """
 
 from __future__ import annotations
@@ -8,7 +8,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import jsonschema
 
@@ -27,14 +27,47 @@ def _load_schema() -> dict[str, Any]:
     return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
+def _reject_non_standard_json_constant(value: str) -> NoReturn:
+    raise ValueError(f"non-standard JSON constant {value!r} is not permitted")
+
+
+def _actor_identity_errors(payload: object) -> list[str]:
+    """Return cross-record actor identity errors after structural validation."""
+    if not isinstance(payload, dict):
+        return []
+    roles = payload.get("roles")
+    if not isinstance(roles, list):
+        return []
+
+    errors: list[str] = []
+    first_index_by_name: dict[str, int] = {}
+    for index, role in enumerate(roles):
+        if not isinstance(role, dict):
+            continue
+        name = role.get("name")
+        if not isinstance(name, str):
+            continue
+        if name in first_index_by_name:
+            errors.append(
+                f"roles.{index}.name: duplicate actor name {name!r}; "
+                f"first declared at roles.{first_index_by_name[name]}.name"
+            )
+        else:
+            first_index_by_name[name] = index
+    return errors
+
+
 def validate_scenario_payload(payload: object) -> list[str]:
+    """Return structural schema and cross-record identity errors."""
     schema = _load_schema()
     validator = jsonschema.Draft202012Validator(schema)
     errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
-    return [
+    messages = [
         f"{'.'.join(str(p) for p in e.path)}: {e.message}" if e.path else e.message
         for e in errors
     ]
+    messages.extend(_actor_identity_errors(payload))
+    return messages
 
 
 def load_validated_scenario(scenario_path: Path) -> Scenario:
@@ -44,11 +77,16 @@ def load_validated_scenario(scenario_path: Path) -> Scenario:
         raise ScenarioInputError(f"cannot read scenario file: {exc}") from exc
 
     try:
-        payload: Any = json.loads(source)
+        payload: Any = json.loads(
+            source,
+            parse_constant=_reject_non_standard_json_constant,
+        )
     except json.JSONDecodeError as exc:
         raise ValueError(
             f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
         ) from exc
+    except ValueError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
 
     errors = validate_scenario_payload(payload)
     if errors:

--- a/tests/test_scenario_loading.py
+++ b/tests/test_scenario_loading.py
@@ -1,0 +1,196 @@
+"""Regression tests for the authoritative scenario-loading boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import run_scenario
+from hub_optimus_simulator import Scenario
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCENARIO = REPO_ROOT / "run_scenario.py"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [sys.executable, str(RUN_SCENARIO), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+
+def _valid_payload() -> dict:
+    return {
+        "title": "Strict scenario",
+        "description": "Synthetic validation fixture.",
+        "roles": [
+            {"name": "Actor A", "role": "negotiator"},
+            {"name": "Actor B", "role": "mediator"},
+        ],
+        "success_criteria": {"offer": 5},
+        "max_rounds": 3,
+    }
+
+
+def _write_non_standard_constant(path: Path, constant: str) -> None:
+    payload = _valid_payload()
+    payload["success_criteria"]["offer"] = "__NON_STANDARD_CONSTANT__"
+    source = json.dumps(payload).replace(
+        '"__NON_STANDARD_CONSTANT__"',
+        constant,
+    )
+    path.write_text(source, encoding="utf-8")
+
+
+def _authoritative_loader(path: Path) -> Scenario:
+    return run_scenario.load_validated_scenario(path)
+
+
+def _compatibility_loader(path: Path) -> Scenario:
+    return Scenario.from_json(str(path))
+
+
+LOADERS: tuple[Callable[[Path], Scenario], ...] = (
+    _authoritative_loader,
+    _compatibility_loader,
+)
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_cli_rejects_non_standard_json_constants(
+    tmp_path: Path,
+    constant: str,
+) -> None:
+    scenario_path = tmp_path / "non_standard.json"
+    output_path = tmp_path / "result.json"
+    _write_non_standard_constant(scenario_path, constant)
+
+    proc = _run_cli(
+        "--scenario",
+        str(scenario_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == run_scenario.INPUT_ERROR_EXIT_CODE
+    assert proc.stdout == ""
+    assert proc.stderr.startswith("[schema-error] Invalid JSON:")
+    assert f"non-standard JSON constant {constant!r} is not permitted" in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert not output_path.exists()
+
+
+def test_cli_rejects_duplicate_actor_names_before_execution(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "duplicate_actors.json"
+    output_path = tmp_path / "result.json"
+    payload = _valid_payload()
+    payload["roles"][1]["name"] = payload["roles"][0]["name"]
+    scenario_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    proc = _run_cli(
+        "--scenario",
+        str(scenario_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == run_scenario.INPUT_ERROR_EXIT_CODE
+    assert proc.stdout == ""
+    assert proc.stderr.startswith("[schema-error]")
+    assert (
+        "roles.1.name: duplicate actor name 'Actor A'; "
+        "first declared at roles.0.name"
+    ) in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert not output_path.exists()
+
+
+@pytest.mark.parametrize("loader", LOADERS, ids=["authoritative", "compatibility"])
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_programmatic_loaders_reject_non_standard_json_constants(
+    tmp_path: Path,
+    loader: Callable[[Path], Scenario],
+    constant: str,
+) -> None:
+    scenario_path = tmp_path / "non_standard.json"
+    _write_non_standard_constant(scenario_path, constant)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"non-standard JSON constant {constant!r} is not permitted",
+    ):
+        loader(scenario_path)
+
+
+@pytest.mark.parametrize("loader", LOADERS, ids=["authoritative", "compatibility"])
+def test_programmatic_loaders_reject_duplicate_actor_names(
+    tmp_path: Path,
+    loader: Callable[[Path], Scenario],
+) -> None:
+    scenario_path = tmp_path / "duplicate_actors.json"
+    payload = _valid_payload()
+    payload["roles"][1]["name"] = payload["roles"][0]["name"]
+    scenario_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate actor name 'Actor A'"):
+        loader(scenario_path)
+
+
+@pytest.mark.parametrize("loader", LOADERS, ids=["authoritative", "compatibility"])
+def test_programmatic_loaders_share_required_field_validation(
+    tmp_path: Path,
+    loader: Callable[[Path], Scenario],
+) -> None:
+    scenario_path = tmp_path / "missing_fields.json"
+    scenario_path.write_text('{"title": "No permissive defaults"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="'description' is a required property"):
+        loader(scenario_path)
+
+
+def test_scenario_from_json_delegates_to_authoritative_loader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario_path = tmp_path / "delegated.json"
+    sentinel = Scenario(
+        title="Validated",
+        description="Returned by authoritative loader.",
+        roles=[{"name": "Actor", "role": "negotiator"}],
+        success_criteria={"offer": 5},
+        max_rounds=1,
+    )
+    received: list[Path] = []
+
+    def fake_loader(path: Path) -> Scenario:
+        received.append(path)
+        return sentinel
+
+    monkeypatch.setattr(run_scenario, "load_validated_scenario", fake_loader)
+
+    assert Scenario.from_json(str(scenario_path)) is sentinel
+    assert received == [scenario_path]
+
+
+def test_valid_loaders_return_equivalent_canonical_scenarios() -> None:
+    scenario_path = REPO_ROOT / "example_scenario.json"
+
+    authoritative = run_scenario.load_validated_scenario(scenario_path)
+    compatibility = Scenario.from_json(str(scenario_path))
+
+    assert vars(compatibility) == vars(authoritative)


### PR DESCRIPTION
Related to #1790.

## Verified problem

External scenario loading had two validation paths: the CLI used the schema, while `Scenario.from_json()` accepted missing fields through defaults. Python's JSON decoder also accepted non-standard `NaN`/`Infinity` constants, and duplicate actor names could collapse dictionary-keyed simulation history.

## Scoped correction

- make `run_scenario.load_validated_scenario()` the authoritative external loading path;
- decode standard JSON only and reject `NaN`, `Infinity`, and `-Infinity`;
- keep `scenario.schema.json` authoritative for document/field structure;
- add the cross-record invariant that actor names are unique within a scenario;
- make `Scenario.from_json()` delegate to the same loader with no permissive defaults or YAML claim;
- preserve direct `Scenario(...)` construction only as an internal container path for already validated/test-controlled values;
- document the exact structural/identity boundary without claiming evidence or real-world verification.

## Validation

- focused loader/runtime tests: 35 passed (plus 16 focused after final formatting correction);
- complete suite: 231 passed, 12 skipped because PowerShell 7 is unavailable in the validation environment;
- runtime benchmarks: 3/3;
- narrative benchmarks: 4/4;
- consistency checker: 0 errors, 0 warnings, 0 info;
- runtime-only bootstrap: Python 3.12.13 / jsonschema 4.26 passed;
- mojibake: 273 Markdown documents clean;
- Python compilation and `git diff --check`: clean.

## Explicit boundaries

Actor identity is exact and case-sensitive; Unicode/case normalization and duplicate JSON object keys are not added by this PR. There is no HTTP scenario-execution endpoint, so parity here covers the CLI, the programmatic loader, and `Scenario.from_json()`. No schema expansion, simulator semantics, policy, web surface, governance rule, or capability is introduced.