### PR TITLE
fix(lab): reuse canonical scenario loading boundary

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -271,6 +271,29 @@ in PR #1771 restores the following behavior:
   39 agreements, 21 no-agreements, and average convergence round 2.26 after
   the issue-#1775 regeneration on commit `af89e420`.
 
+## Canonical Scenario Tool Boundary
+
+Issue #1804 removes independent permissive scenario parsing from telemetry and
+mutation input selection.
+
+Operational boundary:
+
+- `run_scenario.load_validated_scenario` remains the one external-file boundary
+  for standard JSON parsing, structural schema validation, and actor-identity
+  validation;
+- controlled loader errors expose stable categories and codes without changing
+  the supported CLI's exit status or message prefixes;
+- telemetry classifies non-standard JSON constants and non-object roots as
+  parse errors, invalid UTF-8 as an input parse failure, and structural or
+  actor-identity failures as schema errors;
+- manifested telemetry validates and executes the same temporary snapshot made
+  from the exact bytes retained after SHA-256 verification;
+- the mutator validates every selected base through the authoritative loader
+  before creating output and applies the same structural and actor-identity
+  checks to generated mutations;
+- this alignment does not change simulator behavior, frozen benchmark output,
+  or previously published research evidence.
+
 ## Scenario Generation Provenance Boundary
 
 Issue #1758 scopes the laboratory generator/telemetry correction for stale

--- a/run_scenario.py
+++ b/run_scenario.py
@@ -8,7 +8,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, Literal, NoReturn
 
 import jsonschema
 
@@ -21,6 +21,25 @@ INPUT_ERROR_EXIT_CODE = 2
 
 class ScenarioInputError(Exception):
     """A controlled failure while reading the user-supplied scenario file."""
+
+    def __init__(self, message: str, *, error_code: str = "read_error") -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class ScenarioValidationError(ValueError):
+    """A classified parse or validation failure for a scenario document."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        category: Literal["parse", "schema"],
+        error_code: str,
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.error_code = error_code
 
 
 def _load_schema() -> dict[str, Any]:
@@ -73,8 +92,16 @@ def validate_scenario_payload(payload: object) -> list[str]:
 def load_validated_scenario(scenario_path: Path) -> Scenario:
     try:
         source = scenario_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError) as exc:
-        raise ScenarioInputError(f"cannot read scenario file: {exc}") from exc
+    except UnicodeError as exc:
+        raise ScenarioInputError(
+            f"cannot read scenario file: {exc}",
+            error_code="invalid_utf8",
+        ) from exc
+    except OSError as exc:
+        raise ScenarioInputError(
+            f"cannot read scenario file: {exc}",
+            error_code="read_error",
+        ) from exc
 
     try:
         payload: Any = json.loads(
@@ -82,15 +109,29 @@ def load_validated_scenario(scenario_path: Path) -> Scenario:
             parse_constant=_reject_non_standard_json_constant,
         )
     except json.JSONDecodeError as exc:
-        raise ValueError(
-            f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        raise ScenarioValidationError(
+            f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+            category="parse",
+            error_code="invalid_json",
         ) from exc
     except ValueError as exc:
-        raise ValueError(f"Invalid JSON: {exc}") from exc
+        raise ScenarioValidationError(
+            f"Invalid JSON: {exc}",
+            category="parse",
+            error_code="invalid_json",
+        ) from exc
 
     errors = validate_scenario_payload(payload)
     if errors:
-        raise ValueError("\n".join(errors))
+        raise ScenarioValidationError(
+            "\n".join(errors),
+            category="parse" if not isinstance(payload, dict) else "schema",
+            error_code=(
+                "json_root_not_object"
+                if not isinstance(payload, dict)
+                else "schema_invalid"
+            ),
+        )
 
     assert isinstance(payload, dict)
     assert isinstance(payload["title"], str)

--- a/tests/test_scenario_loading.py
+++ b/tests/test_scenario_loading.py
@@ -194,3 +194,21 @@ def test_valid_loaders_return_equivalent_canonical_scenarios() -> None:
     compatibility = Scenario.from_json(str(scenario_path))
 
     assert vars(compatibility) == vars(authoritative)
+
+
+def test_authoritative_loader_exposes_controlled_error_codes(
+    tmp_path: Path,
+) -> None:
+    invalid_root = tmp_path / "array.json"
+    invalid_root.write_text("[]\n", encoding="utf-8")
+    invalid_utf8 = tmp_path / "invalid-utf8.json"
+    invalid_utf8.write_bytes(b"\xff\xfe")
+
+    with pytest.raises(run_scenario.ScenarioValidationError) as root_error:
+        run_scenario.load_validated_scenario(invalid_root)
+    assert root_error.value.category == "parse"
+    assert root_error.value.error_code == "json_root_not_object"
+
+    with pytest.raises(run_scenario.ScenarioInputError) as utf8_error:
+        run_scenario.load_validated_scenario(invalid_utf8)
+    assert utf8_error.value.error_code == "invalid_utf8"

--- a/tests/test_scenario_mutator.py
+++ b/tests/test_scenario_mutator.py
@@ -1,0 +1,131 @@
+"""Regression tests for authoritative scenario selection in the mutator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "tools" / "scenario_mutator.py"
+
+
+def _load_tool() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("scenario_mutator", TOOL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_scenario() -> dict[str, object]:
+    return {
+        "title": "Mutation fixture",
+        "description": "A valid base for controlled mutations.",
+        "roles": [{"name": "Alpha", "role": "negotiator"}],
+        "success_criteria": {"offer": 5},
+        "max_rounds": 2,
+    }
+
+
+def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TOOL), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _source_with_constant(constant: str) -> bytes:
+    source = json.dumps(_valid_scenario()).replace(
+        '"offer": 5',
+        f'"offer": {constant}',
+    )
+    return source.encode("utf-8")
+
+
+def _duplicate_actor_source() -> bytes:
+    payload = _valid_scenario()
+    payload["roles"] = [
+        {"name": "Alpha", "role": "negotiator"},
+        {"name": "Alpha", "role": "mediator"},
+    ]
+    return json.dumps(payload).encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    ("source", "error_code"),
+    [
+        pytest.param(_source_with_constant("NaN"), "invalid_json", id="nan"),
+        pytest.param(
+            _source_with_constant("Infinity"),
+            "invalid_json",
+            id="positive-infinity",
+        ),
+        pytest.param(
+            _source_with_constant("-Infinity"),
+            "invalid_json",
+            id="negative-infinity",
+        ),
+        pytest.param(
+            _duplicate_actor_source(),
+            "schema_invalid",
+            id="duplicate-actors",
+        ),
+        pytest.param(b"\xff\xfe", "invalid_utf8", id="invalid-utf8"),
+        pytest.param(
+            b'{"title": "Incomplete"}',
+            "schema_invalid",
+            id="missing-fields",
+        ),
+        pytest.param(b"[]", "json_root_not_object", id="non-object-root"),
+    ],
+)
+def test_invalid_base_fails_closed_before_output_creation(
+    tmp_path: Path,
+    source: bytes,
+    error_code: str,
+) -> None:
+    base_path = tmp_path / "invalid.json"
+    output_dir = tmp_path / "mutations"
+    base_path.write_bytes(source)
+
+    result = _run_tool(
+        "--base",
+        str(base_path),
+        "--output-dir",
+        str(output_dir),
+    )
+
+    assert result.returncode == 2
+    assert error_code in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not output_dir.exists()
+
+
+def test_generated_mutations_reuse_semantic_actor_validation(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mutator = _load_tool()
+    base = _valid_scenario()
+    base["roles"] = [{"name": "Faction_E", "role": "negotiator"}]
+
+    mutations = mutator.generate_mutations(
+        [("existing-extra-name", base)],
+        ["actors"],
+    )
+
+    assert [stem for stem, _axis, _scenario in mutations] == [
+        "existing-extra-name_actors_1"
+    ]
+    captured = capsys.readouterr()
+    assert "duplicate actor name 'Faction_E'" in captured.err

--- a/tests/test_scenario_telemetry.py
+++ b/tests/test_scenario_telemetry.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TOOL = REPO_ROOT / "tools" / "scenario_telemetry.py"
 
@@ -42,6 +44,27 @@ def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_non_standard_json_constants_are_parse_outcomes(
+    tmp_path: Path,
+    constant: str,
+) -> None:
+    telemetry = _load_tool()
+    path = tmp_path / "non-standard.json"
+    source = json.dumps(_valid_scenario()).replace(
+        '"offer": 5',
+        f'"offer": {constant}',
+    )
+    path.write_text(source, encoding="utf-8")
+
+    record = telemetry.collect_one(path, 42)
+
+    assert record["processing_outcome"] == "parse_error"
+    assert record["error_code"] == "invalid_json"
+    assert record["schema_valid"] is False
+    assert record["runtime_error"] is False
+
+
 def test_non_object_json_is_a_parse_outcome(tmp_path: Path) -> None:
     telemetry = _load_tool()
     path = tmp_path / "array.json"
@@ -63,6 +86,37 @@ def test_invalid_utf8_is_a_parse_outcome(tmp_path: Path) -> None:
 
     assert record["processing_outcome"] == "parse_error"
     assert record["error_code"] == "invalid_utf8"
+    assert record["runtime_error"] is False
+
+
+def test_duplicate_actor_names_are_a_schema_outcome(tmp_path: Path) -> None:
+    telemetry = _load_tool()
+    path = tmp_path / "duplicate-actors.json"
+    payload = _valid_scenario()
+    payload["roles"] = [
+        {"name": "Alpha", "role": "negotiator"},
+        {"name": "Alpha", "role": "mediator"},
+    ]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    record = telemetry.collect_one(path, 42)
+
+    assert record["processing_outcome"] == "schema_error"
+    assert record["error_code"] == "schema_invalid"
+    assert record["schema_valid"] is False
+    assert record["runtime_error"] is False
+
+
+def test_missing_required_fields_are_a_schema_outcome(tmp_path: Path) -> None:
+    telemetry = _load_tool()
+    path = tmp_path / "missing-fields.json"
+    path.write_text('{"title": "Incomplete"}\n', encoding="utf-8")
+
+    record = telemetry.collect_one(path, 42)
+
+    assert record["processing_outcome"] == "schema_error"
+    assert record["error_code"] == "schema_invalid"
+    assert record["schema_valid"] is False
     assert record["runtime_error"] is False
 
 

--- a/tools/scenario_mutator.py
+++ b/tools/scenario_mutator.py
@@ -25,13 +25,16 @@ import copy
 import json
 import sys
 from pathlib import Path
-
-import jsonschema
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCHEMA_PATH = REPO_ROOT / "scenario.schema.json"
 GENERATED_DIR = REPO_ROOT / "scenarios" / "generated"
 OUTPUT_DIR = REPO_ROOT / "scenarios" / "mutations"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import run_scenario  # noqa: E402
 
 EXTRA_ACTORS = [
     {"name": "Faction_E", "role": "negotiator"},
@@ -45,7 +48,10 @@ EXTRA_ACTORS = [
 # ── Mutation functions ──────────────────────────────────────
 
 
-def mutate_threshold(base: dict, base_label: str) -> list[tuple[str, dict]]:
+def mutate_threshold(
+    base: dict[str, Any],
+    base_label: str,
+) -> list[tuple[str, dict[str, Any]]]:
     """Sweep success_criteria.offer from 1 to 5."""
     results = []
     for threshold in range(1, 6):
@@ -61,7 +67,10 @@ def mutate_threshold(base: dict, base_label: str) -> list[tuple[str, dict]]:
     return results
 
 
-def mutate_rounds(base: dict, base_label: str) -> list[tuple[str, dict]]:
+def mutate_rounds(
+    base: dict[str, Any],
+    base_label: str,
+) -> list[tuple[str, dict[str, Any]]]:
     """Sweep max_rounds from 1 to 10."""
     results = []
     for rounds in range(1, 11):
@@ -77,7 +86,10 @@ def mutate_rounds(base: dict, base_label: str) -> list[tuple[str, dict]]:
     return results
 
 
-def mutate_actors(base: dict, base_label: str) -> list[tuple[str, dict]]:
+def mutate_actors(
+    base: dict[str, Any],
+    base_label: str,
+) -> list[tuple[str, dict[str, Any]]]:
     """Sweep actor count from 1 to min(6, base+3) by adding/removing negotiators."""
     original_count = len(base["roles"])
     results = []
@@ -112,7 +124,22 @@ AXES = {
 # ── Core logic ──────────────────────────────────────────────
 
 
-def pick_base_scenarios(base_path: str | None) -> list[tuple[str, dict]]:
+def _scenario_payload(scenario: run_scenario.Scenario) -> dict[str, Any]:
+    """Return a mutation-safe payload from an authoritatively loaded scenario."""
+    return copy.deepcopy(
+        {
+            "title": scenario.title,
+            "description": scenario.description,
+            "roles": scenario.roles,
+            "success_criteria": scenario.success_criteria,
+            "max_rounds": scenario.max_rounds,
+        }
+    )
+
+
+def pick_base_scenarios(
+    base_path: str | None,
+) -> list[tuple[str, dict[str, Any]]]:
     """Select base scenario(s) for mutation.
 
     If base_path is given, use that single file.
@@ -120,8 +147,8 @@ def pick_base_scenarios(base_path: str | None) -> list[tuple[str, dict]]:
     """
     if base_path:
         p = Path(base_path)
-        payload = json.loads(p.read_text(encoding="utf-8"))
-        return [(p.stem, payload)]
+        scenario = run_scenario.load_validated_scenario(p)
+        return [(p.stem, _scenario_payload(scenario))]
 
     bases = []
     if not GENERATED_DIR.is_dir():
@@ -134,33 +161,37 @@ def pick_base_scenarios(base_path: str | None) -> list[tuple[str, dict]]:
         jsons = sorted(family_dir.glob("*.json"))
         if jsons:
             p = jsons[0]
-            payload = json.loads(p.read_text(encoding="utf-8"))
-            bases.append((p.stem, payload))
+            scenario = run_scenario.load_validated_scenario(p)
+            bases.append((p.stem, _scenario_payload(scenario)))
 
     return bases
 
 
 def generate_mutations(
-    bases: list[tuple[str, dict]],
+    bases: list[tuple[str, dict[str, Any]]],
     axes: list[str],
-) -> list[tuple[str, str, dict]]:
+) -> list[tuple[str, str, dict[str, Any]]]:
     """Generate all mutations for the given bases and axes.
 
     Returns list of (filename_stem, axis_name, scenario_dict).
     """
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    validator = jsonschema.Draft202012Validator(schema)
-
-    results: list[tuple[str, str, dict]] = []
+    results: list[tuple[str, str, dict[str, Any]]] = []
 
     for base_label, base_scenario in bases:
+        base_errors = run_scenario.validate_scenario_payload(base_scenario)
+        if base_errors:
+            print(
+                f"  SKIP  {base_label}: invalid base — {'; '.join(base_errors)}",
+                file=sys.stderr,
+            )
+            continue
         for axis_name in axes:
             mutator = AXES[axis_name]
             mutations = mutator(base_scenario, base_label)
             for stem, scenario in mutations:
-                errors = list(validator.iter_errors(scenario))
+                errors = run_scenario.validate_scenario_payload(scenario)
                 if errors:
-                    msgs = "; ".join(e.message for e in errors)
+                    msgs = "; ".join(errors)
                     print(f"  SKIP  {stem}: schema invalid — {msgs}", file=sys.stderr)
                     continue
                 results.append((stem, axis_name, scenario))
@@ -169,7 +200,7 @@ def generate_mutations(
 
 
 def write_mutations(
-    mutations: list[tuple[str, str, dict]],
+    mutations: list[tuple[str, str, dict[str, Any]]],
     output_dir: Path,
 ) -> int:
     """Write mutations organized by axis subdirectory."""
@@ -211,7 +242,20 @@ def main() -> int:
     out = Path(args.output_dir) if args.output_dir else OUTPUT_DIR
     axes = [args.axis] if args.axis else list(AXES.keys())
 
-    bases = pick_base_scenarios(args.base)
+    try:
+        bases = pick_base_scenarios(args.base)
+    except run_scenario.ScenarioInputError as exc:
+        print(
+            f"[base-input-error] {exc.error_code}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    except run_scenario.ScenarioValidationError as exc:
+        print(
+            f"[base-{exc.category}-error] {exc.error_code}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
     if not bases:
         print("No base scenarios found. Run the generator first:\n"
               "  python tools/scenario_generator/generate_scenarios.py",

--- a/tools/scenario_telemetry.py
+++ b/tools/scenario_telemetry.py
@@ -22,6 +22,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from contextlib import ExitStack
 import hashlib
 import json
 import os
@@ -34,7 +35,6 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNNER = REPO_ROOT / "run_scenario.py"
-SCHEMA_PATH = REPO_ROOT / "scenario.schema.json"
 DEFAULT_SCENARIO_DIR = REPO_ROOT / "scenarios" / "generated"
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "scenarios"
 SEED = "42"
@@ -52,6 +52,11 @@ GENERATOR_ID = "tools/scenario_generator/generate_scenarios.py"
 GENERATOR_FAMILIES = frozenset(
     {"info_asymmetry", "resource_scarcity", "incentive_misalignment"}
 )
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import run_scenario  # noqa: E402
 
 
 class ManifestError(ValueError):
@@ -208,15 +213,6 @@ def _infer_mutation_axis(path: Path) -> str | None:
     return None
 
 
-def _validate_schema(payload: Any) -> bool:
-    """Check if the scenario payload passes schema validation."""
-    import jsonschema
-
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    validator = jsonschema.Draft202012Validator(schema)
-    return not list(validator.iter_errors(payload))
-
-
 def collect_one(
     scenario_path: Path,
     seed: int,
@@ -251,117 +247,106 @@ def collect_one(
         "error_code": None,
     }
 
-    # Load and validate schema
-    try:
-        scenario_bytes = (
-            verified_scenario_bytes
-            if verified_scenario_bytes is not None
-            else scenario_path.read_bytes()
-        )
-    except OSError:
-        record["error_code"] = "read_error"
-        return record
-
-    try:
-        payload = json.loads(scenario_bytes.decode("utf-8"))
-    except UnicodeDecodeError:
-        record["error_code"] = "invalid_utf8"
-        return record
-    except json.JSONDecodeError:
-        record["error_code"] = "invalid_json"
-        return record
-
-    if not isinstance(payload, dict):
-        record["error_code"] = "json_root_not_object"
-        return record
-
-    record["schema_valid"] = _validate_schema(payload)
-    if not record["schema_valid"]:
-        record["processing_outcome"] = "schema_error"
-        record["error_code"] = "schema_invalid"
-        return record
-
-    record["actors"] = len(payload["roles"])
-    record["max_rounds"] = payload["max_rounds"]
-
-    # Run through the simulator
-    record["processing_outcome"] = "runtime_error"
-    record["runtime_error"] = True
-    snapshot_directory: tempfile.TemporaryDirectory[str] | None = None
-    runner_scenario_path = scenario_path
-    actual: Path | None = None
-    try:
+    with ExitStack() as stack:
+        runner_scenario_path = scenario_path
         if verified_scenario_bytes is not None:
-            snapshot_directory = tempfile.TemporaryDirectory(
-                prefix="hub-optimus-telemetry-"
+            snapshot_directory = Path(
+                stack.enter_context(
+                    tempfile.TemporaryDirectory(
+                        prefix="hub-optimus-telemetry-"
+                    )
+                )
             )
             runner_scenario_path = (
-                Path(snapshot_directory.name) / scenario_path.name
+                snapshot_directory / scenario_path.name
             )
-            runner_scenario_path.write_bytes(verified_scenario_bytes)
+            try:
+                runner_scenario_path.write_bytes(verified_scenario_bytes)
+            except OSError:
+                record["processing_outcome"] = "runtime_error"
+                record["runtime_error"] = True
+                record["error_code"] = "verified_snapshot_error"
+                return record
+
+        try:
+            scenario = run_scenario.load_validated_scenario(runner_scenario_path)
+        except run_scenario.ScenarioInputError as exc:
+            record["error_code"] = exc.error_code
+            return record
+        except run_scenario.ScenarioValidationError as exc:
+            record["processing_outcome"] = f"{exc.category}_error"
+            record["error_code"] = exc.error_code
+            return record
+
+        record["schema_valid"] = True
+        record["actors"] = len(scenario.roles)
+        record["max_rounds"] = scenario.max_rounds
+
+        # Run through the simulator only after the authoritative loader accepts
+        # the exact path validated above. Manifested runs use the retained
+        # verified-byte snapshot for both validation and execution.
+        record["processing_outcome"] = "runtime_error"
+        record["runtime_error"] = True
         actual = runner_scenario_path.with_suffix(".telemetry_tmp.json")
+        try:
+            env = os.environ.copy()
+            env["PYTHONIOENCODING"] = "utf-8"
+            proc = subprocess.run(
+                [
+                    sys.executable, str(RUNNER),
+                    str(runner_scenario_path),
+                    "--output", str(actual),
+                    "--seed", str(seed),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True, text=True,
+                encoding="utf-8", errors="replace",
+                env=env, check=False,
+            )
 
-        env = os.environ.copy()
-        env["PYTHONIOENCODING"] = "utf-8"
-        proc = subprocess.run(
-            [
-                sys.executable, str(RUNNER),
-                str(runner_scenario_path),
-                "--output", str(actual),
-                "--seed", str(seed),
-            ],
-            cwd=REPO_ROOT,
-            capture_output=True, text=True,
-            encoding="utf-8", errors="replace",
-            env=env, check=False,
-        )
+            if proc.returncode != 0:
+                record["error_code"] = "runner_exit"
+                return record
 
-        if proc.returncode != 0:
-            record["error_code"] = "runner_exit"
-            return record
+            result = json.loads(actual.read_text(encoding="utf-8"))
+            if not isinstance(result, dict):
+                record["error_code"] = "runner_output_not_object"
+                return record
 
-        result = json.loads(actual.read_text(encoding="utf-8"))
-        if not isinstance(result, dict):
-            record["error_code"] = "runner_output_not_object"
-            return record
+            result_status = result.get("status")
+            rounds_used = result.get("rounds")
+            if result_status not in {"success", "failure"}:
+                record["error_code"] = "runner_status_invalid"
+                return record
+            if (
+                not isinstance(rounds_used, int)
+                or isinstance(rounds_used, bool)
+                or rounds_used < 0
+            ):
+                record["error_code"] = "runner_rounds_invalid"
+                return record
 
-        result_status = result.get("status")
-        rounds_used = result.get("rounds")
-        if result_status not in {"success", "failure"}:
-            record["error_code"] = "runner_status_invalid"
-            return record
-        if (
-            not isinstance(rounds_used, int)
-            or isinstance(rounds_used, bool)
-            or rounds_used < 0
-        ):
-            record["error_code"] = "runner_rounds_invalid"
-            return record
+            record["runtime_error"] = False
+            record["result_status"] = result_status
+            record["rounds_used"] = rounds_used
+            record["processing_outcome"] = (
+                "agreement" if result_status == "success" else "no_agreement"
+            )
+            record["error_code"] = None
 
-        record["runtime_error"] = False
-        record["result_status"] = result_status
-        record["rounds_used"] = rounds_used
-        record["processing_outcome"] = (
-            "agreement" if result_status == "success" else "no_agreement"
-        )
-        record["error_code"] = None
-
-        if result_status == "success":
-            record["convergence_round"] = rounds_used
-    except UnicodeDecodeError:
-        record["error_code"] = "runner_output_invalid_utf8"
-    except json.JSONDecodeError:
-        record["error_code"] = "runner_output_invalid_json"
-    except OSError:
-        record["error_code"] = "runner_output_error"
-    finally:
-        if actual is not None:
+            if result_status == "success":
+                record["convergence_round"] = rounds_used
+        except UnicodeDecodeError:
+            record["error_code"] = "runner_output_invalid_utf8"
+        except json.JSONDecodeError:
+            record["error_code"] = "runner_output_invalid_json"
+        except OSError:
+            record["error_code"] = "runner_output_error"
+        finally:
             try:
                 actual.unlink(missing_ok=True)
             except OSError:
                 pass
-        if snapshot_directory is not None:
-            snapshot_directory.cleanup()
 
     return record
 


### PR DESCRIPTION
## Decision

Reuse `run_scenario.load_validated_scenario` as the authoritative parse, schema, and actor-identity boundary for the runner, telemetry inputs, and mutation bases. Classify controlled failures with stable codes while preserving the runner CLI's existing prefixes and exit code.

Related to #1804

## Scope

- Add typed parse/schema classifications to the existing authoritative loader.
- Make telemetry validate with that loader and execute the same retained byte snapshot for manifested runs.
- Make the mutator reject invalid bases before creating any output.
- Reuse the same structural and duplicate-actor validation for generated mutations.
- Add focused loading, telemetry, and mutator regressions.
- Preserve strict JSON/API work from #1812 and the URL contract from #1811.

## Files changed

- `run_scenario.py`
- `tools/scenario_telemetry.py`
- `tools/scenario_mutator.py`
- `tests/test_scenario_loading.py`
- `tests/test_scenario_telemetry.py`
- `tests/test_scenario_mutator.py`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] Runtime, telemetry, and mutator input selection reuse one authoritative validation boundary.
- [x] Non-standard constants, duplicate names, invalid UTF-8/JSON, missing fields, and non-object roots receive controlled classifications.
- [x] Manifested telemetry validates and runs the retained bytes whose SHA-256 was verified.
- [x] Mutation does not create output from an invalid base.
- [x] Simulator behavior, frozen fixtures, and research conclusions are unchanged.
- [x] Focused, scenario, benchmark, narrative, and full suites pass.

## Validation

- #1804 focused suite: `50 passed`.
- Strict JSON, URL, and Operator preservation suite: `129 passed`.
- Full suite: `400 passed, 12 skipped`.
- The 12 skips require PowerShell 7, which is not installed in the local validation environment.
- Manifested generation run: `sha256:cab1baacc6cd3494487a59dd3f75ca9584dc872e8b3b3ec65dbd822f9bf0de92`.
- Telemetry: `60/60` processed; 0 parse/schema/runtime errors; 39 agreements, 21 non-agreements; mean convergence round `2.26`.
- Deterministic benchmarks: `3/3`.
- Frozen narratives: `5/5`; consistency `0 errors, 0 warnings, 0 info`.
- Mojibake scan: 275 Markdown files clean.
- `git diff --check`: clean.
- Published tree SHA matches the validated local tree exactly: `e90b7b70db367bd8529ebbe832ddea785abc698b`.

## Risks

- Telemetry and mutation now reject inputs that the runner already rejected, so previously inconsistent permissive cases change from accepted/partially processed to controlled errors.
- Manifest verification and telemetry remain repository tooling, not real-world validation or deployment evidence.
- No historical evidence is regenerated and no synthetic result is reinterpreted.

## AI_HANDOFF update

The handoff records the shared loader boundary, stable classification, exact-byte manifested execution, invalid-base mutation behavior, and unchanged simulator/evidence scope.

## Next PR recommendation

Land #1806 separately so repository-health PR/issue counts are exhaustive and fail closed instead of silently truncating at 30.