### PR TITLE
docs(truth): refresh capability evidence baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 >
 > **Translation status:** DE governance path translated · CA / FR / RU = progressive translation · HE / ZH = onboarding stubs, full translation pending
 >
-> Source of truth: [docs/context/STATUS.md](docs/context/STATUS.md)
+> Translation-policy authority:
+> [docs/context/STATUS.md](docs/context/STATUS.md)
 
 **Quick paths:**
 - 90 seconds: [EN](docs/00_start_here.md) · [ES](docs/es/00_start_here.md) · [DE](docs/de/00_start_here.md)
@@ -105,7 +106,11 @@ HUB_Optimus exists to **break that cycle** by evaluating scenarios **before** de
 - `docs/architecture/platform_compatibility.md` → platform-neutral access and execution policy
 - `legacy/` → historical/exploratory materials (v0), preserved for transparency
 
-> Source-of-truth policy is defined in `docs/context/STATUS.md`: `v1_core/languages/es/` is canonical and `v1_core/languages/en/` is parity reference.
+> Project-wide precedence is defined in
+> [`docs/context/SOURCE_OF_TRUTH.md`](docs/context/SOURCE_OF_TRUTH.md).
+> Language policy remains in `docs/context/STATUS.md`:
+> `v1_core/languages/es/` is canonical and `v1_core/languages/en/` is the
+> parity reference.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ This folder contains onboarding guides and multilingual entry points.
 
 - [What HUB_Optimus is, what is built, and what is not](context/PROJECT_OVERVIEW.md)
 - [Evidence-backed capability ledger](architecture/capability_status.md)
+- [Machine-readable capability evidence snapshot](architecture/capability_evidence.v1.json)
+- [Source-of-truth hierarchy](context/SOURCE_OF_TRUTH.md)
 - [RFC lifecycle guide](rfc/README.md)
 - [Versioned RFC registry](rfc/registry.v1.json)
 - [Canonical language and source-of-truth status](context/STATUS.md)

--- a/docs/architecture/capability_evidence.v1.json
+++ b/docs/architecture/capability_evidence.v1.json
@@ -1,0 +1,217 @@
+{
+  "format_version": 1,
+  "authority": "Offline evidence snapshot for the capability ledger. It records repository evidence at one commit and does not attest mutable GitHub, deployment, release, professional-review, or repository-settings state.",
+  "baseline": {
+    "repository": "Voxterrae/HUB_Optimus",
+    "commit": "df0ef345e5ac627f3e2735573c802fe2f60821f4",
+    "verified_at": "2026-07-29",
+    "kind": "repository-tree"
+  },
+  "current_truth_documents": [
+    "README.md",
+    "docs/architecture/capability_status.md",
+    "docs/context/PROJECT_OVERVIEW.md",
+    "docs/context/SOURCE_OF_TRUTH.md",
+    "docs/context/STATUS.md"
+  ],
+  "terminal_pull_requests": [
+    {
+      "number": 1737,
+      "state": "merged",
+      "commit": "581aab7f858ff109b06d2b7737084cb660637c7a"
+    },
+    {
+      "number": 1744,
+      "state": "merged",
+      "commit": "4c959847a5fa2dcca3e9a322a7bb9f09f6e27173"
+    },
+    {
+      "number": 1745,
+      "state": "merged",
+      "commit": "dcdc37857d6649f7b720bb1285b33b5432a58e83"
+    },
+    {
+      "number": 1746,
+      "state": "merged",
+      "commit": "6ce8488ba4616ac6bd3c083d1d6f3c166bb11c8d"
+    },
+    {
+      "number": 1770,
+      "state": "merged",
+      "commit": "e60af8b2ee311e7bd451ccd4215dc46c0051c2ea"
+    },
+    {
+      "number": 1771,
+      "state": "merged",
+      "commit": "3672310ac013012bc8f8da9dad1b4daa2ad8262f"
+    },
+    {
+      "number": 1772,
+      "state": "merged",
+      "commit": "dd94b898356de7e4be04eeeb7e0c286f4adc8023"
+    },
+    {
+      "number": 1774,
+      "state": "merged",
+      "commit": "eaa7f2ecc006c59c4faf1812e43feef35c01058f"
+    },
+    {
+      "number": 1777,
+      "state": "merged",
+      "commit": "46e890e2328ffaed2f1a1f384ed21b31a112feaa"
+    },
+    {
+      "number": 1778,
+      "state": "merged",
+      "commit": "aceb366e0657a5ccba2cca270dec103859eaa272"
+    },
+    {
+      "number": 1779,
+      "state": "merged",
+      "commit": "af89e420efb7b60eb95867b840ebeaf23dd989b6"
+    },
+    {
+      "number": 1783,
+      "state": "merged",
+      "commit": "1355b9410921db415754a57c7251d1f72df2bea5"
+    },
+    {
+      "number": 1791,
+      "state": "merged",
+      "commit": "01bd9530d8c62301723ff8caf9f24744987795a2"
+    },
+    {
+      "number": 1792,
+      "state": "merged",
+      "commit": "f502fc82b35a9ec07c22d9f1300ea791ef69d6b4"
+    },
+    {
+      "number": 1793,
+      "state": "merged",
+      "commit": "f1fb2e14f8cf1da577bfc07145e0b22f4a59b49e"
+    },
+    {
+      "number": 1794,
+      "state": "merged",
+      "commit": "5b5ab543491ccce175c328ad4dfa493a5820ed25"
+    },
+    {
+      "number": 1795,
+      "state": "merged",
+      "commit": "e14b2a49186870fc61f11c64e8b461be13817efb"
+    },
+    {
+      "number": 1796,
+      "state": "merged",
+      "commit": "6a4de9a390a11ae2e304c7abf39b119e7fe82ce5"
+    },
+    {
+      "number": 1797,
+      "state": "merged",
+      "commit": "8701b083d24fbea52d9faa0207ab51010ba61273"
+    },
+    {
+      "number": 1799,
+      "state": "merged",
+      "commit": "13327d734b4437104c2778d59326d697e8739417"
+    },
+    {
+      "number": 1802,
+      "state": "merged",
+      "commit": "3843025037536dcc890bde183b1ad36d44883f5e"
+    },
+    {
+      "number": 1808,
+      "state": "merged",
+      "commit": "3b7b6ac018f139c1e01aed65261f0155a0653957"
+    },
+    {
+      "number": 1811,
+      "state": "merged",
+      "commit": "01b6ba232607d7d65675d4b35406f81555b23226"
+    },
+    {
+      "number": 1812,
+      "state": "merged",
+      "commit": "824d5602e11f3e0eea84baed1cc085c613dc7e59"
+    },
+    {
+      "number": 1813,
+      "state": "merged",
+      "commit": "5f18f3e902a9be24525705c811a7e633c3e70bff"
+    },
+    {
+      "number": 1814,
+      "state": "merged",
+      "commit": "df0ef345e5ac627f3e2735573c802fe2f60821f4"
+    }
+  ],
+  "external_unresolved": [
+    {
+      "id": "pull-request-1773-lifecycle",
+      "subject": "Current review and lifecycle state of PR #1773",
+      "reason": "Mutable Pull Request state is not contained in the baseline tree."
+    },
+    {
+      "id": "public-deployment",
+      "subject": "Current public deployment content, availability, and runtime configuration",
+      "reason": "Repository files and workflow source do not attest a live deployment."
+    },
+    {
+      "id": "repository-settings",
+      "subject": "Branch protection, required reviews, rulesets, Secret Scanning, Push Protection, and Pages settings",
+      "reason": "GitHub repository settings are outside the commit tree."
+    },
+    {
+      "id": "repository-health-hosted-run",
+      "subject": "Execution result and published summary of the updated repository-health workflow",
+      "reason": "Workflow source and isolated tests do not prove that GitHub Actions has run the reviewed revision."
+    },
+    {
+      "id": "release-state",
+      "subject": "Current GitHub Release designation and published release assets",
+      "reason": "Tags in a checkout do not attest the current GitHub Releases object."
+    },
+    {
+      "id": "labs-repository",
+      "subject": "Current contents and releases of Voxterrae/HUB-Optimus-labs",
+      "reason": "A different repository is outside this baseline."
+    },
+    {
+      "id": "professional-translation-review",
+      "subject": "Qualified human review of non-canonical translations",
+      "reason": "The baseline contains no named qualified reviewer record that certifies professional parity."
+    }
+  ],
+  "archived_documents": [
+    {
+      "path": "docs/context/hub_optimus_checkpoint.md",
+      "status": "historical",
+      "current": false,
+      "superseded_by": [
+        "docs/context/SOURCE_OF_TRUTH.md",
+        "docs/context/STATUS.md",
+        "docs/context/AI_HANDOFF.md",
+        "docs/architecture/capability_status.md"
+      ]
+    }
+  ],
+  "verification_commands": [
+    {
+      "purpose": "Full Python suite",
+      "command": "python -m pytest -q"
+    },
+    {
+      "purpose": "Scenario benchmark bytes",
+      "command": "python benchmarks/run_benchmarks.py"
+    },
+    {
+      "purpose": "Narrative benchmark bytes",
+      "command": "python benchmarks/run_narrative_benchmarks.py"
+    },
+    {
+      "purpose": "Documentation encoding",
+      "command": "python tools/check_mojibake.py ."
+    }
+  ]
+}

--- a/docs/architecture/capability_status.md
+++ b/docs/architecture/capability_status.md
@@ -1,57 +1,80 @@
 # Evidence-backed capability status
 
 This ledger describes repository evidence at commit
-`3ef199305c2d2d114f88aceb97b65a08b9f91b4a`, verified on 2026-07-28.
-It is not a roadmap, deployment attestation, legal conclusion, scientific
-validation, or approval of any draft PR.
+`df0ef345e5ac627f3e2735573c802fe2f60821f4`, verified on 2026-07-29.
+The machine-readable baseline, terminal-PR snapshot, external unknowns, and
+reproduction commands are versioned in
+[`capability_evidence.v1.json`](capability_evidence.v1.json).
 
-Pending PRs are named only as review context. Their changes are not part of
-this baseline until humans review and merge them.
+This is a derived repository-tree snapshot. It is not a roadmap, deployment or
+repository-settings attestation, release designation, legal conclusion,
+scientific validation, professional translation review, or statement about
+later GitHub activity. Apply the
+[source-of-truth hierarchy](../context/SOURCE_OF_TRUTH.md) before using it.
 
 ## Status vocabulary
 
 | Status | Meaning |
 | --- | --- |
-| Active document | Versioned project/governance text exists; this is not runtime behavior. |
-| Implemented | Code and tests for the stated narrow behavior exist on the baseline. |
-| Prototype | Executable code exists, but the surface is local, limited, or not release-attested. |
-| Experimental | Research tooling exists; outputs are synthetic observations and known defects may remain. |
-| Partial | Some required pieces exist, but the stated surface is incomplete or unverified. |
+| Active document | Versioned project or governance text exists; this is not runtime behavior. |
+| Implemented | Versioned code and executable tests cover the stated narrow behavior on the baseline. |
+| Prototype | Executable code and tests exist, but the surface is local, limited, or not release-attested. |
+| Experimental | Research tooling and tests exist; outputs remain synthetic observations. |
+| Partial | Some bounded pieces are evidenced, but the wider surface is incomplete or unverified. |
 | Draft / RFC | Proposal text exists and authorizes nothing by itself. |
-| Not implemented | No baseline implementation evidence was found. |
-| External state | The fact depends on a repository, deployment, or setting outside this commit. |
+| Not implemented | The baseline contains no implementation evidence for the stated capability. |
+| External / unresolved | The fact depends on mutable GitHub state, another repository, a deployment, settings, or professional review outside this commit. |
 
 ## Ledger
 
-| Capability or surface | Status | Baseline evidence | Verified boundary or open gap |
+| Capability or surface | Status | Versioned or executable evidence | Verified boundary or unresolved gap |
 | --- | --- | --- | --- |
-| Normative governance documents | Active document | `docs/governance/KERNEL.md`; `CHARTER.md`; `CONSENSUS_PROCESS.md`; `TRUST_LAYER.md` | These are human project rules, not executable code or legal authority. Current amendment language is not fully mechanical; issue #1751 and draft PR #1773 propose clarification but are not active governance. |
-| Canonical v1 methodology | Active document | `docs/context/STATUS.md`; `v1_core/languages/es/`; `v1_core/languages/en/` | Spanish v1 wins on conflict; English is the parity target. Methodology claims are broader than the current simulator. |
-| Scenario JSON validation and CLI error contract | Implemented | `scenario.schema.json`; `run_scenario.py`; `tests/test_run_scenario_cli.py`; `tests/test_regression_runner.py` | Validates a narrow scenario contract and returns deterministic JSON. It does not assess real-world truth or policy quality. |
-| Round-based scenario simulator | Prototype | `hub_optimus_simulator.py`; `run_scenario.py`; `benchmarks/scenarios/` | Implements actors, simple policies, exact offer-threshold success, rounds, and history. Repeat-run/global-RNG isolation defect is tracked in #1755; draft #1770 is not in the baseline. |
-| Frozen runtime benchmarks | Implemented | `benchmarks/run_benchmarks.py`; `benchmarks/expected/`; `.github/workflows/ci.yml` | Byte-level and structural drift checks exist. The CI benchmark step is advisory (`continue-on-error`) on this baseline. |
-| Scenario generator, mutator, telemetry, boundary and frontier tools | Experimental | `tools/scenario_generator/`; `tools/scenario_mutator.py`; `tools/scenario_telemetry.py`; `tools/scenario_boundary_search.py`; `tools/scenario_frontier.py` | Synthetic laboratory tools, not real-world predictors. Known corrections are separately proposed in #1771, #1774, and stacked #1779; evidence regeneration is tracked in #1775. |
-| Semantic Engine contracts and CLI | Prototype | `semantic_engine/contracts/`; `semantic_engine/cli/`; `tests/semantic_engine/` | Minimal deterministic record assembly exists. It is not a claim evaluator, scorer, model judge, autonomous analyst, or public service. Strict shared input validation is proposed in draft #1778. |
-| Operator browser/PWA | Prototype | `site/operator/`; `tests/test_operator_pwa_product_actions.py`; `tests/test_operator_pwa_record_integrity.py` | Local/browser intake and draft preparation exist. Browser output is not Semantic Engine output. The repository-truth redesign remains draft #1737. |
-| Controlled single-URL intake | Partial | `ops/ec2/hub-api.sh`; `site/operator/index.html`; `tests/test_hub_api_controlled_url_intake.py`; PRs #1717 and #1720 | A local/private endpoint and browser fallback exist. No crawling, truth verification, or public deployment is established. Invalid-port and DNS connection-boundary work remains issue #1761. |
-| Raw mobile intake CLI | Prototype | `tools/mobile_ingest.py` | Captures local text; the baseline default can expose raw intake to accidental version control. Private-by-default storage is proposed in draft #1777. |
-| Narrative-risk datasets and consistency checks | Implemented | `datasets/ai_risk_narratives/`; `datasets/geopolitical_claim_packs/`; `tools/check_narrative_consistency.py`; related tests | Deterministic schema/taxonomy consistency only. Passing checks do not verify claims, sources, motives, legality, or truth. |
-| Multilingual documentation structure | Partial | `docs/context/STATUS.md`; locale directories under `docs/` | File presence is not linguistic quality. RU is progressive; HE and current Chinese (`docs/zh`, intended as `zh-Hans`) are stubs/progressive copies. No professional parity is certified; draft #1772 proposes a versioned maturity audit. |
-| Static public site and PWA shell | Prototype | `site/`; `.github/workflows/pages.yml`; site tests | Static assets and a Pages workflow exist. The current production-domain content and private GitHub Pages settings are external state; the replacement portfolio is draft #1737. |
-| Local EC2 operational scripts | Prototype | `ops/ec2/`; `scripts/infra/bootstrap_aws_dev_runtime.sh`; ops tests | Provider-specific scripts exist. Their presence does not prove a live deployment, security posture, availability, or an architectural commitment to AWS. No Azure migration is approved or implemented. |
-| CI, link check, PR Safety and Kernel Guard workflows | Implemented | `.github/workflows/`; `tools/kernel_guard.py` | Workflow code exists. Protected-branch, required-review, Secret Scanning, Push Protection, HTTPS and ruleset settings remain external/unverified under #1743. Hardening changes remain drafts #1744–#1746. |
-| Governance Intelligence protocol | Active document | `docs/governance/GOVERNANCE_INTELLIGENCE.md`; issue #1694; PR #1695 as recorded in the document | The repository declares this protocol ratified. It keeps human accountability mandatory and creates no AI authority or legal authority. |
-| RFC lifecycle registry | Implemented | `docs/rfc/registry.v1.json`; `tests/test_rfc_registry.py` | Tracks evidence and missing records. It cannot ratify proposals and must be refreshed when RFC metadata changes. |
+| Normative governance documents | Active document | `docs/governance/KERNEL.md`; `docs/governance/CHARTER.md`; `docs/governance/CONSENSUS_PROCESS.md`; `docs/governance/TRUST_LAYER.md` | Human project rules, not executable code, AI authority, or legal authority. Proposed amendment mechanics are absent from this baseline; the current lifecycle of PR #1773 is external and unresolved here. |
+| Canonical v1 methodology | Active document | `docs/context/STATUS.md`; `v1_core/languages/es/`; `tests/test_core_es_en_parity_matrix.py` | Spanish v1 is canonical and English is a parity target. The methodology is broader than the simulator. |
+| Scenario JSON validation and CLI error contract | Implemented | `scenario.schema.json`; `run_scenario.py`; `tests/test_run_scenario_cli.py`; `tests/test_regression_runner.py`; `tests/test_scenario_loading.py` | One authoritative loader rejects non-standard JSON constants and duplicate actor names and exposes controlled parse/input/schema categories to repository tools. It validates structure and identity, not real-world truth or policy quality. |
+| Round-based scenario simulator | Prototype | `hub_optimus_simulator.py`; `tests/test_simulator_isolation.py`; `benchmarks/scenarios/`; `benchmarks/expected/` | Isolated seeded runs, clean per-run history, result snapshots, simple policies, rounds, and exact offer matching are tested. Synthetic behavior is not diplomacy, prediction, or causal evidence. |
+| Frozen runtime benchmarks | Implemented | `benchmarks/run_benchmarks.py`; `benchmarks/expected/`; `python benchmarks/run_benchmarks.py` | Three seed-42 outputs are compared byte for byte. The workflow benchmark job remains advisory through `continue-on-error: true`. |
+| Scenario generator, mutator, telemetry, boundary, and frontier tools | Experimental | `tools/scenario_generator/`; `tools/scenario_mutator.py`; `tools/scenario_telemetry.py`; `tools/scenario_boundary_search.py`; `tests/test_scenario_mutator.py`; `tests/test_scenario_telemetry.py`; `docs/lab_regeneration_1775.md` | Mutator base selection and telemetry now reuse the authoritative scenario loader, including strict JSON, schema, and actor-identity boundaries. Generation manifests and complete non-monotonic boundary enumeration are tested. Results remain synthetic and do not establish policy quality, generalization, or prediction. |
+| Semantic Engine contracts and CLI | Prototype | `semantic_engine/contracts/`; `semantic_engine/cli/`; `tests/semantic_engine/test_case_input_validation.py`; `tests/semantic_engine/test_cli_smoke.py` | `CaseInput v1` structural and cross-reference integrity is enforced. File decoding rejects nested `NaN`/infinities and serialization fails closed on non-finite values. The CLI is not a claim evaluator, scorer, model judge, autonomous analyst, or public service. |
+| Operator browser/PWA | Prototype | `site/operator/`; `tests/test_operator_pwa_product_actions.py`; `tests/test_operator_pwa_record_integrity.py` | Browser intake has one canonical source state and prepares local drafts. Browser output is not automatically verified evidence or Semantic Engine output. |
+| Controlled single-URL intake | Partial | `docs/rfc/operator_controlled_url_intake.md`; `ops/ec2/controlled_url_intake.v1.schema.json`; `ops/ec2/hub-api.sh`; `tests/test_hub_api_controlled_url_intake.py`; `tests/test_operator_pwa_product_actions.py` | The contract accepts one URL, enforces documented size/network/redirect limits, and uses strict JSON request/result/response boundaries. It records unreviewed provenance; it does not crawl, verify truth, or prove that an endpoint is deployed. |
+| Raw mobile intake CLI | Prototype | `tools/mobile_ingest.py`; `tests/test_mobile_ingest.py`; `.gitignore` | Default raw intake is local and ignored, with tested path and file-safety checks. It provides no encryption, managed retention, truth verification, publication, or multi-writer guarantee. |
+| Narrative-risk datasets and consistency checks | Implemented | `datasets/ai_risk_narratives/`; `datasets/geopolitical_claim_packs/`; `tests/test_ai_risk_narratives.py`; `tests/test_narrative_consistency.py`; `python benchmarks/run_narrative_benchmarks.py` | Deterministic schema, taxonomy, renderer, and frozen-output checks only. Seed transcripts remain provisional where source images are absent; passing checks do not verify claims or motives. |
+| Multilingual documentation structure | Partial | `docs/context/STATUS.md`; `docs/i18n/maturity.v1.json`; `tests/test_i18n_maturity.py` | The manifest distinguishes canonical, parity, review-needed, machine draft, stub, and missing states at a revision. File presence and a green audit do not establish linguistic quality or professional review. |
+| Static public site and PWA shell | Prototype | `site/`; `site/assets/geo/land-110m.geojson`; `site/assets/geo/land-110m.geojson.sha256`; `tests/test_public_portfolio.py`; `.github/workflows/pages.yml` | Repository code includes a tested WebGL globe, accessible fallback, multilingual public claims, Operator, and Pages workflow. Public availability, served bytes, custom-domain state, and Pages configuration are external. |
+| Local EC2 operational scripts | Prototype | `ops/ec2/`; `tests/test_ec2_run_identity_and_provenance.py`; `tests/test_ec2_deploy_hub_api_sync.py`; `tests/test_ec2_operator_api_proxy_config.py` | Run identity, explicit deployment provenance, rollback records, and API synchronization are tested in isolated fixtures. No live host, availability, restart, security posture, or provider commitment is attested. |
+| Repository workflow source | Implemented | `.github/workflows/`; `tests/test_workflow_action_pins.py`; `tests/test_kernel_guard.py`; `tests/test_repo_maintenance_workflow.py`; `tests/test_repo_health_summary_workflow.py` | External Actions are pinned and scheduled maintenance is read-only. Repository-health source requests exhaustive PR/issue counts through its stated 10,000-item ceiling, fails closed on incomplete data, and labels the top-author field as a last-100-PR sample. Tests do not attest a hosted run. |
+| Governance Intelligence protocol | Active document | `docs/governance/GOVERNANCE_INTELLIGENCE.md`; commit `e82998079340f63807e506f6bd7a07ce5b184eee` (PR #1695) | The versioned protocol keeps human accountability mandatory. It creates no AI authority, legal authority, or autonomous ratification path. |
+| RFC lifecycle registry | Implemented | `docs/rfc/registry.v1.json`; `tests/test_rfc_registry.py` | Machine-checkable lifecycle metadata and evidence paths exist. The registry cannot ratify proposals and its external PR state must be refreshed explicitly. |
 | HERMES PWA | Draft / RFC | `docs/rfc/hermes_pwa_interface_boundary.md`; `docs/rfc/hermes_pwa_gate_issue_pack.md` | No HERMES app, authentication, billing, dashboard, or public Semantic Engine API is implemented. |
 | Post-quantum control plane | Draft / RFC | `docs/rfc/post_quantum_control_plane.md` | No ML-KEM exchange, ML-DSA/SLH-DSA signing, key management, node identity, quorum access, or production security claim is implemented. |
-| Enterprise product | Draft / RFC | `docs/rfc/enterprise_boundary.md` | No accepted enterprise decision, product, customer configuration, billing, launch, or deployment evidence is recorded. |
-| Professional RU / HE / zh-Hans parity | Not implemented | `docs/context/STATUS.md`; locale files | Native/qualified human review records are absent. Automated structure checks cannot supply them. |
-| Public remote Semantic Engine or autonomous analysis | Not implemented | Semantic CLI and local ops boundaries above | No evidence supports a public engine, autonomous conclusions, truth verdicts, predictive authority, or human-replacing governance. |
-| `Voxterrae/HUB-Optimus-labs` artifacts | External state | [HUB-Optimus-labs](https://github.com/Voxterrae/HUB-Optimus-labs) | GitHub reported the official public repository at size 0 on 2026-07-28. It is part of the portfolio as an incubation location, but contributes no released artifact or capability yet. |
+| Enterprise product | Draft / RFC | `docs/rfc/enterprise_boundary.md` | No accepted enterprise decision, customer configuration, billing, launch, or deployment evidence is recorded. |
+| Professional non-canonical translation parity | Not implemented | `docs/i18n/maturity.v1.json`; `tests/test_i18n_maturity.py`; external item `professional-translation-review` in `capability_evidence.v1.json` | The baseline contains no named qualified human reviewer record certifying professional parity. Automated audits cannot supply it. |
+| Public remote Semantic Engine or autonomous analysis | Not implemented | `semantic_engine/cli/`; `docs/architecture/semantic_engine_cli.md`; public-deployment external item in `capability_evidence.v1.json` | No baseline evidence supports a public engine, autonomous conclusions, truth verdicts, predictive authority, or human-replacing governance. |
+| Public deployment and GitHub repository settings | External / unresolved | External items `public-deployment`, `repository-settings`, and `release-state` in `capability_evidence.v1.json` | Source, tests, workflows, local tags, and prior observations do not certify current deployment bytes, availability, GitHub settings, or the current Release object. |
+| Hosted repository-health execution | External / unresolved | External item `repository-health-hosted-run` in `capability_evidence.v1.json` | The updated workflow revision has source and isolated contract tests; this baseline does not prove that GitHub Actions executed it or published a complete live summary. |
+| `Voxterrae/HUB-Optimus-labs` artifacts | External / unresolved | External item `labs-repository` in `capability_evidence.v1.json` | Another repository's current contents and releases are outside this baseline. No positive or negative capability claim is inferred. |
+
+## Reproduction
+
+The snapshot records these commands without claiming that command text is a
+passing result:
+
+```bash
+python -m pytest -q
+python benchmarks/run_benchmarks.py
+python benchmarks/run_narrative_benchmarks.py
+python tools/check_mojibake.py .
+```
+
+Validation results belong to the reviewed PR/commit and its GitHub Checks.
+PowerShell behavior requires the dedicated CI job with PowerShell 7; local
+skips are not certification.
 
 ## Interpretation rule
 
 When project prose and executable evidence differ, describe both and keep the
 narrower claim. A test proves only the behavior it asserts. A merged RFC proves
-that proposal text is versioned, not that it was accepted. An external
-deployment or repository setting requires fresh external evidence.
+that proposal text is versioned, not accepted. A deployment, GitHub setting,
+Release object, Pull Request lifecycle, professional review, or other
+repository requires direct external evidence at a stated time.

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -505,6 +505,35 @@ because their changes also affect execution or credential behavior.
 - Repository tests and launcher source do not assert that this change is
   deployed on any host.
 
+## Capability Truth Snapshot Boundary
+
+Issue #1807 establishes one precedence map in
+`docs/context/SOURCE_OF_TRUTH.md` and refreshes the derived capability ledger
+against repository-tree baseline
+`df0ef345e5ac627f3e2735573c802fe2f60821f4`.
+
+Operational boundary:
+
+- GitHub `main` and each live GitHub object's own state remain authoritative
+  for the repository and mutable object state that they respectively contain.
+- `STATUS.md` resolves language/canonical policy; applicable governance,
+  runtime contracts, schemas, source, and executable tests govern their
+  narrower domains.
+- `AI_HANDOFF.md` summarizes operational boundaries and cannot override those
+  sources.
+- `docs/architecture/capability_status.md` is a derived view. Its versioned
+  offline evidence snapshot is
+  `docs/architecture/capability_evidence.v1.json`.
+- Deployment, GitHub settings, Releases, another repository, current PR
+  lifecycle, and qualified professional review remain external unless
+  directly inspected at a stated time.
+- `docs/context/hub_optimus_checkpoint.md` is an archived, non-authoritative
+  historical snapshot; its release, phase, CI, and task values are not current
+  claims.
+- The offline regression rejects draft wording for PRs recorded as terminal
+  in the versioned baseline and rejects restoring that checkpoint as a current
+  source. It does not replace live GitHub inspection.
+
 ## Meta-learning Follow-up
 
 - `.github/copilot-instructions.md` currently identifies `v1_core/workflow/05_meta_learning.md` as the meta-learning update location.

--- a/docs/context/PROJECT_OVERVIEW.md
+++ b/docs/context/PROJECT_OVERVIEW.md
@@ -1,7 +1,7 @@
 # HUB_Optimus — project overview
 
 Verified against repository commit
-`3ef199305c2d2d114f88aceb97b65a08b9f91b4a` on 2026-07-28.
+`df0ef345e5ac627f3e2735573c802fe2f60821f4` on 2026-07-29.
 
 ## In one paragraph
 
@@ -48,9 +48,9 @@ tests, limitations, and known open defects.
 - professional Russian, Hebrew, or Simplified Chinese parity;
 - private GitHub settings such as required reviews, Secret Scanning, Push
   Protection, rulesets, or a live deployment unless separately attested;
-- released artifacts from
-  [HUB-Optimus-labs](https://github.com/Voxterrae/HUB-Optimus-labs), which
-  GitHub reported as an empty official incubation repository on 2026-07-28.
+- current contents or released artifacts from
+  [HUB-Optimus-labs](https://github.com/Voxterrae/HUB-Optimus-labs); another
+  repository is external to this baseline and remains unresolved here.
 
 ## Kernel, consensus, runtime, and RFC are different things
 
@@ -66,8 +66,9 @@ tests, limitations, and known open defects.
 The current Consensus Process requires human proposal, review, objection
 handling, ratification, and a record. It does not yet make every roster,
 quorum, threshold, window, emergency, or rollback rule mechanically decidable.
-Issue #1751 and draft PR #1773 propose precise vocabulary and amendment
-mechanics; they are not current governance.
+Proposed changes associated with issue #1751 and PR #1773 are absent from this
+baseline and are not current governance. The Pull Request's current lifecycle
+is mutable GitHub state and remains external to this snapshot.
 
 The versioned RFC registry is
 [`../rfc/registry.v1.json`](../rfc/registry.v1.json), with a readable guide in
@@ -97,8 +98,11 @@ translated or at parity.
 
 ## Operating discipline
 
-- GitHub issues, PRs, commits, files, and CI are the project source of truth.
-- `docs/context/STATUS.md` resolves current language/canonical-source conflicts.
+- The ordered project hierarchy is
+  [`SOURCE_OF_TRUTH.md`](SOURCE_OF_TRUTH.md); GitHub `main` and each live
+  GitHub object's own state come first for their applicable question.
+- `docs/context/STATUS.md` resolves language and canonical-source conflicts
+  only within that domain.
 - Changes should remain one issue, one bounded branch, and one reviewable PR.
 - AI can prepare evidence and proposals; it cannot supply human ratification,
   legal advice, professional translation review, or self-approval.

--- a/docs/context/SOURCE_OF_TRUTH.md
+++ b/docs/context/SOURCE_OF_TRUTH.md
@@ -1,0 +1,47 @@
+# HUB_Optimus source-of-truth hierarchy
+
+This hierarchy defines which evidence wins when two project artifacts appear to
+describe the same state. It does not make every fact available from one file.
+The question must first be classified, and the narrowest direct evidence below
+must be used.
+
+## Precedence
+
+1. **GitHub `main` and live GitHub records.** The immutable commit on
+   `Voxterrae/HUB_Optimus` is authoritative for the repository tree that it
+   contains. Live Issues, Pull Requests, Checks, Releases, Project state, and
+   repository settings are authoritative only for their own current GitHub
+   state. A checkout cannot certify those mutable external facts.
+2. **Canonical domain contracts inside that commit.** Governance text under
+   `docs/governance/` governs project rules. For executable behavior, the
+   applicable schema, source, and
+   [`runtime_contract.md`](../architecture/runtime_contract.md) are read
+   together with the tests that exercise the claimed boundary. A passing test
+   proves only its asserted behavior.
+3. **[`STATUS.md`](STATUS.md) for canonical-language and parity policy.**
+   `STATUS.md` resolves which language or surface is canonical. It does not
+   override executable behavior, governance, or live GitHub state.
+4. **[`AI_HANDOFF.md`](AI_HANDOFF.md) for operational handoff.** The handoff
+   summarizes merged boundaries and current contributor constraints. It must
+   cite GitHub or repository evidence and cannot turn chat, a proposal, or an
+   external deployment into repository truth.
+5. **Versioned capability evidence.** The
+   [capability ledger](../architecture/capability_status.md) and its
+   [machine-readable evidence snapshot](../architecture/capability_evidence.v1.json)
+   are derived views at one explicit commit. They never certify later PR
+   state, deployment, repository settings, legal conclusions, or professional
+   review.
+6. **Overview, onboarding, and historical records.** Navigation and overview
+   documents summarize the sources above. Historical checkpoints record what
+   was said at an earlier time and are never current operational authority.
+
+## Conflict rule
+
+When claims conflict, use the higher applicable source and retain the narrower
+claim. Mark mutable GitHub, deployment, infrastructure, repository-settings,
+release, and third-party facts as external until inspected directly at a
+stated time. Mark a capability unresolved when the baseline has no direct
+evidence; absence of evidence is not evidence of a positive capability.
+
+Chat history, model output, generated prose, file presence, and a green test
+outside its asserted boundary do not outrank this hierarchy.

--- a/docs/context/STATUS.md
+++ b/docs/context/STATUS.md
@@ -24,11 +24,19 @@ governance source under `docs/governance/TRANSLATION_POLICY.md`, while the
 canonical v1 methodology remains Spanish under `v1_core/languages/es/`.
 
 **Source-of-truth rule:**
-- If repository docs conflict, **this file (`docs/context/STATUS.md`) wins**.
-- For HUB_Optimus v1, the canonical source-of-truth is `v1_core/languages/es/`.
-- English and other languages are reference or parity translations unless explicitly stated otherwise.
-- Local labels such as "English source" or EN/ES cross-links are navigation/parity aids only;
-  they do not redefine canonical authority for `v1_core`.
+- The project-wide precedence order is defined once in
+  [`SOURCE_OF_TRUTH.md`](SOURCE_OF_TRUTH.md).
+- This file is authoritative for canonical-language, locale, and parity
+  conflicts. It does not override GitHub `main`, live GitHub object state,
+  governance sources, runtime contracts, source code, or executable evidence
+  in their own domains.
+- For HUB_Optimus v1, the canonical methodology source is
+  `v1_core/languages/es/`.
+- English and other languages are reference or parity translations unless
+  explicitly stated otherwise.
+- Local labels such as "English source" or EN/ES cross-links are
+  navigation/parity aids only; they do not redefine canonical authority for
+  `v1_core`.
 
 **Planned switch (later, not now):**
 - Once en reaches stable parity, we may declare **en as canonical** for a future version (v1.1 or v2).

--- a/docs/context/hub_optimus_checkpoint.md
+++ b/docs/context/hub_optimus_checkpoint.md
@@ -1,63 +1,74 @@
-# HUB_Optimus — Systemic Checkpoint
+# HUB_Optimus — archived systemic checkpoint
 
-> Single source of truth for the operational state of the project.
-> Updated at each significant milestone.
+Status: **historical snapshot (non-authoritative)**
 
-## System state
+This file preserves an early project checkpoint for traceability. It is not
+updated at milestones and must not be used to determine current release,
+runtime, CI, benchmark, scenario, phase, task, or deployment state.
 
-| Property    | Value   |
-|-------------|---------|
-| Release     | v0.1.0  |
-| Runtime     | stable  |
-| CI          | passing |
-| Benchmarks  | active  |
+Use the hierarchy in
+[`docs/context/SOURCE_OF_TRUTH.md`](SOURCE_OF_TRUTH.md), the current
+language/canonical policy in [`STATUS.md`](STATUS.md), operational boundaries
+in [`AI_HANDOFF.md`](AI_HANDOFF.md), and the explicit-commit
+[capability ledger](../architecture/capability_status.md).
 
-## Last completed work
+## Values recorded by the historical snapshot
 
-- PR #109 merged
-- Benchmark summary visible in CI
-- `runtime_contract.md` published
-- Scenario corpus: 001–005 integrated
+| Property | Historical recorded value | Current authority |
+| --- | --- | --- |
+| Release | `v0.1.0` | Live GitHub Releases; external to this file |
+| Runtime | `stable` | Applicable source, runtime contract, tests, and GitHub Checks at a named commit |
+| CI | `passing` | Live GitHub Checks for the relevant commit or PR |
+| Benchmarks | `active` | Versioned benchmark source, expected bytes, and their execution result |
 
-## Scenario corpus
+None of the values above is a current attestation.
 
-| #   | Name                      | Family                   |
-|-----|---------------------------|--------------------------|
-| 001 | Partial Ceasefire         | Ceasefire Negotiation    |
-| 002 | Verified Ceasefire        | Ceasefire Negotiation    |
-| 003 | Coalition Fracture        | Coalition Stability      |
-| 004 | Shared Resource Drought   | Shared Resource Conflict |
+## Work recorded as completed at that time
+
+- PR #109 was recorded as merged.
+- A benchmark summary was recorded as visible in CI.
+- `runtime_contract.md` was recorded as published.
+- Scenario references 001–005 were recorded as integrated.
+
+## Scenario references recorded at that time
+
+| # | Name | Family |
+| --- | --- | --- |
+| 001 | Partial Ceasefire | Ceasefire Negotiation |
+| 002 | Verified Ceasefire | Ceasefire Negotiation |
+| 003 | Coalition Fracture | Coalition Stability |
+| 004 | Shared Resource Drought | Shared Resource Conflict |
 | 005 | Spain Diplomatic War Accusation | Domestic Political Pressure |
 
-## Active taxonomy families
+The current classification and existence of scenario material must be checked
+against the baseline tree and
+[`docs/scenarios/catalog.md`](../scenarios/catalog.md).
+
+## Taxonomy families recorded at that time
 
 - Ceasefire Negotiation
 - Coalition Stability
 - Shared Resource Conflict
 - Domestic Political Pressure
 
-## Documentary infrastructure
+## Documentary paths recorded at that time
 
-```
+```text
 docs/scenarios/
   scenario_taxonomy.md
   scenario_template.md
   catalog.md
 ```
 
-## Current phase
+## Phase sequence recorded at that time
 
-```
-Phase 1 — reproducible runtime        ✔
-Phase 2 — executable benchmarks       ✔
-Phase 3 — CI observability            ✔
-Phase 4 — behavioral diagnostics      ← current
-```
+1. Phase 1 — reproducible runtime
+2. Phase 2 — executable benchmarks
+3. Phase 3 — CI observability
+4. Phase 4 — behavioral diagnostics (then marked as active)
 
-## Next task
+## Proposed follow-up recorded at that time
 
-Task 24 — structural drift analysis for benchmarks
-
-## Next action
-
-commit → push → PR
+The snapshot named “Task 24 — structural drift analysis for benchmarks” and
+“commit → push → PR”. These are historical notes, not an active assignment or
+authorization.

--- a/tests/test_capability_truth.py
+++ b/tests/test_capability_truth.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_PATH = (
+    REPO_ROOT / "docs" / "architecture" / "capability_evidence.v1.json"
+)
+CAPABILITY_PATH = REPO_ROOT / "docs" / "architecture" / "capability_status.md"
+CHECKPOINT_PATH = REPO_ROOT / "docs" / "context" / "hub_optimus_checkpoint.md"
+
+
+def _evidence() -> dict:
+    return json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+
+
+def test_capability_evidence_has_an_explicit_offline_baseline() -> None:
+    evidence = _evidence()
+    baseline = evidence["baseline"]
+
+    assert evidence["format_version"] == 1
+    assert baseline["repository"] == "Voxterrae/HUB_Optimus"
+    assert baseline["kind"] == "repository-tree"
+    assert re.fullmatch(r"[0-9a-f]{40}", baseline["commit"])
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", baseline["verified_at"])
+
+    capability_text = CAPABILITY_PATH.read_text(encoding="utf-8")
+    assert baseline["commit"] in capability_text
+    assert baseline["verified_at"] in capability_text
+
+    for relative in evidence["current_truth_documents"]:
+        assert (REPO_ROOT / relative).is_file(), relative
+    for command in evidence["verification_commands"]:
+        assert command["purpose"].strip()
+        assert command["command"].strip()
+
+
+def test_terminal_pull_requests_are_not_called_drafts_in_current_truth_docs() -> None:
+    evidence = _evidence()
+    terminal = {
+        record["number"]: record for record in evidence["terminal_pull_requests"]
+    }
+
+    assert len(terminal) == len(evidence["terminal_pull_requests"])
+    for number, record in terminal.items():
+        assert record["state"] in {"merged", "closed-unmerged"}
+        if record["state"] == "merged":
+            assert re.fullmatch(r"[0-9a-f]{40}", record["commit"])
+        else:
+            assert record["commit"] is None
+
+    stale: list[str] = []
+    for relative in evidence["current_truth_documents"]:
+        text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not re.search(r"\b(?:drafts?|open)\b", line, flags=re.IGNORECASE):
+                continue
+            numbers = {int(value) for value in re.findall(r"#(\d+)", line)}
+            for number in sorted(numbers & terminal.keys()):
+                stale.append(f"{relative}:{line_number}: PR #{number}")
+
+    assert stale == []
+
+
+def test_every_checkpoint_document_is_machine_classified_as_historical() -> None:
+    evidence = _evidence()
+    checkpoint_records = {
+        record["path"]: record for record in evidence["archived_documents"]
+    }
+    checkpoint_files = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in (REPO_ROOT / "docs" / "context").rglob("*.md")
+        if "checkpoint" in path.name.casefold()
+    }
+
+    assert checkpoint_files == set(checkpoint_records)
+    assert CHECKPOINT_PATH.relative_to(REPO_ROOT).as_posix() in checkpoint_files
+
+    for relative in checkpoint_files:
+        record = checkpoint_records[relative]
+        assert record["status"] == "historical"
+        assert record["current"] is False
+        assert record["superseded_by"] == [
+            "docs/context/SOURCE_OF_TRUTH.md",
+            "docs/context/STATUS.md",
+            "docs/context/AI_HANDOFF.md",
+            "docs/architecture/capability_status.md",
+        ]
+
+        checkpoint = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        assert "Status: **historical snapshot (non-authoritative)**" in checkpoint
+        assert "Single source of truth for the operational state" not in checkpoint
+        assert "Updated at each significant milestone" not in checkpoint
+        assert "## Current phase" not in checkpoint
+        assert "## Next task" not in checkpoint
+        assert "docs/context/SOURCE_OF_TRUTH.md" in checkpoint

--- a/tests/test_rfc_registry.py
+++ b/tests/test_rfc_registry.py
@@ -140,4 +140,6 @@ def test_plain_overview_and_capability_ledger_keep_claim_classes_separate() -> N
         "| Public remote Semantic Engine or autonomous analysis | Not implemented |"
         in capabilities
     )
-    assert "GitHub reported the official public repository at size 0" in capabilities
+    assert "| `Voxterrae/HUB-Optimus-labs` artifacts | External / unresolved |" in (
+        capabilities
+    )


### PR DESCRIPTION
## Decision

Establish one explicit, machine-checked capability evidence baseline at `df0ef345e5ac627f3e2735573c802fe2f60821f4`.

The repository remains the authority for code, tests, contracts, and repository-backed evidence. Deployment state, repository settings, release metadata, qualified translation review, Labs behavior, and human governance decisions remain external or unresolved until separately evidenced.

Related to #1807

## Scope

- define the source-of-truth hierarchy and the baseline commit;
- add a machine-readable capability evidence ledger and a readable status view;
- replace stale status/overview wording with statements tied to repository evidence;
- mark the historical checkpoint as archived rather than current;
- add an offline terminal-PR snapshot so tests do not depend on live GitHub state;
- keep the hosted Repo Health workflow run explicitly unverified.

Out of scope:

- runtime, API, CLI, simulator, or scenario behavior;
- public-site UI, i18n, or deployment changes;
- GitHub settings, Releases, Pages/DNS, or hosted workflow execution;
- governance decisions in #1773;
- any claim of qualified human review for ES/EN/DE.

## Files changed

- `README.md`, `docs/README.md`
- `docs/architecture/capability_evidence.v1.json`
- `docs/architecture/capability_status.md`
- `docs/context/{AI_HANDOFF,PROJECT_OVERVIEW,SOURCE_OF_TRUTH,STATUS}.md`
- `docs/context/hub_optimus_checkpoint.md`
- `tests/test_capability_truth.py`
- `tests/test_rfc_registry.py`

## Acceptance criteria

- [x] every current capability statement has an evidence class and repository path;
- [x] archived material is not presented as current product truth;
- [x] external facts are not inferred from repository contents;
- [x] the ledger is schema-checked and pinned to the reviewed baseline;
- [x] terminal PR facts are tested from an offline snapshot;
- [x] no runtime, site, i18n, deployment, or governance behavior changes.

## Validation

- `pytest -q tests/test_capability_truth.py tests/test_rfc_registry.py ...` — 161 passed
- `pytest -q` — 409 passed, 12 skipped (PowerShell-only)
- scenario benchmarks — 3/3 passed
- narrative consistency — 5/5 passed
- local Markdown links — 63 checked
- mojibake scan — 276 text files checked
- `git diff --check` — clean
- local tree SHA — `5dc9a7aca23253a5dc21e5184dfd34184e6ec9f8`, identical to the GitHub tree

## Risks

Documentation can still become stale after future merges. Machine checks constrain structure and pinned evidence, but they do not prove external deployment/settings state or replace human authority. Those limits are recorded explicitly.

## AI_HANDOFF update

Updated the handoff with the baseline, evidence hierarchy, validation record, residual external facts, and the next bounded work item.

## Next PR recommendation

Refresh public-site evidence links and contrast against the merged baseline, then synchronize that exact GitHub Pages artifact into Sites.