### PR TITLE
fix(intake): make controlled URL contract canonical

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -405,6 +405,19 @@ because their changes also affect execution or credential behavior.
 
 ## Controlled URL Intake Network Follow-up
 
+- Issue #1753 establishes
+  `ops/ec2/controlled_url_intake.v1.schema.json` as the versioned application
+  payload contract for `POST /intake/url`.
+- The only meaningful request field is `url`. Success and application errors
+  are flat objects: `final_url` is the accepted final resource and `error` is
+  the stable failure-code field. There is no nested `intake`, `resolved_url`,
+  or `error_code` contract.
+- HTTP framing, malformed UTF-8/JSON, non-object JSON, and oversized request
+  bodies fail before the URL-intake application contract.
+- Contract tests couple the schema examples, exact application error set,
+  Operator request, launcher User-Agent, 4,096-byte request body, 2,048
+  URL-character, 1,000,000 raw-byte, 24,000 extracted-character, three
+  redirect, and eight-second limits.
 - Issue #1761 converts malformed and out-of-range URL ports into controlled
   intake errors.
 - URL intake resolves and validates every address once per URL/redirect hop,

--- a/docs/rfc/operator_controlled_url_intake.md
+++ b/docs/rfc/operator_controlled_url_intake.md
@@ -9,320 +9,325 @@ and a browser fallback exist in the repository (implementation PRs #1717 and
 #1720), with contract tests in
 `tests/test_hub_api_controlled_url_intake.py`. This is not evidence of a public
 deployment, complete RFC implementation, source verification, crawling, or
-truth adjudication. Issue #1753 tracks detailed RFC/implementation
-reconciliation.
+truth adjudication.
 
-## Decision
+Issue #1753 reconciles this record with the implementation. The versioned
+application payload contract is
+[`ops/ec2/controlled_url_intake.v1.schema.json`](../../ops/ec2/controlled_url_intake.v1.schema.json).
+When prose and that schema disagree about request fields, response fields,
+error codes, or limits, the schema and executable tests are the narrower source
+of truth. Network and security behavior remains implemented by
+`ops/ec2/hub-api.sh`.
 
-HUB_Optimus Operator should support URL-only analysis only through a controlled backend intake step.
+## Decision boundary
 
-A submitted URL is a source reference until the backend explicitly retrieves, bounds, extracts, and records source text. Intake does not verify truth, does not bypass access controls, and does not convert a URL into a conclusion.
+HUB_Optimus Operator may request URL-only intake only through a controlled
+backend step.
 
-The RFC text itself authorizes no additional implementation, public API
-exposure, scraping infrastructure, crawler behavior, browser-side third-party
-fetching, authentication changes, storage changes, or analysis contract
-changes. Existing code must be evaluated against its own reviewed issues,
-tests, and deployment evidence.
+A submitted URL is a source reference until the backend retrieves, bounds,
+extracts, and records source text. Intake does not verify truth, bypass access
+controls, or convert a URL into a conclusion.
+
+This RFC authorizes no additional public API exposure, crawler behavior,
+browser-side third-party fetching, authentication changes, storage changes, or
+analysis contract changes. Existing code must be evaluated against its reviewed
+issues, tests, and deployment evidence.
 
 ## Parent boundary
 
 This RFC extends `docs/rfc/ingestion_evidence_intake_boundary.md`.
 
-That parent boundary already states that URL intake may preserve URL, retrieval date, visible title, source domain, source type, and whether content was actually fetched or merely referenced. It also requires separate issues/RFCs before implementation beyond manual/raw intake.
+That parent boundary permits preservation of the submitted URL, retrieval date,
+visible title, source domain, source type, and whether content was fetched or
+merely referenced. It does not turn retrieved material into verified evidence.
 
-## Problem
-
-Operator currently accepts a URL as reference but cannot read or analyze a URL by itself.
-
-This creates product friction:
-
-- users expect a news/article URL to produce a draft analysis;
-- the current browser-only flow requires pasted article text;
-- browser-side fetching would be fragile and unsafe;
-- the product needs clear error behavior when a site blocks access, requires cookies, uses paywalls, or returns non-article content.
-
-## Goals
-
-- Allow a user to paste a public HTTP/HTTPS URL and request controlled intake.
-- Fetch only the supplied URL, not a crawl of linked pages.
-- Extract bounded plain text suitable for the existing Operator normalizer.
-- Preserve source metadata and uncertainty.
-- Fail clearly when content cannot be fetched or safely extracted.
-- Keep the backend private/local by default unless a separate public deployment RFC approves exposure.
-- Prevent SSRF, crawler drift, credential use, hidden tracking, and source laundering.
-
-## Non-goals
-
-This RFC does not add:
-
-- implementation code;
-- public API exposure;
-- browser-side `fetch()` to third-party news sites;
-- crawler infrastructure;
-- recursive link traversal;
-- paywall bypass;
-- authentication or cookie replay;
-- JavaScript browser automation;
-- OCR;
-- PDF/document extraction;
-- vector storage;
-- server-side memory persistence;
-- dynamic OG per analyzed result;
-- LLM-as-judge;
-- truth verdicts;
-- legal or geopolitical conclusions.
-
-## Proposed controlled flow
+## Implemented narrow flow
 
 ```text
-operator URL
--> validate URL
--> block unsafe destinations
--> controlled backend fetch
--> content-type and size checks
--> bounded HTML/text extraction
--> source metadata record
--> normalizer input draft
--> existing claim/evidence/inference/uncertainty rendering
+Operator URL
+-> POST /intake/url with {"url": "..."}
+-> validate URI, host, port and resolved addresses
+-> controlled single-resource fetch
+-> content-type and byte bounds
+-> bounded HTML/plain-text extraction
+-> flat provenance response
+-> Operator browser-local draft
 ```
 
-## Endpoint shape for a later implementation
+The endpoint fetches one supplied resource and validated redirect hops. It does
+not crawl links, execute page JavaScript, retrieve embedded resources, run the
+Semantic Engine, or make a truth decision.
 
-A later implementation may add a local-only endpoint:
+## Canonical application payload contract
+
+The canonical v1 schema contains three document shapes:
+
+- `request`;
+- `success_response`;
+- `error_response`.
+
+It also records the reviewed runtime limits and stable application error-code
+mapping. HTTP framing, invalid UTF-8, malformed JSON, non-object JSON, and
+oversized request-body errors occur before the URL-intake application handler;
+those generic API error bodies are intentionally outside this application
+schema.
+
+### Endpoint and request
 
 ```text
 POST /intake/url
+Content-Type: application/json
 ```
-
-Example request:
 
 ```json
 {
-  "url": "https://example.com/article",
-  "source_hint": "news-article",
-  "operator_context": "operator-pwa"
+  "url": "https://example.com/article"
 }
 ```
 
-Example success response:
+Only `url` has application meaning. The current v1 handler ignores additional
+object properties. In particular, it does not implement `source_hint` or
+`operator_context`, and ignored fields do not become context, evidence,
+analysis input, or provenance.
+
+### Flat success response
 
 ```json
 {
   "status": "ok",
-  "intake": {
-    "url": "https://example.com/article",
-    "resolved_url": "https://example.com/article",
-    "source_domain": "example.com",
-    "retrieved_at_utc": "2026-07-20T00:00:00Z",
-    "content_type": "text/html; charset=utf-8",
-    "title": "Article title if available",
-    "text": "Plain extracted article text...",
-    "text_length": 12345,
-    "truncated": false,
-    "fetch_status": "fetched",
-    "verification_status": "unreviewed",
-    "limitations": [
-      "Fetched content is not verification.",
-      "Extraction may omit navigation, embeds, captions, or dynamic content."
-    ]
-  }
-}
-```
-
-Example failure response:
-
-```json
-{
-  "status": "error",
-  "error_code": "fetch_blocked_or_unavailable",
-  "message": "The URL could not be fetched or safely extracted.",
-  "limitations": [
-    "No claim was analyzed from URL-only input.",
-    "Paste article text manually or try another public source."
+  "intake_type": "controlled_url",
+  "url": "https://example.com/article",
+  "final_url": "https://example.com/article",
+  "source_domain": "example.com",
+  "retrieved_at_utc": "2026-07-20T00:00:00+00:00",
+  "title": "Public source article title.",
+  "text": "Plain extracted article text.",
+  "content_type": "text/html; charset=utf-8",
+  "bytes_read": 4096,
+  "truncated": false,
+  "redirects": [],
+  "verification_status": "unreviewed",
+  "learning_status": "candidate-source-not-verified",
+  "extraction_notes": [
+    "Fetched by local backend controlled URL intake.",
+    "No cookies, authentication, browser automation, or paywall bypass were used.",
+    "Text extraction is source-bound and does not verify truth."
   ]
 }
 ```
 
-## URL validation requirements
+The response is flat. There is no nested `intake` object. The accepted final
+resource is `final_url`, not `resolved_url`. `bytes_read` replaces the earlier
+proposal's `text_length`; it records retained response bytes, not character
+count.
 
-A later implementation must reject:
+### Flat application error response
+
+```json
+{
+  "status": "error",
+  "error": "url_fetch_failed",
+  "message": "URL fetch failed with HTTP 403.",
+  "url": "https://example.com/article",
+  "verification_status": "unreviewed"
+}
+```
+
+The stable code field is `error`, not `error_code`. The current handler echoes
+the submitted `url` value for provenance, including a non-string value on the
+`invalid_url` path. A controlled fetch failure says nothing about whether the
+source is true, false, valid, or invalid.
+
+## URL validation boundary
+
+The implementation rejects:
 
 - non-HTTP/HTTPS schemes;
 - empty or malformed URLs;
+- raw spaces, control characters, and Unicode IRIs;
 - URLs containing credentials;
-- local hostnames;
-- private, loopback, link-local, multicast, or unspecified IPs;
-- redirects to blocked destinations;
-- responses above configured size limits;
+- missing, malformed, local, or non-public hosts;
+- non-default HTTP/HTTPS ports;
+- private, loopback, link-local, multicast, unspecified, and other non-global
+  resolved addresses;
+- known IPv6 transition forms that embed a non-global IPv4 destination;
+- redirects to a rejected destination;
+- redirects without `Location`;
 - unsupported content types;
-- suspicious binary payloads;
-- requests requiring cookies, login, or session replay.
+- empty extracted text.
 
-## SSRF boundary
+International hostnames must use an IDNA A-label. Non-ASCII path and query text
+must be percent-encoded before submission.
 
-URL intake must defend against server-side request forgery.
+## SSRF and network boundary
 
-Minimum requirements:
+For each supplied URL and permitted redirect hop, the current launcher:
 
-- parse and normalize the URL before fetch;
-- resolve DNS and block private/internal addresses before request;
-- re-check the final resolved URL after redirects;
-- cap redirect count;
-- cap timeout;
-- cap response size;
-- never send local credentials, cookies, authorization headers, or cloud metadata headers;
-- block cloud metadata endpoints and localhost ranges explicitly.
+- parses the URL before fetching;
+- resolves the hostname and rejects the whole hop when any returned address is
+  not permitted;
+- disables environment proxies;
+- opens a numeric socket to one of the validated addresses;
+- verifies that the connected peer remains in the validated set;
+- preserves the hostname for the HTTP `Host` header and HTTPS SNI/certificate
+  verification;
+- validates every redirect before the next request;
+- sends no cookies, authorization header, local credentials, or browser state.
 
-## Fetch limits
+The synchronous Linux server uses one monotonic eight-second application budget
+across address candidates, redirects, TLS, headers, and body reading.
+Interruption of a blocking system DNS resolver is best-effort rather than a
+portable cancellation guarantee. Infrastructure egress controls, NAT, firewall,
+resolver configuration, and host deployment remain outside the repository's
+application-level proof boundary.
 
-Initial recommended limits:
+## Runtime limits
 
-- timeout: 8 seconds;
-- redirects: max 3;
-- response size: max 1 MB raw body;
-- extracted text size: max 40,000 characters;
-- request method: GET only;
-- accepted schemes: `http`, `https`;
-- default User-Agent: `HUB_Optimus-Operator-Intake/0.1 (+https://huboptimus.dev/operator/)`.
+These are implemented values, not recommendations:
 
-These values may change during implementation review, but limits must exist before merge.
+| Boundary | Implemented value |
+| --- | --- |
+| JSON request body | 4,096 bytes |
+| Submitted URL | 2,048 characters |
+| Total fetch budget | 8 seconds |
+| Redirects | At most 3 |
+| Retained raw response body | 1,000,000 bytes |
+| Extracted source text | At most 24,000 characters before an optional ellipsis |
+| Maximum returned `text` | 24,001 characters including an optional ellipsis |
+| Remote request method | `GET` |
+| Accepted schemes | `http`, `https` |
+| User-Agent | `HUB_Optimus-Operator-URL-Intake/0.1 (+https://huboptimus.dev/operator/)` |
 
-## Extraction rules
+The reader requests one byte beyond the raw-body limit to detect overflow,
+retains at most 1,000,000 bytes, and sets `truncated=true`; it does not claim to
+have read or extracted the remainder.
 
-The extractor should:
+## Extraction behavior
 
-- prefer visible text from article-like HTML;
-- remove scripts, styles, forms, navigation, cookie banners where reasonably detectable, and hidden elements;
-- preserve title when available;
-- preserve source URL and resolved URL;
-- preserve retrieval timestamp;
-- mark extraction as lossy and unverified;
-- avoid inventing missing article text;
-- fail clearly when content is too short, blocked, unsupported, or unusable.
+The current extractor:
 
-The extractor must not:
+- accepts HTML, XHTML, and plain-text responses;
+- decodes the declared charset when known and falls back to UTF-8 with
+  replacement for undecodable bytes;
+- ignores `canvas`, `iframe`, `noscript`, `script`, `style`, `svg`, and
+  `template` element content;
+- preserves a cleaned document title when available;
+- normalizes whitespace, removes duplicate cleaned lines, and drops short
+  non-sentence fragments;
+- returns non-empty bounded text or a controlled `empty_extraction` error.
+
+It is a bounded text extractor, not a complete article parser. It may retain
+navigation or other visible boilerplate and may omit meaningful dynamic,
+embedded, caption, or short-form content. It does not:
 
 - execute JavaScript;
 - interact with cookie banners;
 - log in;
 - bypass paywalls;
-- scrape related links;
-- follow article recommendations;
-- infer unavailable content.
+- fetch document links or embedded resources;
+- infer unavailable text.
 
-## Output contract
+## Operator behavior
 
-URL intake output may populate the existing source normalizer fields:
+The repository Operator posts only `{"url": sourceUrl}` to the controlled
+endpoint when a URL exists and source text is empty.
 
-- `source_url` from the final accepted URL;
-- `source_text` from extracted plain text;
-- `signal_source_type` from explicit source hint or conservative inference;
-- metadata fields for retrieval time, source domain, title, fetch status, and extraction limitations.
+On success, it:
 
-URL intake must remain upstream of analysis. It prepares material; it does not decide truth.
+- uses `text` as the browser-local draft input;
+- preserves submitted and final URL, source domain, title, retrieval time,
+  redirect chain, content type, byte count, truncation, and unreviewed status;
+- continues through the existing local conservative-triage UI.
 
-## Operator UI behavior
+On failure, it:
 
-When a URL is present and text is empty, a later UI implementation may show:
+- shows the controlled error message;
+- asks the operator to paste source text;
+- does not fetch the third-party URL directly from the browser;
+- does not classify the failed source as false or invalid.
 
-```text
-Read URL
-```
+If the operator supplies text and a URL, the browser treats the URL as
+operator-provided, unfetched attribution. The primary action analyzes actual
+text only: pasted text or text returned by controlled intake.
 
-If intake succeeds:
-
-```text
-URL read. Review extracted text, then analyze.
-```
-
-If intake fails:
-
-```text
-URL could not be read safely. Paste article text manually.
-```
-
-The primary `Analyze` action should only analyze actual text, whether pasted manually or extracted by controlled intake.
+The hard-coded endpoint URL in the static Operator is repository configuration,
+not proof that the service is publicly deployed, reachable, secure, or
+available.
 
 ## Storage and privacy
 
-Initial implementation should not store fetched text server-side beyond transient request handling unless a separate storage policy is approved.
+The endpoint returns fetched text within the request/response lifecycle and
+does not add a server-side fetched-text store. No persistence, retention,
+encryption, or deletion guarantee is established by this RFC.
 
-If request/response logs are needed, they must be limited to public-safe metadata:
+No implementation may log full article text, personal data, cookies,
+authorization headers, or sensitive operator content by default without a
+separately reviewed policy and change.
 
-- URL domain;
-- status code category;
-- error code;
-- timestamp;
-- byte counts;
-- duration.
+## Stable application failure codes
 
-Do not log full article text, personal data, cookies, headers, or user-provided sensitive content by default.
-
-## Failure codes
-
-A later implementation should use stable error codes such as:
+The schema and launcher currently define:
 
 - `invalid_url`;
-- `blocked_scheme`;
-- `blocked_private_address`;
-- `redirect_blocked`;
-- `timeout`;
-- `response_too_large`;
+- `invalid_url_host`;
+- `invalid_url_port`;
+- `unsupported_url_iri`;
+- `unsupported_url_scheme`;
+- `unsupported_url_credentials`;
+- `unsupported_url_port`;
+- `blocked_url_host`;
+- `unresolvable_url_host`;
 - `unsupported_content_type`;
-- `fetch_blocked_or_unavailable`;
-- `extractor_empty_text`;
-- `extractor_low_confidence`.
+- `empty_extraction`;
+- `redirect_without_location`;
+- `too_many_redirects`;
+- `url_fetch_failed`;
+- `url_fetch_timeout`;
+- `url_fetch_unavailable`;
+- `url_too_long`.
+
+The schema's `x-hub-optimus-error-http-status` map records the current HTTP
+status for each code. Generic request-body errors remain outside this list
+because URL intake has not started when they occur.
 
 ## Security review checklist
 
-Before implementation merge:
+The repository tests cover:
 
-- SSRF protections are covered by tests;
-- redirects are tested;
-- private IPs are blocked;
-- response size is capped;
-- timeout is capped;
-- no credentials/cookies are sent;
-- no browser-side third-party fetch is added;
-- extraction is bounded and non-executing;
-- failure states are clear to the user;
-- output marks intake as unverified.
+- URI, port, address, and redirect rejection;
+- DNS rebinding/connection pinning boundaries;
+- IPv6 transition-address cases;
+- response size and extracted-text bounds;
+- one total timeout budget;
+- disabled environment proxies;
+- absent cookies and authorization headers;
+- malformed HTTP and read failures;
+- single-resource fetching;
+- unreviewed success and failure provenance.
 
-## Acceptance criteria for this RFC
+Passing tests prove only those reviewed code paths. They do not attest the
+configuration or behavior of a deployed host.
 
-This RFC is acceptable when it:
+## Acceptance criteria for issue #1753
 
-- states that URL intake is not verification;
-- requires backend-controlled intake rather than browser scraping;
-- defines URL validation boundaries;
-- defines SSRF protections;
-- defines fetch and extraction limits;
-- defines success/failure response shapes;
-- defines Operator UI behavior;
-- keeps implementation out of this PR;
-- preserves GitHub as source of truth.
-
-## Follow-up implementation plan
-
-If accepted, implementation should proceed in small PRs:
-
-1. `ops/api: add controlled URL intake endpoint`
-   - endpoint only;
-   - local/private API only;
-   - SSRF/timeout/size tests.
-2. `site/operator: add URL read action`
-   - button and UI state only;
-   - no browser third-party fetch;
-   - consumes controlled endpoint.
-3. `tests: add URL intake smoke fixtures`
-   - local fixture server or mocked HTTP responses;
-   - blocked private URL tests;
-   - extraction failure tests.
+- One versioned schema defines current request, success, and application error
+  payloads.
+- The RFC, backend constants, Operator request, schema examples, limits,
+  User-Agent, and error-code set are coupled by executable tests.
+- No nested response, `resolved_url`, `error_code`, 40,000-character limit, or
+  obsolete User-Agent is presented as the active contract.
+- No network, deployment, storage, verification, or analysis capability is
+  added by the reconciliation.
+- GitHub remains the source of truth.
 
 ## Validation
 
-Documentation-only validation:
-
 ```bash
-python tools/check_mojibake.py docs/rfc/operator_controlled_url_intake.md
+python -m pytest -q \
+  tests/test_hub_api_controlled_url_intake.py \
+  tests/test_operator_pwa_product_actions.py
+python -m json.tool \
+  ops/ec2/controlled_url_intake.v1.schema.json >/dev/null
+python tools/check_mojibake.py \
+  docs/rfc/operator_controlled_url_intake.md
 ```

--- a/docs/rfc/registry.v1.json
+++ b/docs/rfc/registry.v1.json
@@ -211,10 +211,11 @@
       "evidence_paths": [
         "docs/rfc/operator_controlled_url_intake.md",
         "ops/ec2/hub-api.sh",
+        "ops/ec2/controlled_url_intake.v1.schema.json",
         "site/operator/index.html",
         "tests/test_hub_api_controlled_url_intake.py"
       ],
-      "note": "A local/private, single-URL prototype and browser fallback exist. This does not ratify the RFC or prove a public deployment."
+      "note": "A local/private, single-URL prototype, browser fallback, and versioned application payload schema exist. This does not ratify the RFC, verify retrieved content, or prove a public deployment."
     },
     {
       "id": "post-quantum-control-plane",

--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -49,6 +49,7 @@ Validated endpoints:
 
 - GET /health
 - GET /status
+- POST /intake/url
 - POST /analyze
 
 POST /analyze returns direct JSON with:
@@ -102,6 +103,13 @@ service when the process should load the restored launcher.
 The repository launcher source also defines `POST /intake/url`. This records the
 reviewed code boundary; it is not evidence that any particular host or public
 endpoint is currently deployed.
+
+The versioned application request/success/error payload contract is
+[`controlled_url_intake.v1.schema.json`](controlled_url_intake.v1.schema.json).
+The endpoint accepts `{"url": "..."}` as its only meaningful application field
+and returns the schema's flat `status=ok` or `status=error` shape. HTTP framing
+and malformed-body errors occur before that application contract. Executable
+tests bind the schema to the launcher constants and the Operator request.
 
 For each supplied URL and each permitted redirect hop, the launcher:
 

--- a/ops/ec2/controlled_url_intake.v1.schema.json
+++ b/ops/ec2/controlled_url_intake.v1.schema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://huboptimus.dev/schemas/controlled-url-intake-v1.schema.json",
+  "title": "HUB_Optimus controlled URL intake v1",
+  "description": "Canonical application payload contract for POST /intake/url. HTTP framing and malformed-body errors occur before this application contract.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/request"
+    },
+    {
+      "$ref": "#/$defs/success_response"
+    },
+    {
+      "$ref": "#/$defs/error_response"
+    }
+  ],
+  "x-hub-optimus-runtime-limits": {
+    "endpoint": "/intake/url",
+    "request_body_bytes": 4096,
+    "url_characters": 2048,
+    "raw_response_bytes": 1000000,
+    "extracted_text_characters": 24000,
+    "maximum_returned_text_characters": 24001,
+    "redirects": 3,
+    "timeout_seconds": 8,
+    "remote_request_method": "GET",
+    "accepted_schemes": [
+      "http",
+      "https"
+    ],
+    "user_agent": "HUB_Optimus-Operator-URL-Intake/0.1 (+https://huboptimus.dev/operator/)"
+  },
+  "x-hub-optimus-error-http-status": {
+    "blocked_url_host": 400,
+    "empty_extraction": 422,
+    "invalid_url": 400,
+    "invalid_url_host": 400,
+    "invalid_url_port": 400,
+    "redirect_without_location": 502,
+    "too_many_redirects": 508,
+    "unresolvable_url_host": 400,
+    "unsupported_content_type": 415,
+    "unsupported_url_credentials": 400,
+    "unsupported_url_iri": 400,
+    "unsupported_url_port": 400,
+    "unsupported_url_scheme": 400,
+    "url_fetch_failed": 502,
+    "url_fetch_timeout": 504,
+    "url_fetch_unavailable": 503,
+    "url_too_long": 414
+  },
+  "$defs": {
+    "request": {
+      "title": "Controlled URL intake request",
+      "description": "Only url has application meaning. The v1 handler ignores additional object properties; they do not become source hints, context, evidence, or analysis input.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "not": {
+        "required": [
+          "status"
+        ]
+      },
+      "properties": {
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "description": "Submitted absolute ASCII HTTP/HTTPS URI. The backend applies the authoritative URI, port, DNS, address, and redirect checks."
+        }
+      },
+      "additionalProperties": true,
+      "examples": [
+        {
+          "url": "https://example.com/article"
+        }
+      ]
+    },
+    "success_response": {
+      "title": "Controlled URL intake success response",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "intake_type",
+        "url",
+        "final_url",
+        "source_domain",
+        "retrieved_at_utc",
+        "title",
+        "text",
+        "content_type",
+        "bytes_read",
+        "truncated",
+        "redirects",
+        "verification_status",
+        "learning_status",
+        "extraction_notes"
+      ],
+      "properties": {
+        "status": {
+          "const": "ok"
+        },
+        "intake_type": {
+          "const": "controlled_url"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "final_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_domain": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retrieved_at_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 24001,
+          "description": "The extractor keeps at most 24,000 source characters and may append one ellipsis marker when truncated."
+        },
+        "content_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bytes_read": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "redirects": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/$defs/redirect"
+          }
+        },
+        "verification_status": {
+          "const": "unreviewed"
+        },
+        "learning_status": {
+          "const": "candidate-source-not-verified"
+        },
+        "extraction_notes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "examples": [
+        {
+          "status": "ok",
+          "intake_type": "controlled_url",
+          "url": "https://example.com/article",
+          "final_url": "https://example.com/article",
+          "source_domain": "example.com",
+          "retrieved_at_utc": "2026-07-20T00:00:00+00:00",
+          "title": "Public source article title.",
+          "text": "Plain extracted article text.",
+          "content_type": "text/html; charset=utf-8",
+          "bytes_read": 4096,
+          "truncated": false,
+          "redirects": [],
+          "verification_status": "unreviewed",
+          "learning_status": "candidate-source-not-verified",
+          "extraction_notes": [
+            "Fetched by local backend controlled URL intake.",
+            "No cookies, authentication, browser automation, or paywall bypass were used.",
+            "Text extraction is source-bound and does not verify truth."
+          ]
+        }
+      ]
+    },
+    "error_response": {
+      "title": "Controlled URL intake application error response",
+      "description": "Returned after a JSON object reaches the application handler and URL intake rejects or cannot fetch it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "error",
+        "message",
+        "url",
+        "verification_status"
+      ],
+      "properties": {
+        "status": {
+          "const": "error"
+        },
+        "error": {
+          "type": "string",
+          "enum": [
+            "blocked_url_host",
+            "empty_extraction",
+            "invalid_url",
+            "invalid_url_host",
+            "invalid_url_port",
+            "redirect_without_location",
+            "too_many_redirects",
+            "unresolvable_url_host",
+            "unsupported_content_type",
+            "unsupported_url_credentials",
+            "unsupported_url_iri",
+            "unsupported_url_port",
+            "unsupported_url_scheme",
+            "url_fetch_failed",
+            "url_fetch_timeout",
+            "url_fetch_unavailable",
+            "url_too_long"
+          ]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "description": "Submitted url value echoed for provenance. Invalid non-string input remains possible on this error-only path."
+        },
+        "verification_status": {
+          "const": "unreviewed"
+        }
+      },
+      "examples": [
+        {
+          "status": "error",
+          "error": "url_fetch_failed",
+          "message": "URL fetch failed with HTTP 403.",
+          "url": "https://example.com/article",
+          "verification_status": "unreviewed"
+        }
+      ]
+    },
+    "redirect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "status"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "minLength": 1
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "integer",
+          "enum": [
+            301,
+            302,
+            303,
+            307,
+            308
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/test_hub_api_controlled_url_intake.py
+++ b/tests/test_hub_api_controlled_url_intake.py
@@ -1,4 +1,7 @@
+import ast
 import io
+import json
+import re
 import socket
 import sys
 import threading
@@ -8,10 +11,75 @@ from http.client import BadStatusLine, IncompleteRead, LineTooLong
 from pathlib import Path
 from urllib.error import URLError
 
+import jsonschema
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 API_SCRIPT = ROOT / "ops" / "ec2" / "hub-api.sh"
+CONTRACT_SCHEMA = ROOT / "ops" / "ec2" / "controlled_url_intake.v1.schema.json"
+RFC = ROOT / "docs" / "rfc" / "operator_controlled_url_intake.md"
+
+
+def load_contract_schema() -> dict:
+    return json.loads(CONTRACT_SCHEMA.read_text(encoding="utf-8"))
+
+
+def validate_contract_payload(payload: dict) -> None:
+    schema = load_contract_schema()
+    jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    ).validate(payload)
+
+
+def embedded_api_source() -> str:
+    source = API_SCRIPT.read_text(encoding="utf-8")
+    return source.split('cat > "$API_FILE" <<\'PY\'\n', 1)[1].split(
+        "\nPY\n",
+        1,
+    )[0]
+
+
+def static_intake_error_statuses() -> dict[str, int]:
+    tree = ast.parse(embedded_api_source())
+    statuses: dict[str, int] = {}
+
+    def record(call: ast.Call) -> None:
+        if len(call.args) < 2:
+            return
+        status_node, code_node = call.args[:2]
+        if not (
+            isinstance(status_node, ast.Constant)
+            and isinstance(status_node.value, int)
+            and isinstance(code_node, ast.Constant)
+            and isinstance(code_node.value, str)
+        ):
+            return
+        previous = statuses.setdefault(code_node.value, status_node.value)
+        assert previous == status_node.value
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "IntakeError"
+        ):
+            record(node)
+
+    deadline_error = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "FetchDeadlineExceeded"
+    )
+    for node in ast.walk(deadline_error):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "__init__"
+        ):
+            record(node)
+
+    return statuses
 
 
 def make_body_reader(namespace: dict, content_length: str | None, body: bytes):
@@ -51,6 +119,67 @@ def address_info(ip_text, port):
         else (ip_text, port)
     )
     return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", socket_address)
+
+
+def test_controlled_url_intake_schema_and_examples_are_valid():
+    schema = load_contract_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+    examples = [
+        schema["$defs"][name]["examples"][0]
+        for name in ("request", "success_response", "error_response")
+    ]
+    for example in examples:
+        validate_contract_payload(example)
+
+    assert schema["$id"].endswith("/controlled-url-intake-v1.schema.json")
+
+
+def test_rfc_examples_are_the_canonical_schema_examples():
+    schema = load_contract_schema()
+    rfc = RFC.read_text(encoding="utf-8")
+    documented_examples = [
+        json.loads(block)
+        for block in re.findall(r"```json\n(.*?)\n```", rfc, re.DOTALL)
+    ]
+    canonical_examples = [
+        schema["$defs"][name]["examples"][0]
+        for name in ("request", "success_response", "error_response")
+    ]
+
+    assert documented_examples == canonical_examples
+    assert '"intake": {' not in rfc
+    assert '"resolved_url":' not in rfc
+    assert '"error_code":' not in rfc
+    assert "max 40,000 characters" not in rfc
+    assert "HUB_Optimus-Operator-Intake/0.1" not in rfc
+
+
+def test_runtime_limits_user_agent_and_error_codes_match_schema(hub_api):
+    schema = load_contract_schema()
+    limits = schema["x-hub-optimus-runtime-limits"]
+
+    assert limits["request_body_bytes"] == hub_api.MAX_URL_BODY_LENGTH
+    assert limits["url_characters"] == hub_api.MAX_URL_LENGTH
+    assert limits["raw_response_bytes"] == hub_api.MAX_URL_BYTES
+    assert limits["extracted_text_characters"] == hub_api.MAX_EXTRACTED_TEXT_CHARS
+    assert (
+        limits["maximum_returned_text_characters"]
+        == hub_api.MAX_EXTRACTED_TEXT_CHARS + 1
+    )
+    assert limits["redirects"] == hub_api.MAX_REDIRECTS
+    assert limits["timeout_seconds"] == hub_api.URL_TIMEOUT_SECONDS
+    assert limits["user_agent"] == hub_api.USER_AGENT
+    assert limits["endpoint"] == "/intake/url"
+    assert limits["remote_request_method"] == "GET"
+    assert limits["accepted_schemes"] == ["http", "https"]
+
+    schema_statuses = schema["x-hub-optimus-error-http-status"]
+    error_enum = set(
+        schema["$defs"]["error_response"]["properties"]["error"]["enum"]
+    )
+    assert set(schema_statuses) == error_enum
+    assert static_intake_error_statuses() == schema_statuses
 
 
 def test_hub_api_controlled_url_intake_endpoint_present():
@@ -548,6 +677,7 @@ def test_success_fetches_one_url_without_crawling_and_marks_provenance(
 
     result = hub_api.fetch_url_text("https://public.example/article")
 
+    validate_contract_payload(result)
     assert len(requests) == 1
     assert requests[0][0] == "https://public.example/article"
     assert 0 < requests[0][1] <= hub_api.URL_TIMEOUT_SECONDS
@@ -697,6 +827,7 @@ def test_handler_preserves_unreviewed_provenance_for_malformed_http(
     hub_api.Handler.handle_url_intake(handler)
 
     status, payload = handler.response
+    validate_contract_payload(payload)
     assert status == 502
     assert payload["status"] == "error"
     assert payload["error"] == "url_fetch_failed"

--- a/tests/test_operator_pwa_product_actions.py
+++ b/tests/test_operator_pwa_product_actions.py
@@ -1,3 +1,4 @@
+import json
 import re
 import shutil
 import subprocess
@@ -11,6 +12,9 @@ INDEX = ROOT / "site" / "operator" / "index.html"
 ICON = ROOT / "site" / "operator" / "icon.svg"
 LOCKUP = ROOT / "site" / "assets" / "brand" / "hub-optimus-logo-lockup.png"
 SW = ROOT / "site" / "operator" / "sw.js"
+URL_INTAKE_SCHEMA = (
+    ROOT / "ops" / "ec2" / "controlled_url_intake.v1.schema.json"
+)
 NODE = shutil.which("node")
 
 
@@ -191,10 +195,32 @@ if (
 
 def test_operator_uses_only_controlled_url_intake_fetch():
     html = _read(INDEX)
+    schema = json.loads(_read(URL_INTAKE_SCHEMA))
+    request = schema["$defs"]["request"]
+    success_fields = set(schema["$defs"]["success_response"]["required"])
+    limits = schema["x-hub-optimus-runtime-limits"]
 
     assert "CONTROLLED_URL_INTAKE_ENDPOINT" in html
-    assert "https://api.huboptimus.dev/intake/url" in html
+    assert f"https://api.huboptimus.dev{limits['endpoint']}" in html
     assert "fetch(CONTROLLED_URL_INTAKE_ENDPOINT" in html
+    assert "JSON.stringify({ url: sourceUrl })" in html
+    assert request["required"] == ["url"]
+    assert set(request["properties"]) == {"url"}
+    assert {"status", "text"} <= success_fields
+    for field in (
+        "url",
+        "final_url",
+        "source_domain",
+        "title",
+        "retrieved_at_utc",
+        "redirects",
+        "content_type",
+        "truncated",
+        "verification_status",
+        "bytes_read",
+    ):
+        assert field in success_fields
+        assert f"intakePayload.{field}" in html
     assert "fetch(sourceUrl" not in html
     assert "fetch(url" not in html
     assert "<form" not in html


### PR DESCRIPTION
## Decision

Adopt `ops/ec2/controlled_url_intake.v1.schema.json` as the versioned application-payload contract for `POST /intake/url`, and make the RFC, registry, backend documentation, Operator request/response expectations, runtime limits, User-Agent, and stable application error set agree with the implementation.

This is intake/retrieval only. It does not verify a source, add crawling, expose a public API, or prove a deployment.

Related to #1753

## Scope

- Reconcile the already-implemented controlled URL intake with one narrow v1 contract.
- Preserve the implemented flat payloads and security/runtime boundaries.
- Add executable coupling between schema examples, backend constants, backend error codes, and the Operator.
- Record implementation evidence without expanding capability.

## Files changed

- `ops/ec2/controlled_url_intake.v1.schema.json`
- `docs/rfc/operator_controlled_url_intake.md`
- `docs/rfc/registry.v1.json`
- `ops/ec2/README.md`
- `tests/test_hub_api_controlled_url_intake.py`
- `tests/test_operator_pwa_product_actions.py`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] One versioned request/success/application-error contract is canonical.
- [x] RFC status and registry describe the implemented subset, not the obsolete proposal.
- [x] Size, timeout, redirect, method, scheme, and User-Agent limits match executable constants.
- [x] Schema error codes and HTTP status mappings match the backend implementation.
- [x] Operator sends only the canonical URL field and consumes the canonical success fields.
- [x] SSRF and redirect behavior remain covered by the existing end-to-end socket tests.
- [x] No public deployment, verification, crawling, or analysis capability is claimed.
- [x] Full suite passes.

## Validation

- Focused URL/API/Operator contract suite: `110 passed`.
- Full suite: `369 passed, 12 skipped`.
- The 12 skips require PowerShell 7, which is not installed in the local validation environment.
- Deterministic scenario benchmarks: `3/3`.
- Narrative consistency: `0 errors, 0 warnings`.
- RFC/schema JSON examples, schema structure, backend constants, application error set, and Operator field usage are exercised by tests.
- Mojibake scan, `bash -n`, and `git diff --check`: clean.
- Published tree SHA was verified byte-for-byte against the validated local tree: `81115982f27c88974b63a2d405927ec7e2a8926b`.

## Risks

- The schema intentionally permits ignored extra request properties because that is the current runtime behavior; it explicitly states they acquire no semantic meaning.
- Invalid framing/UTF-8/JSON errors occur before the application handler and remain outside this application-payload schema.
- Passing repository tests does not attest a deployed host or infrastructure egress policy.

## AI_HANDOFF update

The handoff records the canonical schema, flat payload shape, stable error field, exact limits, and the non-verification/deployment boundary.

## Next PR recommendation

Land the separately scoped strict-JSON boundary from #1803 so non-finite JSON constants cannot cross CLI/API boundaries.