### PR TITLE
fix(bootstrap): verify every declared development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ python -m pip install -r requirements.txt
 python run_scenario.py example_scenario.json --seed 42
 ```
 
-Development and test tooling is separate in `requirements-dev.txt`. See
+Development and test tooling is separate in `requirements-dev.txt`; it adds
+`pytest` and `PyYAML` to the runtime tier. See
 [SIMULATION_README.md](SIMULATION_README.md) for the complete bootstrap
 contract.
 

--- a/SIMULATION_README.md
+++ b/SIMULATION_README.md
@@ -35,7 +35,8 @@ python -m pip install -r requirements.txt
 
 `requirements.txt` contiene únicamente dependencias necesarias para ejecutar
 los comandos soportados. Para desarrollar y ejecutar la suite instala
-`requirements-dev.txt`; este incluye el fichero de runtime y añade `pytest`:
+`requirements-dev.txt`; este incluye el fichero de runtime y añade `pytest` y
+`PyYAML`:
 
 ```bash
 python -m pip install -r requirements-dev.txt
@@ -48,6 +49,10 @@ python scripts/bootstrap.py --runtime-only
 python scripts/bootstrap.py
 python scripts/bootstrap.py --runtime-only --check
 ```
+
+El modo `--check` verifica cada dependencia directa declarada para el nivel
+seleccionado, incluido el paquete `PyYAML` mediante su módulo importable
+`yaml`; no instala paquetes ni ejecuta la suite.
 
 ## 2. Estructura de un escenario
 

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -126,11 +126,17 @@ in PR #1776 establishes:
 
 - supported Python is 3.11 or newer;
 - `requirements.txt` is the runtime tier and contains `jsonschema`;
-- `requirements-dev.txt` includes the runtime tier and adds `pytest`;
+- `requirements-dev.txt` includes the runtime tier and adds `pytest` and
+  `PyYAML`;
 - `python scripts/bootstrap.py --runtime-only` installs/checks runtime
   dependencies and executes the supported scenario CLI smoke test;
 - the default bootstrap remains the development path and fails when tests or
   frozen benchmarks fail rather than printing an ambiguous ready state.
+
+The dependency check enumerates all three direct packages in the development
+tier. `PyYAML` is verified by distribution name and by its importable `yaml`
+module, so `--check` cannot report a ready development environment while that
+declared dependency is absent.
 
 The runtime-only install path has been verified in a newly created virtual
 environment without development requirements.

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import re
 import subprocess
@@ -28,7 +29,15 @@ MIN_PYTHON = (3, 11)
 SUPPORTED_PACKAGE_RANGES = {
     "jsonschema": ((4, 26, 0), (5, 0, 0)),
     "pytest": ((9, 1, 1), (10, 0, 0)),
+    "PyYAML": ((6, 0, 3), (7, 0, 0)),
 }
+PACKAGE_IMPORT_NAMES = {
+    "jsonschema": "jsonschema",
+    "pytest": "pytest",
+    "PyYAML": "yaml",
+}
+RUNTIME_PACKAGES = ("jsonschema",)
+DEVELOPMENT_PACKAGES = (*RUNTIME_PACKAGES, "pytest", "PyYAML")
 
 # ── Checks ──────────────────────────────────────────────────
 
@@ -42,16 +51,17 @@ def check_python() -> bool:
 
 
 def check_package(name: str) -> bool:
+    import_name = PACKAGE_IMPORT_NAMES[name]
     try:
-        __import__(name)
+        importlib.import_module(import_name)
     except ImportError:
-        print(f"  [MISS] {name}")
+        print(f"  [MISS] {name} (import {import_name})")
         return False
 
     try:
         installed = metadata.version(name)
     except metadata.PackageNotFoundError:
-        print(f"  [MISS] {name}")
+        print(f"  [MISS] {name} (distribution metadata)")
         return False
 
     bounds = SUPPORTED_PACKAGE_RANGES.get(name)
@@ -217,7 +227,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # 2. Key packages
     print("\n2. Packages")
-    packages = ["jsonschema"] if args.runtime_only else ["jsonschema", "pytest"]
+    packages = RUNTIME_PACKAGES if args.runtime_only else DEVELOPMENT_PACKAGES
     missing = [p for p in packages if not check_package(p)]
 
     # 3. Git

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -49,6 +50,45 @@ def test_bootstrap_uses_python_311_and_explicit_dependency_tiers() -> None:
     assert bootstrap.MIN_PYTHON == (3, 11)
     assert bootstrap.RUNTIME_REQUIREMENTS == RUNTIME_REQUIREMENTS
     assert bootstrap.DEVELOPMENT_REQUIREMENTS == DEVELOPMENT_REQUIREMENTS
+    assert bootstrap.RUNTIME_PACKAGES == ("jsonschema",)
+    assert bootstrap.DEVELOPMENT_PACKAGES == ("jsonschema", "pytest", "PyYAML")
+
+
+def test_bootstrap_package_inventory_matches_declared_requirement_ranges() -> None:
+    bootstrap = _load_bootstrap()
+    requirements = [
+        *_requirement_lines(RUNTIME_REQUIREMENTS),
+        *[
+            requirement
+            for requirement in _requirement_lines(DEVELOPMENT_REQUIREMENTS)
+            if not requirement.startswith("-r ")
+        ],
+    ]
+    parsed = {}
+    for requirement in requirements:
+        match = re.fullmatch(
+            r"(?P<name>[A-Za-z0-9_.-]+)>="
+            r"(?P<minimum>\d+(?:\.\d+){0,2}),"
+            r"<(?P<maximum>\d+(?:\.\d+){0,2})",
+            requirement,
+        )
+        assert match is not None, requirement
+        minimum = tuple(
+            int(part)
+            for part in match.group("minimum").split(".")
+        )
+        maximum = tuple(
+            int(part)
+            for part in match.group("maximum").split(".")
+        )
+        parsed[match.group("name")] = (
+            minimum + (0,) * (3 - len(minimum)),
+            maximum + (0,) * (3 - len(maximum)),
+        )
+
+    assert bootstrap.SUPPORTED_PACKAGE_RANGES == parsed
+    assert set(bootstrap.PACKAGE_IMPORT_NAMES) == set(parsed)
+    assert set(bootstrap.DEVELOPMENT_PACKAGES) == set(parsed)
 
 
 def test_runtime_only_check_does_not_require_pytest() -> None:
@@ -66,6 +106,47 @@ def test_runtime_only_check_does_not_require_pytest() -> None:
     assert "Mode: runtime (requirements.txt)" in proc.stdout
     assert "[OK]   jsonschema" in proc.stdout
     assert "pytest" not in proc.stdout.lower()
+    assert "pyyaml" not in proc.stdout.lower()
+    assert "import yaml" not in proc.stdout.lower()
+
+
+def test_development_check_probes_every_declared_package(
+    monkeypatch: Any,
+) -> None:
+    bootstrap = _load_bootstrap()
+    checked = []
+    monkeypatch.setattr(bootstrap, "check_python", lambda: True)
+    monkeypatch.setattr(
+        bootstrap,
+        "check_package",
+        lambda name: checked.append(name) or True,
+    )
+    monkeypatch.setattr(bootstrap, "check_tool", lambda _name: True)
+
+    assert bootstrap.main(["--check"]) == 0
+    assert checked == ["jsonschema", "pytest", "PyYAML"]
+
+
+def test_pyyaml_uses_yaml_import_and_pyyaml_distribution_metadata(
+    monkeypatch: Any,
+) -> None:
+    bootstrap = _load_bootstrap()
+    imported = []
+    distributions = []
+    monkeypatch.setattr(
+        bootstrap.importlib,
+        "import_module",
+        lambda name: imported.append(name),
+    )
+    monkeypatch.setattr(
+        bootstrap.metadata,
+        "version",
+        lambda name: distributions.append(name) or "6.0.3",
+    )
+
+    assert bootstrap.check_package("PyYAML")
+    assert imported == ["yaml"]
+    assert distributions == ["PyYAML"]
 
 
 def test_package_check_rejects_an_installed_version_outside_the_contract(
@@ -138,3 +219,6 @@ def test_readmes_document_the_same_minimum_and_install_paths() -> None:
     assert "pip install -r requirements.txt" in readme
     assert "pip install -r requirements.txt" in simulation_readme
     assert "pip install -r requirements-dev.txt" in simulation_readme
+    assert "`pytest` and `PyYAML`" in readme
+    assert "`pytest` y" in simulation_readme
+    assert "`PyYAML`" in simulation_readme


### PR DESCRIPTION
## Decision

Make the bootstrap's development check enumerate the full declared dependency tier, including PyYAML by its distribution and import identities.

## Scope

Related to #1805.

This PR changes only dependency probing, packaging-contract tests, and the documentation that describes those tiers. Runtime-only mode remains unchanged.

## Files changed

- `scripts/bootstrap.py`
- `tests/test_packaging_contract.py`
- `README.md`
- `SIMULATION_README.md`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] development `--check` probes jsonschema, pytest, and PyYAML;
- [x] PyYAML is verified through import `yaml` and distribution metadata `PyYAML`;
- [x] a regression binds the explicit package inventory and version ranges to both requirement files;
- [x] runtime-only mode still requires only jsonschema;
- [x] setup and handoff text describe the actual tiers.

## Validation

- `python -m pytest -q`: 366 passed, 12 skipped (PowerShell-only)
- `python -m pytest -q tests/test_packaging_contract.py`: 12 passed
- `python scripts/bootstrap.py --check`: PASS; PyYAML 6.0.3 reported
- frozen scenario benchmarks: 3/3
- narrative consistency: 0 errors, 0 warnings
- mojibake guard: 275 Markdown files
- `git diff --check`: clean
- published tree SHA matches the validated local tree: `248f30b59c58eb3cb5edb11a1b01649c963f6df0`

## Risks

The package inventory is intentionally explicit. A future direct requirement must update the inventory; the new test fails if requirement ranges and bootstrap checks diverge.

No dependency version, runtime code, workflow permission, benchmark, schema, or governance text changes.

## AI_HANDOFF.md update

Updated because the issue changes the operational bootstrap and contributor dependency contract.

## Next PR recommendation

Keep strict JSON boundary work (#1803) and repository-health pagination (#1806) separate.