### PR TITLE
fix(ops): bind runs and deploys to provenance

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -95,6 +95,29 @@ Operational boundary:
 - The active workflow file, not this helper or chat context, determines
   whether scheduled maintenance invokes it.
 
+## EC2 Run Identity and Deployment Provenance Boundary
+
+Issue #1764 scopes the manually installed `ops/ec2` layer:
+
+- each `hub-core` operation creates its run directory exclusively, using a UTC
+  timestamp plus a random suffix, and emits that exact run ID;
+- the local `/analyze` API uses a per-request mode-`0600` temporary input,
+  removes it after execution, and binds its response to the run ID returned by
+  its own `hub-core` process rather than a shared "latest" lookup;
+- `deploy-current` requires one explicit full commit SHA or exact tag, resolves
+  it to a full commit SHA, and never deploys implicit branch HEAD;
+- deployment state records the actual validation command, exit code, result
+  line, and log instead of a hard-coded test count;
+- rollback verifies the target release against its recorded commit, restores
+  that release's deployment state and launcher, and writes an explicit
+  transition record;
+- deploy and rollback share one fail-fast host lock; neither operation
+  implicitly restarts the API service.
+
+These scripts remain a manually installed EC2 backend layer. Repository tests
+exercise their isolated contracts; only a reviewed deployment and runtime
+inspection can attest the state of a real EC2 host.
+
 ## Python Packaging Boundary
 
 Issue #1763 records drift between the documented Python minimum, executable

--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -58,6 +58,45 @@ POST /analyze returns direct JSON with:
 - run_path
 - analysis_result
 
+Each request is written to its own mode-`0600` temporary JSON file and removed
+after `hub-core` returns. The response uses the run ID emitted by that exact
+`hub-core analyze` process; it does not discover or infer the latest run.
+
+Run directories use UTC timestamps for readability plus an exclusive random
+suffix, for example `20260729T153012Z.aB3dE9`. `RUN_STATE` records that exact
+ID and the full release commit SHA.
+
+## Reviewed deployment and rollback
+
+Deployment has no implicit branch or repository-HEAD default:
+
+```bash
+deploy-current <full-commit-sha-or-tag>
+# or
+hub-ops deploy <full-commit-sha-or-tag>
+```
+
+A tag is resolved to its commit before checkout. Every successful release
+records the requested ref, its resolved full commit SHA, the exact validation
+command, its exit code, its final output line, and its validation log. Failed
+validation leaves its candidate release and metadata for inspection but never
+switches `current`.
+
+The script fixes and records the selected source revision; it does not itself
+prove that a commit or tag was reviewed or signed. GitHub review records and the
+human deploy decision remain the authority for that claim.
+
+Before switching, deployment preserves provenance for the current release.
+`rollback-current` verifies that the recorded commit still matches the target,
+switches explicitly to `previous_release`, restores that release's API launcher
+and deployment state, and writes a separate `ROLLBACK_STATE` transition record.
+Deploy and rollback share a non-blocking host lock so they cannot mutate release
+state concurrently.
+
+Neither operation silently restarts the running API service. After a deploy or
+rollback, an operator must review the recorded state and explicitly restart the
+service when the process should load the restored launcher.
+
 ## Installation note
 
 These scripts are documented from a validated EC2 instance. They are not automatically installed by this repository.
@@ -78,3 +117,9 @@ Runtime validation on EC2:
 hub-product
 hub-api-control status
 curl -sS http://127.0.0.1:8080/health
+
+Repository regression coverage:
+
+```bash
+python -m pytest -q tests/test_ec2_run_identity_and_provenance.py
+```

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -1,27 +1,150 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_ROOT="/opt/hub-optimus"
-REPO_URL="https://github.com/Voxterrae/HUB_Optimus.git"
-RELEASE_ID="$(date -u +%Y%m%dT%H%M%SZ)"
-RELEASE_DIR="$APP_ROOT/releases/$RELEASE_ID"
+APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
+REPO_URL="${HUB_OPTIMUS_REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
+DEPLOY_REF="${1:-}"
+VALIDATION_COMMAND_TEXT="python -m pytest -q"
 
-echo "[deploy] Starting HUB_Optimus deploy"
-echo "[deploy] Release: $RELEASE_ID"
+usage() {
+  cat <<USAGE
+HUB_Optimus explicit release deploy
 
-mkdir -p "$APP_ROOT/releases" "$APP_ROOT/shared/logs" "$APP_ROOT/shared/bin"
+Usage:
+  deploy-current <full-commit-sha-or-tag>
 
-if [ -e "$RELEASE_DIR" ]; then
-  echo "[deploy:error] Release directory already exists: $RELEASE_DIR"
+The requested ref must be a full 40-character commit SHA or an exact tag name.
+Branches and implicit repository HEAD are not deployment inputs.
+USAGE
+}
+
+fail() {
+  echo "[deploy:error] $*" >&2
   exit 1
+}
+
+state_value() {
+  local state_file="$1"
+  local key="$2"
+  if [ ! -f "$state_file" ]; then
+    return 0
+  fi
+  sed -n "s/^${key}=//p" "$state_file" 2>/dev/null | head -n 1
+}
+
+write_previous_release_state() {
+  local previous="$1"
+  local previous_state="$previous/.hub-deployment/RELEASE_STATE"
+
+  if [ -f "$previous_state" ]; then
+    return
+  fi
+
+  local previous_release
+  local previous_commit
+  local previous_validated_at
+  local previous_validation
+  local previous_status
+
+  previous_release="$(basename "$previous")"
+  previous_commit="$(git -C "$previous" rev-parse HEAD)"
+  previous_validated_at="$(
+    state_value "$APP_ROOT/shared/RELEASE_STATE" "validated_at_utc"
+  )"
+  previous_validation="$(
+    state_value "$APP_ROOT/shared/RELEASE_STATE" "validation"
+  )"
+  previous_status="$(
+    state_value "$APP_ROOT/shared/RELEASE_STATE" "status"
+  )"
+
+  mkdir -p "$previous/.hub-deployment"
+  chmod 0700 "$previous/.hub-deployment"
+  if [ -d "$previous/.git/info" ]; then
+    grep -qxF ".hub-deployment/" "$previous/.git/info/exclude" \
+      || echo ".hub-deployment/" >> "$previous/.git/info/exclude"
+  fi
+
+  cat > "$previous_state" <<STATE
+release=$previous_release
+requested_ref=unrecorded-pre-1764
+requested_ref_kind=legacy
+commit=$previous_commit
+path=$previous
+validated_at_utc=${previous_validated_at:-unknown}
+validation_command=unrecorded-pre-1764
+validation_exit_code=unknown
+validation_result=unverified legacy metadata: ${previous_validation:-not recorded}
+status=${previous_status:-legacy-release}
+provenance=adopted-pre-1764
+STATE
+  chmod 0600 "$previous_state"
+}
+
+case "$APP_ROOT" in
+  /*) ;;
+  *) fail "HUB_OPTIMUS_APP_ROOT must be an absolute path." ;;
+esac
+
+case "$DEPLOY_REF" in
+  ""|-h|--help|help)
+    usage
+    if [ -z "$DEPLOY_REF" ]; then
+      exit 2
+    fi
+    exit 0
+    ;;
+esac
+
+if [ "$#" -ne 1 ]; then
+  usage >&2
+  fail "exactly one full commit SHA or tag is required."
 fi
 
-echo "[deploy] Cloning repository"
-git clone --depth 1 "$REPO_URL" "$RELEASE_DIR"
+if [[ "$DEPLOY_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  REF_KIND="commit"
+  FETCH_REF="$DEPLOY_REF"
+else
+  REF_KIND="tag"
+  git check-ref-format "refs/tags/$DEPLOY_REF" >/dev/null 2>&1 \
+    || fail "invalid tag name: $DEPLOY_REF"
+  FETCH_REF="refs/tags/$DEPLOY_REF"
+fi
 
-cd "$RELEASE_DIR"
+echo "[deploy] Starting HUB_Optimus deploy"
+echo "[deploy] Requested $REF_KIND: $DEPLOY_REF"
 
+mkdir -p "$APP_ROOT/releases" "$APP_ROOT/shared/logs" "$APP_ROOT/shared/bin"
+exec 9> "$APP_ROOT/shared/deploy.lock"
+flock -n 9 || fail "another deploy or rollback operation is active."
+RELEASE_DIR="$(mktemp -d "$APP_ROOT/releases/$(date -u +%Y%m%dT%H%M%SZ).XXXXXX")"
+RELEASE_ID="$(basename "$RELEASE_DIR")"
+DEPLOYMENT_DIR="$RELEASE_DIR/.hub-deployment"
+DEPLOYMENT_STATE="$DEPLOYMENT_DIR/RELEASE_STATE"
+VALIDATION_LOG="$DEPLOYMENT_DIR/validation.log"
+
+echo "[deploy] Release: $RELEASE_ID"
+echo "[deploy] Fetching explicit selected ref"
+git init --quiet "$RELEASE_DIR"
+git -C "$RELEASE_DIR" remote add origin "$REPO_URL"
+git -C "$RELEASE_DIR" fetch --quiet --depth 1 origin "$FETCH_REF"
+
+RESOLVED_COMMIT="$(
+  git -C "$RELEASE_DIR" rev-parse --verify 'FETCH_HEAD^{commit}'
+)"
+
+if [ "$REF_KIND" = "commit" ]; then
+  NORMALIZED_REF="$(printf '%s' "$DEPLOY_REF" | tr 'A-F' 'a-f')"
+  if [ "$RESOLVED_COMMIT" != "$NORMALIZED_REF" ]; then
+    fail "fetched commit does not match requested SHA."
+  fi
+fi
+
+git -C "$RELEASE_DIR" checkout --quiet --detach "$RESOLVED_COMMIT"
+
+echo "[deploy] Resolved commit: $RESOLVED_COMMIT"
 echo "[deploy] Creating venv"
+cd "$RELEASE_DIR"
 python3 -m venv .venv
 source .venv/bin/activate
 
@@ -29,22 +152,70 @@ echo "[deploy] Installing dependencies"
 python -m pip install --upgrade pip
 python -m pip install -r requirements-dev.txt
 
-echo "[deploy] Running tests"
-python -m pytest -q
+mkdir -p "$DEPLOYMENT_DIR"
+chmod 0700 "$DEPLOYMENT_DIR"
+
+echo "[deploy] Running validation: $VALIDATION_COMMAND_TEXT"
+set +e
+python -m pytest -q 2>&1 | tee "$VALIDATION_LOG"
+VALIDATION_PIPE_STATUS=("${PIPESTATUS[@]}")
+set -e
+VALIDATION_EXIT_CODE="${VALIDATION_PIPE_STATUS[0]}"
+VALIDATION_LOG_EXIT_CODE="${VALIDATION_PIPE_STATUS[1]}"
 
 deactivate
 
-echo "[deploy] Hiding local venv from git status"
-grep -qxF ".venv/" "$RELEASE_DIR/.git/info/exclude" || echo ".venv/" >> "$RELEASE_DIR/.git/info/exclude"
+VALIDATION_RESULT="$(
+  awk 'NF { result=$0 } END { print result == "" ? "no output" : result }' \
+    "$VALIDATION_LOG"
+)"
+
+if [ "$VALIDATION_EXIT_CODE" -eq 0 ] \
+  && [ "$VALIDATION_LOG_EXIT_CODE" -eq 0 ]; then
+  RELEASE_STATUS="production-candidate-core"
+else
+  RELEASE_STATUS="validation-failed"
+fi
+
+cat > "$DEPLOYMENT_STATE" <<STATE
+release=$RELEASE_ID
+requested_ref=$DEPLOY_REF
+requested_ref_kind=$REF_KIND
+commit=$RESOLVED_COMMIT
+path=$RELEASE_DIR
+validated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+validation_command=$VALIDATION_COMMAND_TEXT
+validation_exit_code=$VALIDATION_EXIT_CODE
+validation_result=$VALIDATION_RESULT
+validation_log=$VALIDATION_LOG
+validation_log_exit_code=$VALIDATION_LOG_EXIT_CODE
+status=$RELEASE_STATUS
+STATE
+chmod 0600 "$DEPLOYMENT_STATE" "$VALIDATION_LOG"
+
+echo "[deploy] Hiding local deployment files from git status"
+for excluded_path in ".venv/" ".hub-deployment/"; do
+  grep -qxF "$excluded_path" "$RELEASE_DIR/.git/info/exclude" \
+    || echo "$excluded_path" >> "$RELEASE_DIR/.git/info/exclude"
+done
+
+if [ "$VALIDATION_LOG_EXIT_CODE" -ne 0 ]; then
+  fail "validation output could not be recorded (tee exit $VALIDATION_LOG_EXIT_CODE)."
+fi
+
+if [ "$VALIDATION_EXIT_CODE" -ne 0 ]; then
+  fail "validation failed (exit $VALIDATION_EXIT_CODE): $VALIDATION_RESULT"
+fi
 
 echo "[deploy] Verifying hub-api launcher source"
 if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then
-  echo "[deploy:error] Missing hub-api launcher source: $RELEASE_DIR/ops/ec2/hub-api.sh"
+  echo "[deploy:error] Missing hub-api launcher source: $RELEASE_DIR/ops/ec2/hub-api.sh" >&2
   exit 1
 fi
 
 if [ -L "$APP_ROOT/current" ]; then
   PREVIOUS="$(readlink -f "$APP_ROOT/current")"
+  write_previous_release_state "$PREVIOUS"
   echo "$PREVIOUS" > "$APP_ROOT/shared/previous_release"
   echo "[deploy] Previous release: $PREVIOUS"
 else
@@ -58,27 +229,17 @@ mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
 echo "[deploy] Syncing hub-api launcher"
 install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"
 
-cd "$APP_ROOT/current"
-
-COMMIT="$(git rev-parse --short HEAD)"
-CURRENT_PATH="$(readlink -f "$APP_ROOT/current")"
-
-cat > "$APP_ROOT/shared/RELEASE_STATE" <<STATE
-release=$RELEASE_ID
-commit=$COMMIT
-path=$CURRENT_PATH
-validated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-validation=pytest 55 passed
-status=production-candidate-core
-STATE
-
+install -m 0644 "$DEPLOYMENT_STATE" "$APP_ROOT/shared/RELEASE_STATE.new"
+mv -Tf "$APP_ROOT/shared/RELEASE_STATE.new" "$APP_ROOT/shared/RELEASE_STATE"
 echo "$RELEASE_ID" > "$APP_ROOT/shared/current_release"
+
+cd "$APP_ROOT/current"
 
 echo "[deploy] Current release:"
 readlink -f "$APP_ROOT/current"
 
 echo "[deploy] Git commit:"
-git rev-parse --short HEAD
+git rev-parse HEAD
 
 echo "[deploy] Git status:"
 git status --short

--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -15,9 +15,11 @@ import datetime as dt
 import html
 import ipaddress
 import json
+import os
 import re
 import socket
 import subprocess
+import tempfile
 from html.parser import HTMLParser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -37,6 +39,8 @@ MAX_EXTRACTED_TEXT_CHARS = 24_000
 MAX_REDIRECTS = 3
 URL_TIMEOUT_SECONDS = 8
 USER_AGENT = "HUB_Optimus-Operator-URL-Intake/0.1 (+https://huboptimus.dev/operator/)"
+CORE_RUN_ID_PREFIX = "[hub-core:run-id] "
+CORE_RUN_ID_PATTERN = re.compile(r"\A\d{8}T\d{6}Z\.[A-Za-z0-9]{6}\Z")
 
 
 class IntakeError(Exception):
@@ -157,12 +161,16 @@ def product_status() -> dict:
     }
 
 
-def latest_run_id(command: str) -> str | None:
-    command_dir = SHARED / "runs" / command
-    if not command_dir.is_dir():
+def core_run_id(stdout: str) -> str | None:
+    candidates = [
+        line.removeprefix(CORE_RUN_ID_PREFIX)
+        for line in stdout.splitlines()
+        if line.startswith(CORE_RUN_ID_PREFIX)
+    ]
+    if len(candidates) != 1:
         return None
-    runs = sorted(p.name for p in command_dir.iterdir() if p.is_dir())
-    return runs[-1] if runs else None
+    run_id = candidates[0]
+    return run_id if CORE_RUN_ID_PATTERN.fullmatch(run_id) else None
 
 
 def blocked_ip_reason(ip_text: str) -> str | None:
@@ -470,45 +478,88 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         case_dir = SHARED / "api" / "cases"
-        case_dir.mkdir(parents=True, exist_ok=True)
-        case_path = case_dir / "api-case.json"
-        case_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
+        case_path: Path | None = None
+        try:
+            case_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            case_dir.chmod(0o700)
+            descriptor, raw_case_path = tempfile.mkstemp(
+                prefix="case-",
+                suffix=".json",
+                dir=case_dir,
+            )
+            case_path = Path(raw_case_path)
+            with os.fdopen(
+                descriptor,
+                "w",
+                encoding="utf-8",
+                newline="\n",
+            ) as case_file:
+                case_file.write(
+                    json.dumps(
+                        payload,
+                        indent=2,
+                        sort_keys=True,
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+        except OSError as exc:
+            if case_path is not None:
+                try:
+                    case_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            self.send_json(500, {"error": f"cannot create temporary case input: {exc}"})
+            return
 
-        before_latest = latest_run_id("analyze")
+        cleanup_error: OSError | None = None
+        try:
+            code, stdout, stderr = run_command([
+                "/opt/hub-optimus/shared/bin/hub-core",
+                "analyze",
+                str(case_path),
+            ])
+        except OSError as exc:
+            code, stdout, stderr = 1, "", str(exc)
+        finally:
+            try:
+                case_path.unlink()
+            except OSError as exc:
+                cleanup_error = exc
 
-        code, stdout, stderr = run_command([
-            "/opt/hub-optimus/shared/bin/hub-core",
-            "analyze",
-            str(case_path),
-        ])
+        if cleanup_error is not None:
+            self.send_json(500, {"error": "cannot remove temporary case input"})
+            return
 
-        after_latest = latest_run_id("analyze")
-
+        run_id = core_run_id(stdout)
         if code != 0:
+            failure = {
+                "error": "analysis failed",
+                "stderr": stderr,
+                "stdout": stdout,
+            }
+            if run_id is not None:
+                failure["run_id"] = run_id
+                failure["run_path"] = str(
+                    SHARED / "runs" / "analyze" / run_id
+                )
+            self.send_json(
+                500,
+                failure,
+            )
+            return
+
+        if run_id is None:
             self.send_json(
                 500,
                 {
-                    "error": "analysis failed",
-                    "stderr": stderr,
+                    "error": "analysis completed without one valid run identity",
                     "stdout": stdout,
                 },
             )
             return
 
-        if not after_latest or after_latest == before_latest:
-            self.send_json(
-                500,
-                {
-                    "error": "analysis completed but run output was not detected",
-                    "stdout": stdout,
-                },
-            )
-            return
-
-        run_path = SHARED / "runs" / "analyze" / after_latest
+        run_path = SHARED / "runs" / "analyze" / run_id
         result_path = run_path / "analysis_result.json"
 
         try:
@@ -524,7 +575,7 @@ class Handler(BaseHTTPRequestHandler):
             200,
             {
                 "status": "ok",
-                "run_id": after_latest,
+                "run_id": run_id,
                 "run_path": str(run_path),
                 "analysis_result": analysis_result,
             },

--- a/ops/ec2/hub-core.sh
+++ b/ops/ec2/hub-core.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_ROOT="/opt/hub-optimus"
+APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 RUN_ROOT="$APP_ROOT/shared/runs"
+RUN_ID_PREFIX="[hub-core:run-id]"
+ACTIVE_RELEASE_PATH=""
+ACTIVE_RELEASE=""
+ACTIVE_COMMIT=""
+
+umask 077
 
 usage() {
   cat <<USAGE
@@ -28,63 +34,76 @@ Commands:
 USAGE
 }
 
-require_current() {
+pin_current_release() {
   if [ ! -L "$APP_ROOT/current" ]; then
     echo "[hub-core:error] current symlink does not exist."
     exit 1
   fi
-  cd "$APP_ROOT/current"
+
+  ACTIVE_RELEASE_PATH="$(readlink -f "$APP_ROOT/current")"
+  if [ ! -d "$ACTIVE_RELEASE_PATH" ]; then
+    echo "[hub-core:error] current release target does not exist."
+    exit 1
+  fi
+
+  ACTIVE_RELEASE="$(basename "$ACTIVE_RELEASE_PATH")"
+  ACTIVE_COMMIT="$(git -C "$ACTIVE_RELEASE_PATH" rev-parse HEAD)"
+  cd "$ACTIVE_RELEASE_PATH"
 }
 
 activate_current() {
-  require_current
-  if [ ! -d ".venv" ]; then
+  pin_current_release
+  if [ ! -d "$ACTIVE_RELEASE_PATH/.venv" ]; then
     echo "[hub-core:error] .venv does not exist in current release."
     exit 1
   fi
-  source .venv/bin/activate
+  source "$ACTIVE_RELEASE_PATH/.venv/bin/activate"
 }
 
 new_run_dir() {
   local name="$1"
   local ts
   ts="$(date -u +%Y%m%dT%H%M%SZ)"
-  local dir="$RUN_ROOT/$name/$ts"
-  mkdir -p "$dir"
-  echo "$dir"
+  local command_root="$RUN_ROOT/$name"
+
+  mkdir -p "$command_root"
+  chmod 0700 "$command_root"
+  mktemp -d "$command_root/$ts.XXXXXX"
+}
+
+announce_run() {
+  local dir="$1"
+  printf '%s %s\n' "$RUN_ID_PREFIX" "$(basename "$dir")"
 }
 
 write_run_meta() {
   local dir="$1"
   local command_name="$2"
   local input_path="${3:-}"
-  local commit
-  local release
-  local current_path
-
-  require_current
-  commit="$(git rev-parse --short HEAD)"
-  current_path="$(readlink -f "$APP_ROOT/current")"
-  release="$(basename "$current_path")"
+  if [ -z "$ACTIVE_RELEASE_PATH" ] || [ -z "$ACTIVE_COMMIT" ]; then
+    echo "[hub-core:error] active release was not pinned." >&2
+    exit 1
+  fi
 
   cat > "$dir/RUN_STATE" <<STATE
+run_id=$(basename "$dir")
 command=$command_name
-release=$release
-commit=$commit
-path=$current_path
+release=$ACTIVE_RELEASE
+commit=$ACTIVE_COMMIT
+path=$ACTIVE_RELEASE_PATH
 input=$input_path
 ran_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 STATE
 }
 
 status_core() {
-  require_current
+  pin_current_release
 
   echo "[hub-core] HUB_Optimus core"
   echo
 
   echo "[hub-core] current:"
-  readlink -f "$APP_ROOT/current"
+  echo "$ACTIVE_RELEASE_PATH"
   echo
 
   echo "[hub-core] release_state:"
@@ -92,7 +111,7 @@ status_core() {
   echo
 
   echo "[hub-core] commit:"
-  git rev-parse --short HEAD
+  echo "$ACTIVE_COMMIT"
   echo
 
   echo "[hub-core] available commands:"
@@ -105,6 +124,7 @@ run_tests() {
   local dir
   dir="$(new_run_dir test)"
   write_run_meta "$dir" "test"
+  announce_run "$dir"
 
   echo "[hub-core:test] Output dir: $dir"
   python -m pytest -q | tee "$dir/pytest.log"
@@ -119,6 +139,7 @@ run_benchmark() {
   local dir
   dir="$(new_run_dir benchmark)"
   write_run_meta "$dir" "benchmark"
+  announce_run "$dir"
 
   echo "[hub-core:benchmark] Output dir: $dir"
   python benchmarks/run_benchmarks.py --summary-file "$dir/benchmark_summary.md" | tee "$dir/benchmark.log"
@@ -133,6 +154,7 @@ run_narrative_benchmark() {
   local dir
   dir="$(new_run_dir narrative-benchmark)"
   write_run_meta "$dir" "narrative-benchmark"
+  announce_run "$dir"
 
   echo "[hub-core:narrative-benchmark] Output dir: $dir"
   python benchmarks/run_narrative_benchmarks.py | tee "$dir/narrative_benchmark.log"
@@ -147,6 +169,7 @@ run_semantic_smoke() {
   local dir
   dir="$(new_run_dir semantic-smoke)"
   write_run_meta "$dir" "semantic-smoke"
+  announce_run "$dir"
 
   echo "[hub-core:semantic-smoke] Output dir: $dir"
   python -m semantic_engine.cli analyze \
@@ -166,6 +189,7 @@ run_scenario_smoke() {
   local dir
   dir="$(new_run_dir scenario-smoke)"
   write_run_meta "$dir" "scenario-smoke"
+  announce_run "$dir"
 
   echo "[hub-core:scenario-smoke] Output dir: $dir"
   python run_scenario.py \
@@ -194,15 +218,16 @@ run_analyze() {
     exit 1
   fi
 
+  input="$(readlink -f "$input")"
   activate_current
 
   local dir
   dir="$(new_run_dir analyze)"
-  write_run_meta "$dir" "analyze" "$input"
+  cp "$input" "$dir/input_case.json"
+  write_run_meta "$dir" "analyze" "$dir/input_case.json"
+  announce_run "$dir"
 
   echo "[hub-core:analyze] Output dir: $dir"
-
-  cp "$input" "$dir/input_case.json"
 
   python -m semantic_engine.cli analyze \
     "$dir/input_case.json" \

--- a/ops/ec2/hub-ops.sh
+++ b/ops/ec2/hub-ops.sh
@@ -10,13 +10,13 @@ HUB_Optimus EC2 ops
 Usage:
   hub-ops status
   hub-ops validate
-  hub-ops deploy
+  hub-ops deploy <commit-sha-or-tag>
   hub-ops rollback
 
 Commands:
   status    Show current release, previous release, state, commit, git status, releases and disk usage.
   validate  Run pytest on current release and show commit/status.
-  deploy    Run deploy-current.
+  deploy    Deploy one explicit reviewed full commit SHA or tag.
   rollback  Run rollback-current.
 USAGE
 }
@@ -108,7 +108,8 @@ case "${1:-}" in
     validate_current
     ;;
   deploy)
-    exec "$APP_ROOT/shared/bin/deploy-current"
+    shift
+    exec "$APP_ROOT/shared/bin/deploy-current" "$@"
     ;;
   rollback)
     exec "$APP_ROOT/shared/bin/rollback-current"

--- a/ops/ec2/rollback-current.sh
+++ b/ops/ec2/rollback-current.sh
@@ -1,24 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_ROOT="/opt/hub-optimus"
+APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
+
+fail() {
+  echo "[rollback:error] $*" >&2
+  exit 1
+}
+
+state_value() {
+  local state_file="$1"
+  local key="$2"
+  sed -n "s/^${key}=//p" "$state_file" | head -n 1
+}
+
+case "$APP_ROOT" in
+  /*) ;;
+  *) fail "HUB_OPTIMUS_APP_ROOT must be an absolute path." ;;
+esac
+
+exec 9> "$APP_ROOT/shared/deploy.lock"
+flock -n 9 || fail "another deploy or rollback operation is active."
 
 if [ ! -L "$APP_ROOT/current" ]; then
-  echo "[rollback:error] Current symlink does not exist."
-  exit 1
+  fail "Current symlink does not exist."
 fi
 
 if [ ! -f "$APP_ROOT/shared/previous_release" ]; then
-  echo "[rollback] No previous release recorded."
-  exit 1
+  fail "No previous release recorded."
 fi
 
 CURRENT="$(readlink -f "$APP_ROOT/current")"
-PREVIOUS="$(cat "$APP_ROOT/shared/previous_release")"
+PREVIOUS="$(readlink -f "$(cat "$APP_ROOT/shared/previous_release")")"
+
+case "$PREVIOUS" in
+  "$APP_ROOT/releases/"*) ;;
+  *) fail "Previous release is outside the managed releases directory: $PREVIOUS" ;;
+esac
 
 if [ ! -d "$PREVIOUS" ]; then
-  echo "[rollback:error] Previous release path does not exist: $PREVIOUS"
-  exit 1
+  fail "Previous release path does not exist: $PREVIOUS"
 fi
 
 if [ "$CURRENT" = "$PREVIOUS" ]; then
@@ -27,30 +48,53 @@ if [ "$CURRENT" = "$PREVIOUS" ]; then
   exit 0
 fi
 
+PREVIOUS_STATE="$PREVIOUS/.hub-deployment/RELEASE_STATE"
+if [ ! -f "$PREVIOUS_STATE" ]; then
+  fail "Previous release has no recorded deployment state: $PREVIOUS_STATE"
+fi
+
+if [ ! -f "$PREVIOUS/ops/ec2/hub-api.sh" ]; then
+  fail "Previous release has no hub-api launcher: $PREVIOUS/ops/ec2/hub-api.sh"
+fi
+
+RECORDED_COMMIT="$(state_value "$PREVIOUS_STATE" "commit")"
+ACTUAL_COMMIT="$(git -C "$PREVIOUS" rev-parse HEAD)"
+if [ -z "$RECORDED_COMMIT" ] || [ "$RECORDED_COMMIT" != "$ACTUAL_COMMIT" ]; then
+  fail "Previous release commit does not match its deployment state."
+fi
+
+CURRENT_COMMIT="$(git -C "$CURRENT" rev-parse HEAD)"
+CURRENT_RELEASE="$(basename "$CURRENT")"
+PREVIOUS_RELEASE="$(basename "$PREVIOUS")"
+
 echo "$CURRENT" > "$APP_ROOT/shared/last_rollback_from"
 
 ln -sfn "$PREVIOUS" "$APP_ROOT/current.new"
 mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
 
-cd "$APP_ROOT/current"
+install -m 0755 \
+  "$APP_ROOT/current/ops/ec2/hub-api.sh" \
+  "$APP_ROOT/shared/bin/hub-api"
+install -m 0644 "$PREVIOUS_STATE" "$APP_ROOT/shared/RELEASE_STATE.new"
+mv -Tf "$APP_ROOT/shared/RELEASE_STATE.new" "$APP_ROOT/shared/RELEASE_STATE"
 
-RELEASE="$(basename "$(readlink -f "$APP_ROOT/current")")"
-COMMIT="$(git rev-parse --short HEAD)"
-CURRENT_PATH="$(readlink -f "$APP_ROOT/current")"
-
-cat > "$APP_ROOT/shared/RELEASE_STATE" <<STATE
-release=$RELEASE
-commit=$COMMIT
-path=$CURRENT_PATH
-validated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-validation=rollback to previously validated release
-status=production-candidate-core
+cat > "$APP_ROOT/shared/ROLLBACK_STATE.new" <<STATE
+rolled_back_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+from_release=$CURRENT_RELEASE
+from_commit=$CURRENT_COMMIT
+to_release=$PREVIOUS_RELEASE
+to_commit=$ACTUAL_COMMIT
 STATE
+chmod 0600 "$APP_ROOT/shared/ROLLBACK_STATE.new"
+mv -Tf "$APP_ROOT/shared/ROLLBACK_STATE.new" "$APP_ROOT/shared/ROLLBACK_STATE"
 
-echo "$RELEASE" > "$APP_ROOT/shared/current_release"
+echo "$PREVIOUS_RELEASE" > "$APP_ROOT/shared/current_release"
 
 echo "[rollback] Rolled back to:"
 readlink -f "$APP_ROOT/current"
 
 echo "[rollback] Release state:"
 cat "$APP_ROOT/shared/RELEASE_STATE"
+
+echo "[rollback] Rollback state:"
+cat "$APP_ROOT/shared/ROLLBACK_STATE"

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HUB_CORE = ROOT / "ops" / "ec2" / "hub-core.sh"
+HUB_API = ROOT / "ops" / "ec2" / "hub-api.sh"
+HUB_OPS = ROOT / "ops" / "ec2" / "hub-ops.sh"
+DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
+ROLLBACK = ROOT / "ops" / "ec2" / "rollback-current.sh"
+RUN_ID_RE = re.compile(r"^\d{8}T\d{6}Z\.[A-Za-z0-9]{6}$")
+
+
+def _run(
+    args: list[str | Path],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(arg) for arg in args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = _run(["git", "-C", repo, *args])
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _init_git_repo(path: Path) -> str:
+    path.mkdir(parents=True)
+    assert _run(["git", "init", "-q", path]).returncode == 0
+    _git(path, "config", "user.email", "tests@example.invalid")
+    _git(path, "config", "user.name", "HUB tests")
+    (path / "tracked.txt").write_text("release\n", encoding="utf-8")
+    _git(path, "add", "tracked.txt")
+    _git(path, "commit", "-qm", "test release")
+    return _git(path, "rev-parse", "HEAD")
+
+
+def _state(path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+
+
+def _load_embedded_api_namespace() -> dict:
+    script = HUB_API.read_text(encoding="utf-8")
+    embedded = script.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    namespace = {"__name__": "hub_api_run_identity_test"}
+    exec(compile(embedded, str(HUB_API), "exec"), namespace)
+    return namespace
+
+
+def _fake_runtime_bin(path: Path) -> Path:
+    bin_dir = path / "fake-bin"
+    bin_dir.mkdir()
+    python = bin_dir / "python"
+    python.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf 'fake pytest passed\\n'\n",
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+
+    date = bin_dir / "date"
+    date.write_text(
+        "#!/usr/bin/env bash\n"
+        "case \"$*\" in\n"
+        "  *+%Y%m%dT%H%M%SZ*) printf '20260729T120000Z\\n' ;;\n"
+        "  *+%Y-%m-%dT%H:%M:%SZ*) printf '2026-07-29T12:00:00Z\\n' ;;\n"
+        "  *) exec /bin/date \"$@\" ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    date.chmod(0o755)
+    return bin_dir
+
+
+def test_same_second_hub_core_runs_get_exclusive_ids(tmp_path: Path) -> None:
+    app_root = tmp_path / "app"
+    release = app_root / "releases" / "current-release"
+    commit = _init_git_repo(release)
+    (release / ".venv" / "bin").mkdir(parents=True)
+    (release / ".venv" / "bin" / "activate").write_text(
+        "deactivate() { :; }\n",
+        encoding="utf-8",
+    )
+    (app_root / "shared").mkdir(parents=True)
+    (app_root / "current").symlink_to(release, target_is_directory=True)
+
+    fake_bin = _fake_runtime_bin(tmp_path)
+    env = os.environ.copy()
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    processes = [
+        subprocess.Popen(
+            ["bash", str(HUB_CORE), "test"],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for _ in range(12)
+    ]
+    completed = [process.communicate(timeout=20) for process in processes]
+
+    run_ids: list[str] = []
+    for process, (stdout, stderr) in zip(processes, completed, strict=True):
+        assert process.returncode == 0, stderr
+        marker = re.search(r"^\[hub-core:run-id\] (\S+)$", stdout, re.MULTILINE)
+        assert marker is not None
+        run_ids.append(marker.group(1))
+
+    assert len(set(run_ids)) == len(run_ids)
+    assert all(run_id.startswith("20260729T120000Z.") for run_id in run_ids)
+    assert all(RUN_ID_RE.fullmatch(run_id) for run_id in run_ids)
+
+    for run_id in run_ids:
+        run_dir = app_root / "shared" / "runs" / "test" / run_id
+        run_state = _state(run_dir / "RUN_STATE")
+        assert stat.S_IMODE(run_dir.stat().st_mode) == 0o700
+        assert run_state["run_id"] == run_id
+        assert run_state["commit"] == commit
+
+
+def test_hub_core_pins_one_release_for_the_complete_run(
+    tmp_path: Path,
+) -> None:
+    app_root = tmp_path / "app"
+    release_a = app_root / "releases" / "release-a"
+    release_b = app_root / "releases" / "release-b"
+    commit_a = _init_git_repo(release_a)
+    _init_git_repo(release_b)
+    (release_b / "tracked.txt").write_text("release-b\n", encoding="utf-8")
+    _git(release_b, "add", "tracked.txt")
+    _git(release_b, "commit", "-qm", "different release")
+    commit_b = _git(release_b, "rev-parse", "HEAD")
+    assert commit_a != commit_b
+
+    ready = tmp_path / "engine-ready"
+    proceed = tmp_path / "engine-proceed"
+    activate = release_a / ".venv" / "bin" / "activate"
+    activate.parent.mkdir(parents=True)
+    activate.write_text(
+        "python() {\n"
+        "  touch \"$HUB_TEST_ENGINE_READY\"\n"
+        "  while [ ! -f \"$HUB_TEST_ENGINE_PROCEED\" ]; do sleep 0.01; done\n"
+        "  local previous=''\n"
+        "  local output=''\n"
+        "  for argument in \"$@\"; do\n"
+        "    if [ \"$previous\" = '--output' ]; then output=\"$argument\"; fi\n"
+        "    previous=\"$argument\"\n"
+        "  done\n"
+        "  printf '{\"release_path\":\"%s\"}\\n' \"$PWD\" > \"$output\"\n"
+        "}\n"
+        "deactivate() { :; }\n",
+        encoding="utf-8",
+    )
+
+    (app_root / "shared").mkdir(parents=True)
+    current = app_root / "current"
+    current.symlink_to(release_a, target_is_directory=True)
+    input_path = tmp_path / "case.json"
+    input_path.write_text("{}\n", encoding="utf-8")
+    fake_bin = _fake_runtime_bin(tmp_path)
+    env = os.environ.copy()
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+    env["HUB_TEST_ENGINE_READY"] = str(ready)
+    env["HUB_TEST_ENGINE_PROCEED"] = str(proceed)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    process = subprocess.Popen(
+        ["bash", str(HUB_CORE), "analyze", str(input_path)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    deadline = time.monotonic() + 5
+    while not ready.exists() and process.poll() is None:
+        if time.monotonic() >= deadline:
+            process.kill()
+            raise AssertionError("fake engine did not start")
+        time.sleep(0.01)
+
+    replacement = app_root / "current.new"
+    replacement.symlink_to(release_b, target_is_directory=True)
+    os.replace(replacement, current)
+    proceed.touch()
+    stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode == 0, stderr
+    marker = re.search(r"^\[hub-core:run-id\] (\S+)$", stdout, re.MULTILINE)
+    assert marker is not None
+    run_dir = app_root / "shared" / "runs" / "analyze" / marker.group(1)
+    run_state = _state(run_dir / "RUN_STATE")
+    result = json.loads((run_dir / "analysis_result.json").read_text())
+    assert current.resolve() == release_b
+    assert run_state["path"] == str(release_a)
+    assert run_state["release"] == "release-a"
+    assert run_state["commit"] == commit_a
+    assert run_state["input"] == str(run_dir / "input_case.json")
+    assert result["release_path"] == str(release_a)
+
+
+def test_api_uses_its_own_run_marker_and_cleans_private_input(
+    tmp_path: Path,
+) -> None:
+    namespace = _load_embedded_api_namespace()
+    shared = tmp_path / "shared"
+    namespace["SHARED"] = shared
+    target_run_id = "20260729T120000Z.Ab12Cd"
+    unrelated_run_id = "20260729T120000Z.Zz99Yy"
+    payload = {
+        "case_id": "request-bound",
+        "core_version_ref": "v1",
+        "input_summary": "Request-owned input.",
+    }
+    seen_case_paths: list[Path] = []
+
+    def fake_run_command(
+        args: list[str],
+        input_text: str | None = None,
+    ) -> tuple[int, str, str]:
+        assert input_text is None
+        assert args[:2] == [
+            "/opt/hub-optimus/shared/bin/hub-core",
+            "analyze",
+        ]
+        case_path = Path(args[2])
+        seen_case_paths.append(case_path)
+        assert case_path.name.startswith("case-")
+        assert case_path.name != "api-case.json"
+        assert stat.S_IMODE(case_path.stat().st_mode) == 0o600
+        assert json.loads(case_path.read_text(encoding="utf-8")) == payload
+
+        target_dir = shared / "runs" / "analyze" / target_run_id
+        unrelated_dir = shared / "runs" / "analyze" / unrelated_run_id
+        target_dir.mkdir(parents=True)
+        unrelated_dir.mkdir(parents=True)
+        (target_dir / "analysis_result.json").write_text(
+            '{"case_id":"request-bound","status":"draft"}\n',
+            encoding="utf-8",
+        )
+        (unrelated_dir / "analysis_result.json").write_text(
+            '{"case_id":"unrelated","status":"draft"}\n',
+            encoding="utf-8",
+        )
+        return (
+            0,
+            f"[hub-core:run-id] {target_run_id}\n",
+            "",
+        )
+
+    namespace["run_command"] = fake_run_command
+    handler = object.__new__(namespace["Handler"])
+    handler.read_json_body = lambda limit: payload
+    responses: list[tuple[int, dict]] = []
+    handler.send_json = lambda status_code, body: responses.append(
+        (status_code, body)
+    )
+
+    handler.handle_analyze()
+
+    assert len(seen_case_paths) == 1
+    assert not seen_case_paths[0].exists()
+    assert stat.S_IMODE(seen_case_paths[0].parent.stat().st_mode) == 0o700
+    assert responses == [
+        (
+            200,
+            {
+                "status": "ok",
+                "run_id": target_run_id,
+                "run_path": str(
+                    shared / "runs" / "analyze" / target_run_id
+                ),
+                "analysis_result": {
+                    "case_id": "request-bound",
+                    "status": "draft",
+                },
+            },
+        )
+    ]
+
+
+def test_api_rejects_missing_ambiguous_or_unsafe_run_markers() -> None:
+    namespace = _load_embedded_api_namespace()
+    parse = namespace["core_run_id"]
+    valid = "20260729T120000Z.Ab12Cd"
+
+    assert parse(f"[hub-core:run-id] {valid}\n") == valid
+    assert parse("") is None
+    assert parse(
+        f"[hub-core:run-id] {valid}\n[hub-core:run-id] {valid}\n"
+    ) is None
+    assert parse("[hub-core:run-id] ../../current\n") is None
+
+
+def test_api_failure_keeps_its_run_identity_and_cleans_input(
+    tmp_path: Path,
+) -> None:
+    namespace = _load_embedded_api_namespace()
+    shared = tmp_path / "shared"
+    namespace["SHARED"] = shared
+    run_id = "20260729T120000Z.Fa11Ed"
+    seen_case_path: Path | None = None
+
+    def fake_run_command(
+        args: list[str],
+        input_text: str | None = None,
+    ) -> tuple[int, str, str]:
+        nonlocal seen_case_path
+        assert input_text is None
+        seen_case_path = Path(args[2])
+        assert seen_case_path.exists()
+        return 1, f"[hub-core:run-id] {run_id}\n", "engine failed"
+
+    namespace["run_command"] = fake_run_command
+    handler = object.__new__(namespace["Handler"])
+    handler.read_json_body = lambda limit: {
+        "case_id": "failed-request",
+        "core_version_ref": "v1",
+        "input_summary": "Failure fixture.",
+    }
+    responses: list[tuple[int, dict]] = []
+    handler.send_json = lambda status_code, body: responses.append(
+        (status_code, body)
+    )
+
+    handler.handle_analyze()
+
+    assert seen_case_path is not None
+    assert not seen_case_path.exists()
+    assert responses == [
+        (
+            500,
+            {
+                "error": "analysis failed",
+                "stderr": "engine failed",
+                "stdout": f"[hub-core:run-id] {run_id}\n",
+                "run_id": run_id,
+                "run_path": str(shared / "runs" / "analyze" / run_id),
+            },
+        )
+    ]
+
+
+def _source_repository(path: Path) -> tuple[str, str]:
+    path.mkdir()
+    assert _run(["git", "init", "-q", path]).returncode == 0
+    _git(path, "config", "user.email", "tests@example.invalid")
+    _git(path, "config", "user.name", "HUB tests")
+
+    (path / "ops" / "ec2").mkdir(parents=True)
+    (path / "requirements-dev.txt").write_text("pytest\n", encoding="utf-8")
+    launcher = path / "ops" / "ec2" / "hub-api.sh"
+    launcher.write_text("#!/usr/bin/env bash\necho api-v1\n", encoding="utf-8")
+    launcher.chmod(0o755)
+    (path / "version.txt").write_text("reviewed\n", encoding="utf-8")
+    _git(path, "add", ".")
+    _git(path, "commit", "-qm", "reviewed release")
+    reviewed_commit = _git(path, "rev-parse", "HEAD")
+    _git(path, "tag", "reviewed-v1")
+
+    launcher.write_text("#!/usr/bin/env bash\necho api-v2\n", encoding="utf-8")
+    (path / "version.txt").write_text("newer-head\n", encoding="utf-8")
+    _git(path, "add", ".")
+    _git(path, "commit", "-qm", "newer branch head")
+    head_commit = _git(path, "rev-parse", "HEAD")
+    return reviewed_commit, head_commit
+
+
+def _fake_deploy_python(path: Path) -> Path:
+    bin_dir = path / "deploy-bin"
+    bin_dir.mkdir()
+    python3 = bin_dir / "python3"
+    python3.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        "test \"${1:-}\" = '-m'\n"
+        "test \"${2:-}\" = 'venv'\n"
+        "mkdir -p \"$3/bin\"\n"
+        "cat > \"$3/bin/activate\" <<'ACTIVATE'\n"
+        "python() {\n"
+        "  if [ \"${1:-}\" = '-m' ] && [ \"${2:-}\" = 'pytest' ]; then\n"
+        "    printf '%s\\n' \"${HUB_TEST_VALIDATION_OUTPUT:-17 passed in 0.01s}\"\n"
+        "    return \"${HUB_TEST_VALIDATION_EXIT:-0}\"\n"
+        "  fi\n"
+        "  return 0\n"
+        "}\n"
+        "deactivate() { :; }\n"
+        "ACTIVATE\n",
+        encoding="utf-8",
+    )
+    python3.chmod(0o755)
+    return bin_dir
+
+
+def _deploy_env(
+    app_root: Path,
+    source_repo: Path,
+    fake_bin: Path,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+    env["HUB_OPTIMUS_REPO_URL"] = str(source_repo)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    return env
+
+
+def test_deploy_is_ref_bound_records_validation_and_rolls_back(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, "reviewed-v1"], env=env)
+    assert first.returncode == 0, first.stderr
+    first_release = (app_root / "current").resolve()
+    assert _git(first_release, "rev-parse", "HEAD") == reviewed_commit
+    first_state = _state(app_root / "shared" / "RELEASE_STATE")
+    assert first_state["requested_ref"] == "reviewed-v1"
+    assert first_state["requested_ref_kind"] == "tag"
+    assert first_state["commit"] == reviewed_commit
+    assert first_state["validation_command"] == "python -m pytest -q"
+    assert first_state["validation_exit_code"] == "0"
+    assert first_state["validation_log_exit_code"] == "0"
+    assert first_state["validation_result"] == "17 passed in 0.01s"
+    assert "55 passed" not in (app_root / "shared" / "RELEASE_STATE").read_text()
+
+    second = _run([DEPLOY, head_commit], env=env)
+    assert second.returncode == 0, second.stderr
+    second_release = (app_root / "current").resolve()
+    assert second_release != first_release
+    assert _git(second_release, "rev-parse", "HEAD") == head_commit
+    second_state = _state(app_root / "shared" / "RELEASE_STATE")
+    assert second_state["requested_ref"] == head_commit
+    assert second_state["requested_ref_kind"] == "commit"
+    assert second_state["commit"] == head_commit
+    assert (app_root / "shared" / "bin" / "hub-api").read_text(
+        encoding="utf-8"
+    ).endswith("echo api-v2\n")
+
+    rolled_back = _run([ROLLBACK], env=env)
+    assert rolled_back.returncode == 0, rolled_back.stderr
+    assert (app_root / "current").resolve() == first_release
+    restored_state = _state(app_root / "shared" / "RELEASE_STATE")
+    assert restored_state["commit"] == reviewed_commit
+    rollback_state = _state(app_root / "shared" / "ROLLBACK_STATE")
+    assert rollback_state["from_commit"] == head_commit
+    assert rollback_state["to_commit"] == reviewed_commit
+    assert (app_root / "shared" / "bin" / "hub-api").read_text(
+        encoding="utf-8"
+    ).endswith("echo api-v1\n")
+
+
+def test_failed_validation_is_recorded_without_switching_current(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, _ = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+    env["HUB_TEST_VALIDATION_EXIT"] = "1"
+    env["HUB_TEST_VALIDATION_OUTPUT"] = "2 failed in 0.01s"
+
+    result = _run([DEPLOY, reviewed_commit], env=env)
+
+    assert result.returncode == 1
+    assert "validation failed (exit 1): 2 failed in 0.01s" in result.stderr
+    assert not (app_root / "current").exists()
+    releases = list((app_root / "releases").iterdir())
+    assert len(releases) == 1
+    failed_state = _state(
+        releases[0] / ".hub-deployment" / "RELEASE_STATE"
+    )
+    assert failed_state["commit"] == reviewed_commit
+    assert failed_state["validation_command"] == "python -m pytest -q"
+    assert failed_state["validation_exit_code"] == "1"
+    assert failed_state["validation_result"] == "2 failed in 0.01s"
+    assert failed_state["status"] == "validation-failed"
+
+
+def test_deploy_requires_explicit_ref_and_hub_ops_forwards_it(
+    tmp_path: Path,
+) -> None:
+    app_root = tmp_path / "app"
+    env = os.environ.copy()
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+
+    result = _run([DEPLOY], env=env)
+
+    assert result.returncode == 2
+    assert not (app_root / "current").exists()
+    hub_ops = HUB_OPS.read_text(encoding="utf-8")
+    assert "  deploy)\n    shift\n" in hub_ops
+    assert 'deploy-current" "$@"' in hub_ops


### PR DESCRIPTION
Related to #1764.

## Verified defects

- run directories used second-resolution timestamps and could collide or mix outputs;
- the API associated a response with the lexicographically latest run rather than the exact invocation;
- deploy cloned implicit repository HEAD and wrote a hard-coded validation summary;
- rollback restored only the symlink, not the matching launcher and deployment provenance.

## Scoped correction

- pin one release path and full commit SHA for each core invocation; create private collision-safe run IDs and archive the exact input in that run;
- have the core emit one validated run marker and make the API use only that marker, with per-request `0600` temporary input and cleanup;
- require deploy by exactly one full SHA or exact tag, fetch/checkout detached, record the resolved full SHA, real validation command/exit/result/log, and never promote a failed release;
- serialize deploy/rollback, confine rollback targets, verify commit against the release manifest, and restore symlink, launcher, and provenance together.

## Validation

- focused EC2/API tests: 19 passed;
- complete suite: 270 passed, 12 skipped because PowerShell 7 is unavailable locally;
- scenario benchmarks: 3/3; narrative benchmarks: 5/5;
- narrative consistency: 0 errors, 0 warnings, 0 info;
- 274 Markdown documents passed mojibake checks;
- runtime bootstrap, `bash -n ops/ec2/*.sh`, Python compilation, and `git diff --check` passed.

## Explicit boundaries

A tag is pinned to its resolved SHA but this does not prove signature or review. A pre-#1764 release is adopted with explicit `unrecorded`/`unknown`/`unverified` fields. Deploy/rollback do not silently restart `hub-api`; the lock is not a power-loss transaction. The scripts remain manually installed EC2 tooling and repository tests do not attest a live instance or systemd configuration. No Semantic Engine, schema, website, CI, governance rule, or capability changes.