### PR TITLE
fix(json): reject non-standard numeric constants

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -388,6 +388,22 @@ multi-writer locking is claimed.
 - Missing, unreadable, invalid UTF-8, invalid JSON, and contract-invalid inputs
   fail through the CLI's controlled error channel without a traceback.
 - This change adds no evaluator, scoring, model judge, or autonomous conclusion.
+
+## Strict JSON Boundary
+
+Issue #1803 closes the permissive-number gap at the Semantic Engine file
+boundary and the embedded API JSON body boundary.
+
+- `NaN`, `Infinity`, and `-Infinity` are rejected during decoding, including
+  when nested inside open metadata.
+- `/analyze` and `/intake/url` share the same strict request-body decoder.
+- Semantic Engine output, temporary API case input, and API responses use
+  fail-closed serialization and cannot emit those non-standard constants.
+- Analysis-result files containing a non-standard constant are rejected before
+  the API constructs its response.
+- Finite numeric metadata remains opaque and round-trippable. These checks add
+  no scoring, truth evaluation, or public-service claim.
+
 ## GitHub Actions supply-chain boundary
 
 The CI, link-check, Pages, PR-safety, and repository-health workflows pin

--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -73,6 +73,29 @@ class IntakeError(Exception):
         self.message = message
 
 
+def reject_non_standard_json_constant(value: str) -> None:
+    """Reject Python's non-standard JSON numeric constants."""
+
+    raise ValueError(f"non-standard numeric constant {value} is not valid JSON")
+
+
+def load_strict_json(raw: str):
+    return json.loads(
+        raw,
+        parse_constant=reject_non_standard_json_constant,
+    )
+
+
+def dump_strict_json(payload) -> str:
+    return json.dumps(
+        payload,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+        ensure_ascii=False,
+    ) + "\n"
+
+
 class FetchDeadlineExceeded(IntakeError):
     def __init__(self) -> None:
         super().__init__(
@@ -806,7 +829,13 @@ class Handler(BaseHTTPRequestHandler):
     server_version = "HUBOptimusAPI/0.1"
 
     def send_json(self, status: int, payload: dict) -> None:
-        body = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        try:
+            body = dump_strict_json(payload)
+        except (TypeError, ValueError):
+            status = 500
+            body = dump_strict_json(
+                {"error": "response payload is not valid strict JSON"}
+            )
         encoded = body.encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -848,9 +877,12 @@ class Handler(BaseHTTPRequestHandler):
             return None
 
         try:
-            payload = json.loads(raw)
+            payload = load_strict_json(raw)
         except json.JSONDecodeError as exc:
             self.send_json(400, {"error": f"invalid JSON: {exc.msg}"})
+            return None
+        except ValueError as exc:
+            self.send_json(400, {"error": f"invalid JSON: {exc}"})
             return None
 
         if not isinstance(payload, dict):
@@ -888,6 +920,15 @@ class Handler(BaseHTTPRequestHandler):
         if payload is None:
             return
 
+        try:
+            serialized_payload = dump_strict_json(payload)
+        except (TypeError, ValueError):
+            self.send_json(
+                500,
+                {"error": "cannot serialize case input as strict JSON"},
+            )
+            return
+
         case_dir = SHARED / "api" / "cases"
         case_path: Path | None = None
         try:
@@ -905,15 +946,7 @@ class Handler(BaseHTTPRequestHandler):
                 encoding="utf-8",
                 newline="\n",
             ) as case_file:
-                case_file.write(
-                    json.dumps(
-                        payload,
-                        indent=2,
-                        sort_keys=True,
-                        ensure_ascii=False,
-                    )
-                    + "\n"
-                )
+                case_file.write(serialized_payload)
         except OSError as exc:
             if case_path is not None:
                 try:
@@ -974,12 +1007,17 @@ class Handler(BaseHTTPRequestHandler):
         result_path = run_path / "analysis_result.json"
 
         try:
-            analysis_result = json.loads(result_path.read_text(encoding="utf-8"))
+            analysis_result = load_strict_json(
+                result_path.read_text(encoding="utf-8")
+            )
         except OSError as exc:
             self.send_json(500, {"error": f"cannot read analysis result: {exc}"})
             return
         except json.JSONDecodeError as exc:
             self.send_json(500, {"error": f"analysis result is invalid JSON: {exc.msg}"})
+            return
+        except ValueError as exc:
+            self.send_json(500, {"error": f"analysis result is invalid JSON: {exc}"})
             return
 
         self.send_json(

--- a/semantic_engine/cli/__main__.py
+++ b/semantic_engine/cli/__main__.py
@@ -21,6 +21,12 @@ class ControlledCliError(Exception):
     """Expected CLI error that should be printed without a traceback."""
 
 
+def reject_non_standard_json_constant(value: str) -> None:
+    """Reject Python's non-standard JSON numeric constants."""
+
+    raise ValueError(f"non-standard numeric constant {value} is not valid JSON")
+
+
 def load_case(path: Path) -> dict[str, Any]:
     """Load a case JSON file and return its object payload."""
 
@@ -36,9 +42,14 @@ def load_case(path: Path) -> dict[str, Any]:
         raise ControlledCliError(f"cannot read input file {path}: {exc}") from exc
 
     try:
-        payload = json.loads(raw)
+        payload = json.loads(
+            raw,
+            parse_constant=reject_non_standard_json_constant,
+        )
     except json.JSONDecodeError as exc:
         raise ControlledCliError(f"invalid JSON in {path}: {exc.msg}") from exc
+    except ValueError as exc:
+        raise ControlledCliError(f"invalid JSON in {path}: {exc}") from exc
 
     if not isinstance(payload, dict):
         raise ControlledCliError("input JSON must be an object")
@@ -231,7 +242,17 @@ def analyze_case(input_path: Path) -> dict[str, Any]:
 def serialize_payload(payload: dict[str, Any]) -> str:
     """Return stable JSON for CLI stdout or file output."""
 
-    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    try:
+        return json.dumps(
+            payload,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise ControlledCliError(
+            "cannot serialize output as strict JSON"
+        ) from exc
 
 
 def write_output(path: Path, content: str) -> None:
@@ -273,11 +294,10 @@ def main(argv: list[str] | None = None) -> int:
             payload = analyze_case(Path(args.input))
         else:  # pragma: no cover - argparse prevents this path.
             parser.error(f"unknown command: {args.command}")
+        content = serialize_payload(payload)
     except ControlledCliError as exc:
         print(f"semantic_engine.cli: error: {exc}", file=sys.stderr)
         return 1
-
-    content = serialize_payload(payload)
 
     if args.output:
         try:

--- a/tests/semantic_engine/test_cli_smoke.py
+++ b/tests/semantic_engine/test_cli_smoke.py
@@ -3,6 +3,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from semantic_engine.cli.__main__ import ControlledCliError, serialize_payload
+
 
 def run_cli(*args):
     return subprocess.run(
@@ -79,6 +83,74 @@ def test_cli_invalid_json_fails_cleanly(tmp_path):
     assert result.stdout == ""
     assert "semantic_engine.cli: error: invalid JSON" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_cli_rejects_non_standard_numeric_constants_in_nested_metadata(
+    tmp_path,
+    constant,
+):
+    case_path = tmp_path / "non-standard-number.json"
+    case_path.write_text(
+        (
+            "{"
+            '"case_id":"case-non-standard-number",'
+            '"core_version_ref":"main",'
+            '"input_summary":"Strict JSON regression fixture.",'
+            f'"metadata":{{"nested":{{"value":{constant}}}}}'
+            "}"
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_cli("analyze", str(case_path))
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert (
+        f"non-standard numeric constant {constant} is not valid JSON"
+        in result.stderr
+    )
+    assert "Traceback" not in result.stderr
+
+
+def test_cli_round_trips_finite_numeric_metadata(tmp_path):
+    case_path = tmp_path / "finite-numbers.json"
+    metadata = {
+        "nested": {
+            "negative": -12.5,
+            "zero": 0,
+            "positive": 6.25e18,
+        }
+    }
+    write_json(
+        case_path,
+        {
+            "case_id": "case-finite-numbers",
+            "core_version_ref": "main",
+            "input_summary": "Finite numeric metadata regression fixture.",
+            "metadata": metadata,
+        },
+    )
+
+    result = run_cli("analyze", str(case_path))
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert json.loads(result.stdout)["metadata"] == metadata
+
+
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), float("inf"), float("-inf")],
+    ids=["nan", "positive-infinity", "negative-infinity"],
+)
+def test_semantic_serializer_fails_closed_for_non_finite_values(value):
+    with pytest.raises(
+        ControlledCliError,
+        match="cannot serialize output as strict JSON",
+    ):
+        serialize_payload({"metadata": {"nested": {"value": value}}})
 
 
 def test_cli_missing_required_field_fails_cleanly(tmp_path):

--- a/tests/test_hub_api_controlled_url_intake.py
+++ b/tests/test_hub_api_controlled_url_intake.py
@@ -256,6 +256,175 @@ def test_json_body_reader_rejects_invalid_utf8_without_traceback(hub_api):
     assert responses == [(400, {"error": "request body must be valid UTF-8"})]
 
 
+@pytest.mark.parametrize(
+    "limit_name",
+    ["MAX_URL_BODY_LENGTH", "MAX_ANALYZE_BODY_LENGTH"],
+    ids=["url-intake", "analyze"],
+)
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_json_body_reader_rejects_non_standard_numeric_constants(
+    hub_api,
+    limit_name,
+    constant,
+):
+    namespace = hub_api.__dict__
+    body = (
+        '{"metadata":{"nested":{"value":' + constant + "}}}"
+    ).encode("utf-8")
+    handler, responses = make_body_reader(
+        namespace,
+        str(len(body)),
+        body,
+    )
+
+    payload = handler.read_json_body(namespace[limit_name])
+
+    assert payload is None
+    assert responses == [
+        (
+            400,
+            {
+                "error": (
+                    "invalid JSON: non-standard numeric constant "
+                    f"{constant} is not valid JSON"
+                )
+            },
+        )
+    ]
+
+
+def test_json_body_reader_preserves_finite_nested_numeric_metadata(hub_api):
+    namespace = hub_api.__dict__
+    body = (
+        b'{"metadata":{"nested":{"negative":-12.5,"zero":0,'
+        b'"positive":6.25e18}}}'
+    )
+    handler, responses = make_body_reader(
+        namespace,
+        str(len(body)),
+        body,
+    )
+
+    payload = handler.read_json_body(namespace["MAX_ANALYZE_BODY_LENGTH"])
+
+    assert payload == {
+        "metadata": {
+            "nested": {
+                "negative": -12.5,
+                "zero": 0,
+                "positive": 6.25e18,
+            }
+        }
+    }
+    assert responses == []
+
+
+def test_response_serializer_fails_closed_before_writing_non_finite_json(
+    hub_api,
+):
+    handler = object.__new__(hub_api.Handler)
+    statuses = []
+    headers = []
+    handler.send_response = statuses.append
+    handler.send_header = lambda name, value: headers.append((name, value))
+    handler.end_headers = lambda: None
+    handler.wfile = io.BytesIO()
+
+    handler.send_json(
+        200,
+        {"metadata": {"nested": {"value": float("nan")}}},
+    )
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert statuses == [500]
+    assert json.loads(body) == {
+        "error": "response payload is not valid strict JSON"
+    }
+    assert "NaN" not in body
+    assert headers[0] == (
+        "Content-Type",
+        "application/json; charset=utf-8",
+    )
+
+
+def test_analyze_serializer_fails_closed_before_creating_case_file(
+    hub_api,
+    tmp_path,
+):
+    hub_api.SHARED = tmp_path / "shared"
+    handler = object.__new__(hub_api.Handler)
+    handler.read_json_body = lambda limit: {
+        "metadata": {"nested": {"value": float("inf")}}
+    }
+    responses = []
+    handler.send_json = lambda status, payload: responses.append(
+        (status, payload)
+    )
+    hub_api.run_command = lambda *args, **kwargs: pytest.fail(
+        "invalid payload must not reach hub-core"
+    )
+
+    handler.handle_analyze()
+
+    assert responses == [
+        (
+            500,
+            {"error": "cannot serialize case input as strict JSON"},
+        )
+    ]
+    assert not (hub_api.SHARED / "api" / "cases").exists()
+
+
+def test_analyze_rejects_non_standard_numeric_constant_in_result_file(
+    hub_api,
+    tmp_path,
+):
+    hub_api.SHARED = tmp_path / "shared"
+    run_id = "20260729T120000Z.Ab12Cd"
+
+    def fake_run_command(args, input_text=None):
+        assert input_text is None
+        result_path = (
+            hub_api.SHARED
+            / "runs"
+            / "analyze"
+            / run_id
+            / "analysis_result.json"
+        )
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text(
+            '{"metadata":{"nested":{"value":NaN}}}\n',
+            encoding="utf-8",
+        )
+        return 0, f"[hub-core:run-id] {run_id}\n", ""
+
+    hub_api.run_command = fake_run_command
+    handler = object.__new__(hub_api.Handler)
+    handler.read_json_body = lambda limit: {
+        "case_id": "strict-result",
+        "core_version_ref": "main",
+        "input_summary": "Strict result regression fixture.",
+    }
+    responses = []
+    handler.send_json = lambda status, payload: responses.append(
+        (status, payload)
+    )
+
+    handler.handle_analyze()
+
+    assert responses == [
+        (
+            500,
+            {
+                "error": (
+                    "analysis result is invalid JSON: non-standard numeric "
+                    "constant NaN is not valid JSON"
+                )
+            },
+        )
+    ]
+
+
 def test_hub_api_controlled_url_intake_security_boundary_present():
     text = API_SCRIPT.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Decision

Treat RFC 8259-compatible finite numbers as the only accepted JSON numeric values at the Semantic Engine CLI and embedded HTTP API boundaries. Reject Python's permissive `NaN`, `Infinity`, and `-Infinity` tokens on input, and fail closed if repository-owned serializers would emit them.

Related to #1803

## Scope

- Make Semantic Engine file parsing strict for non-standard numeric constants.
- Make `/analyze` and `/intake/url` body parsing use the same strict boundary.
- Make CLI, temporary case, analysis result, and HTTP response serialization fail closed.
- Preserve the canonical controlled URL schema and tests merged in #1811.
- Add nested-metadata and finite-number round-trip regressions.

## Files changed

- `semantic_engine/cli/__main__.py`
- `ops/ec2/hub-api.sh`
- `tests/semantic_engine/test_cli_smoke.py`
- `tests/test_hub_api_controlled_url_intake.py`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] Semantic Engine rejects all three non-standard constants with a controlled error and no traceback.
- [x] `/analyze` and `/intake/url` reject them as invalid JSON.
- [x] Repository-owned JSON serialization at these boundaries cannot emit non-finite constants.
- [x] Nested metadata is covered.
- [x] Valid finite numeric metadata round-trips.
- [x] #1811's URL schema, examples, limits, User-Agent, error set, and Operator contract remain intact.
- [x] Focused and full suites pass.

## Validation

- Combined focused boundary/contract suite: `154 passed`.
- Full suite: `386 passed, 12 skipped`.
- The 12 skips require PowerShell 7, which is not installed in the local validation environment.
- PowerShell-focused selection: `9 passed, 12 skipped`.
- Deterministic benchmarks: `3/3`.
- Frozen narratives: `5/5`.
- Narrative consistency: `0 errors, 0 warnings, 0 info`.
- Mojibake scan: 275 Markdown files clean.
- `bash -n ops/ec2/hub-api.sh` and `git diff --check`: clean.
- Published tree SHA matches the validated local tree exactly: `bf404372d87326b4539ff787cf60652f17c809eb`.

## Risks

- Error text becomes more specific for non-standard constants, but valid JSON behavior and response framing stay unchanged.
- This hardens repository boundaries only; it does not prove a public API deployment.
- No scoring, truth evaluation, schema broadening, or new serialization format is introduced.

## AI_HANDOFF update

The handoff records the strict input/output boundary, covered surfaces, controlled failure behavior, and the absence of new semantic capability.

## Next PR recommendation

Land #1804 separately so runtime, telemetry, and mutation tools reuse one authoritative scenario-loading boundary.