### PR TITLE
docs: align PR issue-link guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!-- What does this PR change? One or two sentences. -->
 
-Fixes #
+Related to #
 
 ## Type of change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The active Kernel and simulator.
 2. Comment on the issue to signal intent.
 3. Wait for informal assignment (to avoid duplicate work).
 4. Create a branch: `feat/<short-name>` or `chore/<short-name>`.
-5. Open a focused PR linked to the issue (`Fixes #N`).
+5. Open a focused PR linked to the issue (`Related to #N`).
 
 ---
 


### PR DESCRIPTION
Related to #1689.

The PR template and one onboarding step in `CONTRIBUTING.md` still encouraged `Fixes #N`, while the repository's maintainer policy requires contributors to use `Related to #N` and leave closure to maintainers.

This two-line documentation-only change makes both entry points use the same wording. No checklist, policy, runtime, workflow, schema, benchmark, or governance behavior changes.

Validation: 262 repository tests passed, 12 PowerShell-only tests skipped because PowerShell 7 is unavailable locally; mojibake scan for both files, exact wording guard, and `git diff --check` passed.