### PR TITLE
test(site): pin evidence links and contrast

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -444,6 +444,27 @@ boundary and the embedded API JSON body boundary.
 - Finite numeric metadata remains opaque and round-trippable. These checks add
   no scoring, truth evaluation, or public-service claim.
 
+## Public Site Link and Contrast Boundary
+
+Issue #1810 scopes repository-level checks for the three public HTML entry
+points: the portfolio, the branded 404 page, and Operator.
+
+- Same-origin links, assets, routes, and fragments are resolved against the
+  checked-out `site/` artifact; repository evidence links resolve against
+  local paths and are pinned to commit
+  `f99bfed196dbcb76c8a29a4bab31559fdb567ee5` rather than mutable `main`.
+- Live navigation to the repository, its issue tracker, and the separate Labs
+  repository is allowlisted structurally. Pytest performs no external network
+  request and therefore does not attest current remote availability.
+- The reported muted normal-text selectors share one versioned dark-surface
+  token. Its conservative contrast against `--graphite-3` is greater than
+  4.5:1; representative 404 and Operator muted-text pairs are checked
+  separately.
+- These checks do not constitute accessibility certification or qualified
+  human review. Keyboard/focus, reduced-motion behavior, Hebrew RTL, WebGL
+  fallback, and representative desktop/mobile layout still require
+  controlled-browser QA on the reviewed deployment.
+
 ## GitHub Actions supply-chain boundary
 
 The CI, link-check, Pages, PR-safety, and repository-health workflows pin

--- a/site/index.html
+++ b/site/index.html
@@ -208,8 +208,8 @@
             Spanish is authoritative for v1; English is the parity target.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/main/v1_core/languages/es" data-i18n="viewCanonical">Canonical core</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/context/STATUS.md" data-i18n="viewStatus">Status policy</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/v1_core/languages/es" data-i18n="viewCanonical">Canonical core</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/context/STATUS.md" data-i18n="viewStatus">Status policy</a>
           </div>
         </article>
 
@@ -224,8 +224,8 @@
             output, frozen benchmarks, and structural drift diagnostics.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/SIMULATION_README.md" data-i18n="runScenario">Run a scenario</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/architecture/runtime_contract.md" data-i18n="runtimeContract">Runtime contract</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/SIMULATION_README.md" data-i18n="runScenario">Run a scenario</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/runtime_contract.md" data-i18n="runtimeContract">Runtime contract</a>
           </div>
         </article>
 
@@ -241,8 +241,8 @@
             evaluate or score claims.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/main/semantic_engine" data-i18n="inspectEngine">Inspect the engine</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/architecture/semantic_engine_cli.md" data-i18n="cliContract">CLI contract</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/semantic_engine" data-i18n="inspectEngine">Inspect the engine</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/semantic_engine_cli.md" data-i18n="cliContract">CLI contract</a>
           </div>
         </article>
 
@@ -263,7 +263,7 @@
           </p>
           <div class="card-links">
             <a href="./operator/" data-i18n="openOperator">Open Operator</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/main/site/operator" data-i18n="inspectSource">Inspect source</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/site/operator" data-i18n="inspectSource">Inspect source</a>
           </div>
         </article>
 
@@ -279,8 +279,8 @@
             not verified evidence.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/ops/ec2/hub-api.sh" data-i18n="inspectIntake">Inspect intake source</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/tests/test_hub_api_controlled_url_intake.py" data-i18n="intakeTests">Inspect tests</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/ops/ec2/hub-api.sh" data-i18n="inspectIntake">Inspect intake source</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/tests/test_hub_api_controlled_url_intake.py" data-i18n="intakeTests">Inspect tests</a>
           </div>
         </article>
 
@@ -295,8 +295,8 @@
             narrative consistency checks, and source-labelled research datasets.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/lab_state.md" data-i18n="labState">Lab state</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/main/tools" data-i18n="researchTools">Research tools</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/lab_state.md" data-i18n="labState">Lab state</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/tools" data-i18n="researchTools">Research tools</a>
           </div>
         </article>
 
@@ -311,8 +311,8 @@
             narrative amplification, and operational relevance under human accountability.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/governance/GOVERNANCE_INTELLIGENCE.md" data-i18n="readProtocol">Read protocol</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/governance/SYSTEM_PROTECTION_MATRIX.md" data-i18n="protectionMatrix">Protection matrix</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/governance/GOVERNANCE_INTELLIGENCE.md" data-i18n="readProtocol">Read protocol</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/governance/SYSTEM_PROTECTION_MATRIX.md" data-i18n="protectionMatrix">Protection matrix</a>
           </div>
         </article>
       </div>
@@ -437,7 +437,7 @@
             execution remains local or controlled and provider-independent. A hosting or
             model provider does not gain project or semantic authority.
           </p>
-          <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/architecture/platform_compatibility.md" data-i18n="platformPolicy">
+          <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/platform_compatibility.md" data-i18n="platformPolicy">
             Platform compatibility policy
           </a>
         </aside>
@@ -455,17 +455,17 @@
       </div>
 
       <div class="future-grid">
-        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/rfc/hermes_pwa_interface_boundary.md" data-status="rfc-not-implemented">
+        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/hermes_pwa_interface_boundary.md" data-status="rfc-not-implemented">
           <span data-i18n="futureHermesLabel">RFC / UI</span>
           <h3>HERMES</h3>
           <p data-i18n="hermesCopy">Future PWA interface boundary. Not implemented.</p>
         </a>
-        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/rfc/enterprise_boundary.md" data-status="rfc-not-implemented">
+        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/enterprise_boundary.md" data-status="rfc-not-implemented">
           <span data-i18n="futureEnterpriseLabel">RFC / OPERATING MODEL</span>
           <h3>Enterprise</h3>
           <p data-i18n="enterpriseCopy">Proposed private operating boundary. No enterprise product or public service exists.</p>
         </a>
-        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/rfc/post_quantum_control_plane.md" data-status="rfc-not-implemented">
+        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/post_quantum_control_plane.md" data-status="rfc-not-implemented">
           <span data-i18n="futurePostQuantumLabel">RFC / SECURITY</span>
           <h3 data-i18n="postQuantumTitle">Post-quantum control plane</h3>
           <p data-i18n="postQuantumCopy">RFC planning around standardized cryptographic primitives. No cryptographic implementation.</p>
@@ -489,7 +489,7 @@
       </div>
       <div class="evidence-links">
         <a class="button button-primary" href="https://github.com/Voxterrae/HUB_Optimus" data-i18n="openRepository">Open repository</a>
-        <a class="button button-secondary" href="https://github.com/Voxterrae/HUB_Optimus/blob/main/docs/architecture/capability_status.md" data-i18n="capabilityStatus">Capability status</a>
+        <a class="button button-secondary" href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/capability_status.md" data-i18n="capabilityStatus">Capability status</a>
       </div>
     </section>
   </main>

--- a/site/styles.css
+++ b/site/styles.css
@@ -10,6 +10,7 @@
   --paper: #f5f2e9;
   --paper-2: #ece7dc;
   --signal-amber: #d6a44f;
+  --text-muted-dark: #959793;
   --ink: #16202a;
   --ink-muted: #5f6870;
   --line-dark: rgba(234, 231, 220, 0.16);
@@ -432,7 +433,7 @@ canvas {
 
 .truth-strip dt {
   overflow: hidden;
-  color: rgba(234, 231, 220, 0.48);
+  color: var(--text-muted-dark);
   font-family: var(--font-mono);
   font-size: 0.55rem;
   letter-spacing: 0.08em;
@@ -502,7 +503,7 @@ canvas {
 .globe-toolbar small {
   display: block;
   margin-top: 0.2rem;
-  color: rgba(234, 231, 220, 0.42);
+  color: var(--text-muted-dark);
   font-size: 0.52rem;
   letter-spacing: 0.05em;
 }
@@ -609,7 +610,7 @@ canvas {
 .globe-card figcaption {
   border-top: 1px solid var(--line-dark);
   border-bottom: 0;
-  color: rgba(234, 231, 220, 0.42);
+  color: var(--text-muted-dark);
   font-size: 0.52rem;
 }
 
@@ -792,7 +793,7 @@ canvas {
 }
 
 .card-topline > span {
-  color: rgba(234, 231, 220, 0.38);
+  color: var(--text-muted-dark);
   font-family: var(--font-mono);
   font-size: 0.57rem;
   font-weight: 760;
@@ -1223,7 +1224,7 @@ canvas {
 
 .site-footer p {
   margin: 0;
-  color: rgba(234, 231, 220, 0.45);
+  color: var(--text-muted-dark);
   font-size: 0.72rem;
   text-align: center;
 }

--- a/tests/test_public_portfolio.py
+++ b/tests/test_public_portfolio.py
@@ -786,9 +786,9 @@ def test_public_internal_anchors_and_local_assets_resolve():
 
 def test_repository_evidence_links_point_to_existing_paths():
     parser = parse_public_page()
-    repository_prefixes = (
-        "/Voxterrae/HUB_Optimus/blob/main/",
-        "/Voxterrae/HUB_Optimus/tree/main/",
+    evidence_pattern = re.compile(
+        r"^/Voxterrae/HUB_Optimus/(?:blob|tree)/"
+        r"(?P<ref>[0-9a-f]{40})/(?P<path>.+)$"
     )
 
     checked = []
@@ -796,13 +796,10 @@ def test_repository_evidence_links_point_to_existing_paths():
         parts = urlsplit(reference)
         if parts.netloc != "github.com":
             continue
-        prefix = next(
-            (candidate for candidate in repository_prefixes if parts.path.startswith(candidate)),
-            None,
-        )
-        if not prefix:
+        match = evidence_pattern.match(parts.path)
+        if not match:
             continue
-        repository_path = unquote(parts.path.removeprefix(prefix))
+        repository_path = unquote(match.group("path"))
         checked.append(repository_path)
         assert (ROOT / repository_path).exists(), reference
 

--- a/tests/test_public_site_links_and_contrast.py
+++ b/tests/test_public_site_links_and_contrast.py
@@ -1,0 +1,239 @@
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urljoin, urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "site"
+PUBLIC_ORIGIN = "https://huboptimus.dev"
+EVIDENCE_REF = "f99bfed196dbcb76c8a29a4bab31559fdb567ee5"
+PUBLIC_ROUTES = {
+    "/": SITE / "index.html",
+    "/404.html": SITE / "404.html",
+    "/operator/": SITE / "operator" / "index.html",
+}
+
+
+class PublicHtmlParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.ids = set()
+        self.duplicate_ids = set()
+        self.references = []
+
+    def handle_starttag(self, tag, attributes):
+        attrs = dict(attributes)
+        element_id = attrs.get("id")
+        if element_id:
+            if element_id in self.ids:
+                self.duplicate_ids.add(element_id)
+            self.ids.add(element_id)
+
+        for attribute in ("href", "src", "data-geo-source"):
+            value = attrs.get(attribute)
+            if value:
+                self.references.append((tag, attribute, value))
+
+        if tag == "meta" and attrs.get("property") == "og:image":
+            value = attrs.get("content")
+            if value:
+                self.references.append((tag, "content", value))
+
+
+def parse_document(path):
+    parser = PublicHtmlParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser
+
+
+def route_for_document(path):
+    for route, candidate in PUBLIC_ROUTES.items():
+        if candidate == path:
+            return route
+    raise AssertionError(f"public HTML file has no declared route: {path}")
+
+
+def target_for_public_reference(page_route, reference):
+    absolute = urlsplit(urljoin(f"{PUBLIC_ORIGIN}{page_route}", reference))
+    if absolute.scheme not in {"http", "https"}:
+        raise AssertionError(f"unsupported public URL scheme: {reference}")
+    if absolute.netloc != "huboptimus.dev":
+        return None, absolute
+
+    public_path = unquote(absolute.path)
+    target = (SITE / public_path.lstrip("/")).resolve()
+    assert target.is_relative_to(SITE.resolve()), reference
+    if public_path.endswith("/") or target.is_dir():
+        target /= "index.html"
+    return target, absolute
+
+
+def css_rule_property(source, selector, property_name):
+    values = []
+    pattern = re.compile(
+        rf"{re.escape(selector)}\s*\{{(?P<body>[^{{}}]*)\}}",
+        re.MULTILINE | re.DOTALL,
+    )
+    for match in pattern.finditer(source):
+        declarations = re.findall(
+            rf"(?:^|;)\s*{re.escape(property_name)}\s*:\s*([^;]+)",
+            match.group("body"),
+            re.MULTILINE,
+        )
+        values.extend(value.strip() for value in declarations)
+    assert values, f"{selector} has no {property_name} declaration"
+    return values[-1]
+
+
+def custom_properties(source):
+    root = re.search(r":root\s*\{(?P<body>[^{}]*)\}", source, re.DOTALL)
+    assert root, "CSS :root block is required"
+    return dict(
+        re.findall(
+            r"--([a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{6})\s*;",
+            root.group("body"),
+        )
+    )
+
+
+def rgb_from_hex(value):
+    assert re.fullmatch(r"#[0-9a-fA-F]{6}", value), value
+    return tuple(int(value[index : index + 2], 16) / 255 for index in (1, 3, 5))
+
+
+def relative_luminance(value):
+    def linearize(channel):
+        if channel <= 0.04045:
+            return channel / 12.92
+        return ((channel + 0.055) / 1.055) ** 2.4
+
+    red, green, blue = (linearize(channel) for channel in rgb_from_hex(value))
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+
+def contrast_ratio(foreground, background):
+    lighter, darker = sorted(
+        (relative_luminance(foreground), relative_luminance(background)),
+        reverse=True,
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def test_every_public_html_reference_and_fragment_resolves_in_the_artifact():
+    html_files = set(SITE.rglob("*.html"))
+    assert html_files == set(PUBLIC_ROUTES.values())
+
+    documents = {path: parse_document(path) for path in html_files}
+    for path, document in documents.items():
+        assert not document.duplicate_ids, (path, document.duplicate_ids)
+        page_route = route_for_document(path)
+        for _tag, _attribute, reference in document.references:
+            target, absolute = target_for_public_reference(page_route, reference)
+            if target is None:
+                continue
+            assert target.is_file(), (path, reference, target)
+            if absolute.fragment:
+                assert target.suffix == ".html", (path, reference)
+                target_document = documents.get(target) or parse_document(target)
+                assert absolute.fragment in target_document.ids, (path, reference)
+
+
+def test_repository_evidence_links_are_commit_pinned_and_resolve_locally():
+    evidence_pattern = re.compile(
+        r"^https://github\.com/Voxterrae/HUB_Optimus/"
+        r"(?P<kind>blob|tree)/(?P<ref>[0-9a-f]{40})/(?P<path>.+)$"
+    )
+    checked = []
+    live_repository_documents = {
+        "https://github.com/Voxterrae/HUB_Optimus/blob/main/IP_NOTICE.md",
+        "https://github.com/Voxterrae/HUB_Optimus/blob/main/SECURITY.md",
+    }
+
+    for path in PUBLIC_ROUTES.values():
+        for tag, attribute, reference in parse_document(path).references:
+            if tag != "a" or attribute != "href":
+                continue
+            if "/blob/main/" in reference or "/tree/main/" in reference:
+                assert reference in live_repository_documents
+                continue
+            match = evidence_pattern.match(reference)
+            if not match:
+                continue
+
+            repository_path = ROOT / unquote(match.group("path"))
+            assert match.group("ref") == EVIDENCE_REF, reference
+            if match.group("kind") == "blob":
+                assert repository_path.is_file(), reference
+            else:
+                assert repository_path.is_dir(), reference
+            checked.append(reference)
+
+    assert len(checked) == 18
+
+
+def test_live_external_navigation_targets_are_explicit_and_network_free_in_pytest():
+    expected_navigation = {
+        "https://github.com/Voxterrae/HUB_Optimus",
+        "https://github.com/Voxterrae/HUB_Optimus/blob/main/IP_NOTICE.md",
+        "https://github.com/Voxterrae/HUB_Optimus/blob/main/SECURITY.md",
+        "https://github.com/Voxterrae/HUB_Optimus/issues",
+        "https://github.com/Voxterrae/HUB-Optimus-labs",
+    }
+    external_navigation = set()
+
+    for path in PUBLIC_ROUTES.values():
+        route = route_for_document(path)
+        for tag, attribute, reference in parse_document(path).references:
+            if tag != "a" or attribute != "href":
+                continue
+            absolute = urlsplit(urljoin(f"{PUBLIC_ORIGIN}{route}", reference))
+            assert absolute.scheme in {"http", "https"}
+            if absolute.netloc == "huboptimus.dev":
+                continue
+            if re.match(
+                r"^https://github\.com/Voxterrae/HUB_Optimus/"
+                r"(?:blob|tree)/[0-9a-f]{40}/",
+                reference,
+            ):
+                continue
+            external_navigation.add(reference)
+
+    assert external_navigation == expected_navigation
+
+
+def test_reported_dark_surface_normal_text_uses_one_contrast_guarded_token():
+    css = (SITE / "styles.css").read_text(encoding="utf-8")
+    properties = custom_properties(css)
+    muted = properties["text-muted-dark"]
+    conservative_dark_surface = properties["graphite-3"]
+
+    selectors = (
+        ".truth-strip dt",
+        ".globe-toolbar small",
+        ".globe-card figcaption",
+        ".card-topline > span",
+        ".site-footer p",
+    )
+    for selector in selectors:
+        assert css_rule_property(css, selector, "color") == "var(--text-muted-dark)"
+
+    assert contrast_ratio(muted, conservative_dark_surface) >= 4.5
+
+
+def test_404_and_operator_muted_text_pairs_remain_above_normal_text_minimum():
+    not_found = (SITE / "404.html").read_text(encoding="utf-8")
+    not_found_foreground = css_rule_property(not_found, ".review-note", "color")
+    assert contrast_ratio(not_found_foreground, "#18232f") >= 4.5
+
+    operator = (SITE / "operator" / "index.html").read_text(encoding="utf-8")
+    properties = custom_properties(operator)
+    assert css_rule_property(operator, ".footer", "color") == "var(--dim)"
+    assert css_rule_property(operator, ".topline", "color") == "var(--dim)"
+    assert (
+        contrast_ratio(
+            properties["brand-signal-dim"],
+            properties["brand-signal-panel-2"],
+        )
+        >= 4.5
+    )


### PR DESCRIPTION
## Decision

Make the checked-in GitHub Pages artifact prove its own local navigation and contrast boundaries, and pin repository evidence links to the merged capability baseline `f99bfed196dbcb76c8a29a4bab31559fdb567ee5`.

Related to #1810

## Scope

- resolve every same-origin link, route, asset, data source, Open Graph image, and fragment across the landing page, branded 404, and Operator;
- pin 18 capability/evidence links to the reviewed baseline instead of mutable `main`;
- keep repository home, issues, IP notice, security policy, and the separate Labs repository as explicit live navigation;
- raise muted dark-surface text to one versioned token with measured normal-text contrast;
- record the browser-QA and certification boundary.

Out of scope:

- runtime, API, simulator, Semantic Engine, or intake behavior;
- WebGL renderer or cartography changes;
- external-network availability certification;
- accessibility certification or qualified human ES/EN/DE review;
- GitHub Pages, DNS, or Sites deployment state.

## Files changed

- `site/index.html`
- `site/styles.css`
- `tests/test_public_portfolio.py`
- `tests/test_public_site_links_and_contrast.py`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] all three public HTML entry points are declared and traversed;
- [x] same-origin routes, files, assets, and fragments resolve in the artifact;
- [x] repository evidence links are immutable and resolve to checked-in paths;
- [x] live external navigation is an explicit, network-free allowlist in pytest;
- [x] reported muted normal text meets a conservative 4.5:1 contrast threshold;
- [x] no unsupported accessibility, deployment, or linguistic-review claim is added.

## Validation

- `python -m pytest -q` — 414 passed, 12 skipped (PowerShell-only)
- scenario benchmarks — 3/3 passed
- narrative consistency — 0 errors, 0 warnings
- mojibake scan — 276 Markdown files
- `git diff --check` — clean
- local/GitHub tree SHA — `5d6ce912b6911c4c06b3e28bf93583dae16aab98`

## Risks

Pytest deliberately performs no live network requests, so it does not certify current availability of GitHub, Pages, DNS, or Labs. Numeric contrast checks cover the selectors declared in scope; they do not replace browser, keyboard, reduced-motion, RTL, WebGL-fallback, or qualified accessibility review.

## AI_HANDOFF update

Added the exact evidence-link, contrast, external-navigation, and controlled-browser QA boundaries for #1810.

## Next PR recommendation

Synchronize the merged `site/` artifact into the existing Sites project, run clean desktop/mobile/ES/EN/DE/404/Operator/WebGL-fallback browser QA, and deploy that exact source version without maintaining a parallel implementation.