### PR TITLE
fix(ops): make repository health counts exhaustive

### DIFF
--- a/.github/workflows/repo-health-summary.yml
+++ b/.github/workflows/repo-health-summary.yml
@@ -32,29 +32,86 @@ jobs:
 
           echo "Event: ${GITHUB_EVENT_NAME} | Actor: ${GITHUB_ACTOR}"
 
+          # GitHub CLI list commands default to 30 results. Fetch one item beyond
+          # the documented ceiling so a repository that exceeds the audit
+          # boundary fails closed instead of publishing a partial count.
+          GH_LIST_COUNT_CEILING=10000
+          GH_LIST_FETCH_LIMIT=$((GH_LIST_COUNT_CEILING + 1))
+
+          fetch_gh_list() {
+            local resource="$1"
+            local fields="$2"
+            shift 2
+            local output
+            local count
+
+            if ! output=$(gh "$resource" list \
+              --limit "$GH_LIST_FETCH_LIMIT" \
+              --json "$fields" \
+              "$@"); then
+              echo "::error::Failed to fetch GitHub ${resource} list; no health summary was published." >&2
+              return 1
+            fi
+
+            if ! count=$(jq -er \
+              'if type == "array" then length else error("expected an array") end' \
+              <<<"$output"); then
+              echo "::error::GitHub ${resource} list returned invalid JSON; no health summary was published." >&2
+              return 1
+            fi
+
+            if [ "$count" -gt "$GH_LIST_COUNT_CEILING" ]; then
+              echo "::error::GitHub ${resource} list exceeds the ${GH_LIST_COUNT_CEILING}-item audit ceiling; no partial summary was published." >&2
+              return 1
+            fi
+
+            printf '%s\n' "$output"
+          }
+
           # --- Core metrics ---
-          PRS=$(gh pr list --state open --json number --jq 'length')
-          ISSUES=$(gh issue list --state open --json number --jq 'length')
+          OPEN_PRS_JSON=$(fetch_gh_list pr number,author --state open)
+          OPEN_ISSUES_JSON=$(fetch_gh_list issue number --state open)
+          PRS=$(jq -r 'length' <<<"$OPEN_PRS_JSON")
+          ISSUES=$(jq -r 'length' <<<"$OPEN_ISSUES_JSON")
           LAST5=$(gh run list --limit 5 --json conclusion --jq '.[].conclusion' | tr '\n' ' ')
           FAILURES=$(gh run list --limit 10 --json conclusion --jq '[.[] | select(.conclusion=="failure")] | length')
           LAST_COMMIT=$(git log -1 --pretty=format:"%h %s")
           DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
 
           # --- Extended metrics ---
-          BRANCHES=$(git ls-remote --heads origin | wc -l | tr -d ' ')
-          BOT_BRANCHES=$(git ls-remote --heads origin | grep -c "chore/maintenance-" || true)
+          if ! REMOTE_HEADS=$(git ls-remote --heads origin); then
+            echo "::error::Failed to fetch remote branch refs; no health summary was published." >&2
+            exit 1
+          fi
+          BRANCHES=$(awk 'NF { count += 1 } END { print count + 0 }' <<<"$REMOTE_HEADS")
+          BOT_BRANCHES=$(awk \
+            '$2 ~ /^refs\/heads\/chore\/maintenance-/ { count += 1 } END { print count + 0 }' \
+            <<<"$REMOTE_HEADS")
           WEEK_AGO=$(date -u -d '7 days ago' +"%Y-%m-%dT%H:%M:%SZ")
-          PRS_CLOSED_WEEK=$(gh pr list --state closed --json closedAt \
-            --jq "[.[] | select(.closedAt >= \"$WEEK_AGO\")] | length")
-          PRS_OPENED_WEEK=$(gh pr list --state all --json createdAt \
-            --jq "[.[] | select(.createdAt >= \"$WEEK_AGO\")] | length")
-          ISSUES_OPENED_WEEK=$(gh issue list --state all --json createdAt \
-            --jq "[.[] | select(.createdAt >= \"$WEEK_AGO\")] | length")
+          CLOSED_PRS_JSON=$(fetch_gh_list pr closedAt --state closed)
+          ALL_PRS_JSON=$(fetch_gh_list pr createdAt,author --state all)
+          ALL_ISSUES_JSON=$(fetch_gh_list issue createdAt --state all)
+          PRS_CLOSED_WEEK=$(jq -r \
+            --arg week_ago "$WEEK_AGO" \
+            '[.[] | select(.closedAt >= $week_ago)] | length' \
+            <<<"$CLOSED_PRS_JSON")
+          PRS_OPENED_WEEK=$(jq -r \
+            --arg week_ago "$WEEK_AGO" \
+            '[.[] | select(.createdAt >= $week_ago)] | length' \
+            <<<"$ALL_PRS_JSON")
+          ISSUES_OPENED_WEEK=$(jq -r \
+            --arg week_ago "$WEEK_AGO" \
+            '[.[] | select(.createdAt >= $week_ago)] | length' \
+            <<<"$ALL_ISSUES_JSON")
 
           # --- Automation actor analysis ---
-          TOP_PR_AUTHOR=$(gh pr list --limit 100 --state all --json author \
-            --jq '[.[].author.login] | group_by(.) | map({author: .[0], count: length}) | sort_by(-.count) | .[0] | "\(.author) (\(.count))"')
-          DEPENDABOT_PRS=$(gh pr list --state open --search "author:app/dependabot" --json number --jq 'length')
+          # This is an explicitly labelled 100-PR sample, not a repository count.
+          TOP_PR_AUTHOR=$(jq -r \
+            '.[0:100] | [.[].author.login] | group_by(.) | map({author: .[0], count: length}) | sort_by(-.count) | .[0] | "\(.author) (\(.count))"' \
+            <<<"$ALL_PRS_JSON")
+          DEPENDABOT_PRS=$(jq -r \
+            '[.[] | select(.author.login == "dependabot[bot]")] | length' \
+            <<<"$OPEN_PRS_JSON")
 
           # --- Anomaly detection ---
           ALERTS=""

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -158,6 +158,23 @@ Operational boundary:
 - retiring historical maintenance branches remains a separate audited action
   and is not authorized or performed by the scheduled drift check.
 
+## Repository Health Count Boundary
+
+Issue #1806 keeps the weekly repository-health summary exhaustive within an
+explicit, fail-closed audit boundary.
+
+Operational boundary:
+
+- every PR or issue total used as a repository metric requests up to 10,001
+  records, making counts through the documented 10,000-item ceiling exhaustive;
+- a result beyond that ceiling, invalid JSON, or any failed GitHub CLI/API call
+  stops the run before it can publish a partial or plausible-zero snapshot;
+- remote branch refs are fetched once and a failed fetch is terminal;
+- the established anomaly thresholds and `contents: read` / `issues: write`
+  permissions remain unchanged;
+- the top-author field remains an explicitly labelled last-100-PR sample and is
+  not represented as an exhaustive repository count.
+
 ## Simulator Isolation Boundary
 
 Issue #1755 records a verified mismatch between the runtime contract and the

--- a/docs/context/WORKFLOWS.md
+++ b/docs/context/WORKFLOWS.md
@@ -128,6 +128,12 @@ powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1
   - `issues: write`
 - Job:
   - Collects repository health metrics with `gh`.
+  - PR and issue counts request up to 10,001 records so counts through the
+    explicit 10,000-item audit ceiling are exhaustive. A failed CLI/API call,
+    invalid JSON response, or result above that ceiling stops the run without
+    publishing a partial or plausible-zero snapshot.
+  - Remote branch refs are collected once and a failed `git ls-remote` also
+    stops the run instead of being represented as zero maintenance branches.
   - Posts a summary comment to issue `#93`.
 - Writes to repo: no; writes issue comments.
 

--- a/tests/test_repo_health_summary_workflow.py
+++ b/tests/test_repo_health_summary_workflow.py
@@ -1,0 +1,254 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "repo-health-summary.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _run_script() -> str:
+    document = _workflow()
+    steps = document["jobs"]["summary"]["steps"]
+    return next(
+        step["run"]
+        for step in steps
+        if step.get("name") == "Gather and post health summary"
+    )
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _fake_commands(tmp_path: Path) -> tuple[Path, Path]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    captured_body = tmp_path / "captured-body.md"
+
+    _write_executable(
+        fake_bin / "gh",
+        """#!/usr/bin/env python3
+import json
+import os
+import shutil
+import sys
+
+args = sys.argv[1:]
+failure = os.environ.get("FAKE_GH_FAILURE")
+if failure and " ".join(args).startswith(failure):
+    print('[{"number": 1}]')
+    print("simulated GitHub CLI failure", file=sys.stderr)
+    raise SystemExit(23)
+invalid_response = os.environ.get("FAKE_GH_INVALID_RESPONSE")
+if invalid_response and " ".join(args).startswith(invalid_response):
+    print('{"not": "an array"}')
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "comment"]:
+    source = args[args.index("--body-file") + 1]
+    shutil.copyfile(source, os.environ["CAPTURED_BODY"])
+    raise SystemExit(0)
+
+if args[:2] == ["run", "list"]:
+    expression = args[args.index("--jq") + 1]
+    if "failure" in expression:
+        print("2")
+    else:
+        print("success")
+        print("failure")
+        print("success")
+        print("failure")
+        print("success")
+    raise SystemExit(0)
+
+if len(args) < 2 or args[1] != "list":
+    print(f"unsupported gh invocation: {args}", file=sys.stderr)
+    raise SystemExit(64)
+
+limit = int(args[args.index("--limit") + 1])
+fields = args[args.index("--json") + 1].split(",")
+state = args[args.index("--state") + 1]
+
+if args[0] == "pr" and state == "open":
+    total = int(os.environ.get("FAKE_OPEN_PRS", "45"))
+elif args[0] == "issue" and state == "open":
+    total = int(os.environ.get("FAKE_OPEN_ISSUES", "67"))
+elif args[0] == "pr" and state == "closed":
+    total = int(os.environ.get("FAKE_CLOSED_PRS", "41"))
+elif args[0] == "pr" and state == "all":
+    total = int(os.environ.get("FAKE_ALL_PRS", "83"))
+elif args[0] == "issue" and state == "all":
+    total = int(os.environ.get("FAKE_ALL_ISSUES", "91"))
+else:
+    print(f"unsupported gh list invocation: {args}", file=sys.stderr)
+    raise SystemExit(64)
+
+records = []
+for number in range(1, min(total, limit) + 1):
+    record = {}
+    for field in fields:
+        if field == "number":
+            record[field] = number
+        elif field == "author":
+            dependabot_total = int(os.environ.get("FAKE_DEPENDABOT_PRS", "34"))
+            if args[0] == "pr" and state == "open" and number <= dependabot_total:
+                login = "dependabot[bot]"
+            else:
+                login = "alice" if number % 3 else "bob"
+            record[field] = {"login": login}
+        elif field in {"createdAt", "closedAt"}:
+            record[field] = "9999-01-01T00:00:00Z"
+        else:
+            print(f"unsupported field: {field}", file=sys.stderr)
+            raise SystemExit(64)
+    records.append(record)
+print(json.dumps(records))
+""",
+    )
+
+    _write_executable(
+        fake_bin / "git",
+        """#!/usr/bin/env python3
+import os
+import sys
+
+args = sys.argv[1:]
+if args[:2] == ["log", "-1"]:
+    print("abcdef0 fixture commit")
+elif args[:2] == ["ls-remote", "--heads"]:
+    if os.environ.get("FAKE_GIT_LS_REMOTE_FAILURE"):
+        print("0000000000000000000000000000000000000001\\trefs/heads/partial")
+        print("simulated git failure", file=sys.stderr)
+        raise SystemExit(29)
+    for number in range(1, 206):
+        prefix = "chore/maintenance-" if number <= 25 else "feature/"
+        print(f"{number:040x}\\trefs/heads/{prefix}{number}")
+else:
+    print(f"unsupported git invocation: {args}", file=sys.stderr)
+    raise SystemExit(64)
+""",
+    )
+    return fake_bin, captured_body
+
+
+def _run_health_summary(
+    tmp_path: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    fake_bin, captured_body = _fake_commands(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "CAPTURED_BODY": str(captured_body),
+        "GITHUB_ACTOR": "fixture-actor",
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+    }
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        ["bash", "-c", _run_script()],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, captured_body
+
+
+def test_workflow_preserves_permissions_and_documents_fail_closed_ceiling() -> None:
+    document = _workflow()
+    script = _run_script()
+
+    assert document["permissions"] == {"contents": "read", "issues": "write"}
+    assert "GH_LIST_COUNT_CEILING=10000" in script
+    assert "GH_LIST_FETCH_LIMIT=$((GH_LIST_COUNT_CEILING + 1))" in script
+    assert "fetch_gh_list pr number,author --state open" in script
+    assert "fetch_gh_list issue number --state open" in script
+    assert "fetch_gh_list pr closedAt --state closed" in script
+    assert "fetch_gh_list pr createdAt,author --state all" in script
+    assert "fetch_gh_list issue createdAt --state all" in script
+    assert 'select(.author.login == "dependabot[bot]")' in script
+    assert "gh pr list" not in script
+    assert "gh issue list" not in script
+    assert 'if [ "$PRS" -gt 10 ]; then' in script
+    assert 'if [ "$FAILURES" -gt 3 ]; then' in script
+    assert 'if [ "$BRANCHES" -gt 200 ]; then' in script
+    assert 'if [ "$BOT_BRANCHES" -gt 20 ]; then' in script
+    assert (
+        'if [ "$PRS_OPENED_WEEK" -gt 5 ] '
+        '&& [ "$PRS_CLOSED_WEEK" -gt "$((PRS_OPENED_WEEK * 8 / 10))" ]; then'
+        in script
+    )
+    assert 'if [ "$ISSUES_OPENED_WEEK" -gt 20 ]; then' in script
+    assert 'if [ "$DEPENDABOT_PRS" -gt 10 ]; then' in script
+
+
+def test_counts_above_thirty_are_not_truncated(tmp_path: Path) -> None:
+    result, captured_body = _run_health_summary(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    body = captured_body.read_text(encoding="utf-8")
+    assert "| Open PRs | 45 |" in body
+    assert "| Open Issues | 67 |" in body
+    assert "| PRs opened (7d) | 83 |" in body
+    assert "| PRs closed (7d) | 41 |" in body
+    assert "| Issues opened (7d) | 91 |" in body
+    assert "| Dependabot open PRs | 34 |" in body
+    assert "High open PRs (45)" in body
+    assert "Issue burst (91 new issues this week)" in body
+    assert "Dependabot storm (34 open PRs)" in body
+
+
+def test_github_cli_failure_cannot_publish_a_plausible_zero(tmp_path: Path) -> None:
+    result, captured_body = _run_health_summary(
+        tmp_path,
+        extra_env={"FAKE_GH_FAILURE": "issue list"},
+    )
+
+    assert result.returncode != 0
+    assert not captured_body.exists()
+    assert "Failed to fetch GitHub issue list" in result.stderr
+
+
+def test_count_above_ceiling_fails_without_partial_summary(tmp_path: Path) -> None:
+    result, captured_body = _run_health_summary(
+        tmp_path,
+        extra_env={"FAKE_OPEN_ISSUES": "10001"},
+    )
+
+    assert result.returncode != 0
+    assert not captured_body.exists()
+    assert "exceeds the 10000-item audit ceiling" in result.stderr
+
+
+def test_invalid_github_response_cannot_publish_a_count(tmp_path: Path) -> None:
+    result, captured_body = _run_health_summary(
+        tmp_path,
+        extra_env={"FAKE_GH_INVALID_RESPONSE": "pr list"},
+    )
+
+    assert result.returncode != 0
+    assert not captured_body.exists()
+    assert "GitHub pr list returned invalid JSON" in result.stderr
+
+
+def test_partial_remote_branch_fetch_cannot_publish_a_count(tmp_path: Path) -> None:
+    result, captured_body = _run_health_summary(
+        tmp_path,
+        extra_env={"FAKE_GIT_LS_REMOTE_FAILURE": "1"},
+    )
+
+    assert result.returncode != 0
+    assert not captured_body.exists()
+    assert "Failed to fetch remote branch refs" in result.stderr


### PR DESCRIPTION
## Decision

Make every repository-wide PR/issue health count exhaustive up to an explicit 10,000-item ceiling, and fail closed when GitHub CLI, JSON parsing, or remote-ref collection fails. Preserve the existing anomaly thresholds and workflow permissions.

Related to #1806

## Scope

- Route exhaustive PR and issue list metrics through one bounded fetch helper.
- Fetch 10,001 records so a count over the 10,000-item audit ceiling is detected rather than truncated.
- Reuse the open-PR payload for exhaustive Dependabot counts.
- Keep the top-author metric explicitly as a most-recent-100 sample.
- Collect remote heads once and reject failed/partial `git ls-remote` output.
- Execute the real YAML shell block under faked `gh` and `git` commands in tests.

## Files changed

- `.github/workflows/repo-health-summary.yml`
- `tests/test_repo_health_summary_workflow.py`
- `docs/context/WORKFLOWS.md`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] Repository-wide counts are exhaustive through a documented fail-closed ceiling.
- [x] Counts above 30 are not truncated.
- [x] CLI failure, invalid JSON, over-ceiling results, and partial remote-ref failure cannot publish zero or partial summaries.
- [x] All seven anomaly thresholds keep their previous values and meaning.
- [x] Permissions remain exactly `contents: read` and `issues: write`.
- [x] Focused and full suites pass.
- [ ] The updated workflow still needs one GitHub-hosted manual run after merge.

## Validation

- Focused repo-health and Action-pin suite: `9 passed`.
- Full suite: `406 passed, 12 skipped`.
- The 12 skips require PowerShell 7, which is not installed in the local validation environment.
- The tests execute the actual YAML Bash block and cover 45/67/83/41/91/34-item metrics, invalid JSON, an over-10,000 result, a command that emits partial output then fails, and a partial remote-ref failure.
- All 14 workflow YAML files parse.
- Embedded shell block: `bash -n` clean.
- Immutable Action-pin tests: `3/3`.
- Deterministic benchmarks: `3/3`.
- Narrative corpus: 16 records; `0 errors, 0 warnings, 0 info`.
- Mojibake scan: 275 Markdown files clean.
- `git diff --check` and `git show --check`: clean.
- Published tree SHA matches the validated local tree exactly: `108ec8413234fb291c76c62a44e9b49178071f21`.

## Risks

- A repository larger than 10,000 matching items now fails visibly instead of publishing a partial count.
- Exhaustive weekly list calls cost more API pagination than the former implicit 30-item sample.
- The top-author line remains a labelled 100-PR sample; it is not represented as an exhaustive count.
- Local tests do not substitute for the GitHub-hosted workflow run.

## AI_HANDOFF update

The handoff records the exhaustive ceiling, fail-closed inputs, retained permissions/thresholds, and the hosted-run residual.

## Next PR recommendation

Refresh the capability ledger and retire the obsolete checkpoint claim under #1807, using the resulting `main` as its explicit evidence baseline.