### PR TITLE
docs: define AI access matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,71 @@ Principle: visible alliance, not hidden control.
 
 GitHub remains the source of truth. Chat context is advisory unless reflected in repository artifacts.
 
+## AI Access Matrix
+
+An access level is a governance classification, not a permission grant. Actual
+access is limited by the operator's explicit authorization, the active tool or
+sandbox, GitHub credentials, repository roles, and branch rulesets.
+CODEOWNERS records intended human review responsibility; whether it enforces a
+gate depends on GitHub permissions and rulesets. This matrix creates no token,
+repository permission, approval authority, discretionary merge authority, or
+settings access. If a technical boundary is more restrictive than this
+matrix, the technical boundary wins.
+
+**Source-of-truth rule for every row:** GitHub issues, PRs, commits, reviews,
+checks, and versioned repository documents are the project record. Chat,
+prompts, model output, and uncommitted drafts are advisory only.
+
+| AI actor | Policy level and role | Allowed actions | Prohibited actions | Required GitHub and audit record |
+| --- | --- | --- | --- | --- |
+| ChatGPT | **Level 1 — tracked proposal and review** | Explain repository state; triage; propose scope; draft proposed issues, RFCs, PR text, documentation, or review findings; record issue or PR discussion only when an operator explicitly authorizes an available connected tool. | Directly edit repository files, create commits, or implement changes; treat chat as a decision; act as an approval or merge authority; write directly to `main`; change repository settings, permissions, CODEOWNERS authority, roadmap, architecture, runtime contracts, or governance by conversation. Implementation must move to an authorized Codex or Copilot level-2 workflow. | An actionable proposal must be recorded in an existing issue or PR before action. A review comment or versioned RFC counts only through that linked issue/PR record. Chat alone is not an artifact. Material AI assistance must be identified in the resulting issue or PR record. |
+| Codex | **Level 2 — scoped implementation and review** | Inspect, edit, test, and review within an explicit issue or PR scope; prepare a branch, commit, or draft PR only where the active environment and operator authorization allow it; report validation and limitations; after the repository's [PR merge requirements](CONTRIBUTING.md#pr-merge-requirements) and human review are satisfied, mechanically execute an exact GitHub mutation, including an identified PR merge, only when a human operator explicitly authorizes that target and action. | Expand scope silently; bypass review or checks; independently approve or decide to merge; treat mechanical execution as approval; merge a governance change it authored; merge another protected change without documented human review and exact authorization; write directly to `main`; alter settings, credentials, human ownership, or CODEOWNERS authority; present local tests as hosted CI evidence. | The issue or PR task, reviewable diff, commit and PR when work is proposed for merge, validation results, known limitations, material AI assistance, required human review, and resulting GitHub mutation must remain visible in GitHub. |
+| GitHub Copilot, including Coding Agent | **Level 2 — scoped suggestion or implementation** | Suggest code or documentation inside a human-owned change; on an explicitly scoped Coding Agent task, prepare branch and PR changes if GitHub separately grants that capability; review against repository instructions. | Turn an untracked prompt into project scope; commit directly to `main`; independently approve or decide to merge; bypass CODEOWNERS or required checks; create automation or integrations without a scoped issue; infer authority from product integration. | Inline suggestions accepted as work must appear in a traced commit and PR. Coding Agent work requires an issue or existing PR, branch/commit/PR history, validation results, and disclosure of material AI assistance. |
+| Models outside the approved repository workflow | **Level 0 — consultative only** | Review a bounded Standard Review Packet and return advice under the [External AI Review Protocol](docs/governance/EXTERNAL_AI_REVIEW_PROTOCOL.md). | Access secrets or non-public repository material; mutate GitHub or repository state; implement, approve, merge, ratify, prioritize, or become a source of truth; feed output directly into runtime, roadmap, architecture, or governance. | Every request must use the protocol packet and its output must be triaged under the protocol. An actionable finding must be recorded in an issue or PR comment with the external model/provider, packet scope, finding, and uncertainty. The external conversation alone has no project authority. |
+
+No AI level includes project ownership, human stewardship, CODEOWNERS
+authority, governance ratification, independent approval, discretionary merge,
+release, credential, or repository-settings authority. Mechanically executing
+a specific human-authorized GitHub action does not transfer that authority.
+A model still must not merge a governance change it authored.
+Any model, agent, wrapper, or AI workflow not listed in this matrix defaults to
+level 0 until a scoped issue and reviewed change update the matrix.
+
+### Action and audit rules
+
+- Any actionable work requires an existing GitHub issue or PR. A chat request
+  may inform that artifact but cannot replace it.
+- Implementation proposed for merge requires a reviewable commit and PR. The
+  record must state scope, affected files, validation, risks or limitations,
+  and material AI assistance.
+- Review findings remain findings until a human reviewer or authorized
+  contributor accepts them through the visible GitHub workflow.
+- Codex may mechanically execute an exact GitHub mutation, including an
+  identified PR merge, only after a human operator explicitly authorizes the
+  target and action and the repository's
+  [PR merge requirements](CONTRIBUTING.md#pr-merge-requirements), including
+  required human reviews, are satisfied. This execution is not approval. A
+  governance change authored by a model must instead be merged by a human
+  authenticated actor.
+- No chat-only decision changes roadmap, architecture, runtime contracts, or
+  governance. Those changes require their existing issue/RFC, review, and
+  protected-path process.
+- External-model reviews must also follow
+  the [External AI Review Protocol](docs/governance/EXTERNAL_AI_REVIEW_PROTOCOL.md);
+  every request must use its Standard Review Packet and output-handling rules.
+  Do not upload secrets, credentials, personal data, or non-public repository
+  material.
+
+### Policy versus technical enforcement
+
+| Boundary | Versioned policy or evidence | Technical enforcement status |
+| --- | --- | --- |
+| AI role ceiling | This matrix, the [AI handoff](docs/context/AI_HANDOFF.md), and the scoped issue or PR | Policy only; it does not configure an AI product or grant/revoke credentials. These two files are not currently protected paths in `.github/CODEOWNERS` or `tools/kernel_guard.py`, so the governance-scoped PR still requires explicit human review. |
+| Human path review | `.github/CODEOWNERS` records the intended reviewers. | Enforcement depends on GitHub permissions and active rulesets; CODEOWNERS text alone is not a merge gate. |
+| Tests and checks | Repository workflows and local test commands provide review evidence. | Whether hosted checks block merge is controlled in GitHub Settings. A local pass is not a hosted CI pass. |
+| Branch, approval, and merge limits | This matrix prohibits direct `main` writes and independent approval or discretionary merge decisions by AI actors. It permits Codex to execute a specific non-self-authored-governance merge only after exact human authorization and all PR merge requirements. | Actual prevention and execution capability depend on repository roles, branch/ruleset configuration, and the authenticated GitHub actor. |
+| GitHub audit trail | Issues, commits, PRs, reviews, checks, and versioned documents preserve visible work. | The repository cannot detect or authorize unrecorded private chats; humans and authorized operators must keep actionable work in GitHub. |
+
 ## Operating Rules
 
 - No big rewrites.

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -45,6 +45,55 @@ GitHub remains the source of truth; chat summaries are advisory unless reflected
 - AI operators must read `docs/governance/PROJECT_STEWARDSHIP.md` and must not infer authority beyond versioned GitHub records.
 - Foundational principle: technology amplifies human judgment; it never replaces human responsibility.
 
+## AI Access Matrix Boundary
+
+The actor and access-level matrix implementing issue #1584 is defined in the
+[AI access matrix](../../AGENTS.md#ai-access-matrix).
+
+Operational boundary:
+
+- ChatGPT is level 1 for tracked proposals and review. Codex and GitHub
+  Copilot, including Coding Agent, are level 2 for issue- or PR-scoped
+  implementation and review. Models outside the approved repository workflow
+  are consultative level 0.
+- Any unlisted model, agent, wrapper, or AI workflow defaults to level 0 until
+  a scoped issue and reviewed matrix change say otherwise.
+- These levels are policy ceilings, not technical permission grants. The
+  active operator authorization, tool or sandbox, GitHub credentials,
+  repository roles, and rulesets remain the actual technical access boundary.
+  CODEOWNERS records intended review responsibility; enforcement depends on
+  GitHub permissions and rulesets.
+- No AI actor gains project ownership, human stewardship, CODEOWNERS
+  authority, governance ratification, independent approval, discretionary
+  merge, release, credential, or repository-settings authority.
+- Codex may mechanically execute an exact GitHub mutation, including an
+  identified PR merge, only when a human operator explicitly authorizes that
+  target and action after the repository's
+  [PR merge requirements](../../CONTRIBUTING.md#pr-merge-requirements) and
+  human review are satisfied. Execution does not supply approval or transfer
+  authority. A governance change authored by a model must instead be merged by
+  a human authenticated actor.
+- Any actionable work requires an issue or PR. Implementation proposed for
+  merge requires a reviewable commit and PR with scope, affected files,
+  validation, risks or limitations, and material AI assistance recorded.
+- No chat-only decision changes roadmap, architecture, runtime contracts, or
+  governance.
+- Every external-model review request and its findings follow the
+  [External AI Review Protocol](../governance/EXTERNAL_AI_REVIEW_PROTOCOL.md);
+  the request uses its Standard Review Packet, and an authorized human or
+  internal operator triages the output back into GitHub.
+- The matrix does not claim that CODEOWNERS, required checks, or branch
+  restrictions are fully machine-enforced. Their current repository evidence
+  and settings gaps remain recorded in the
+  [System Protection Matrix](../governance/SYSTEM_PROTECTION_MATRIX.md).
+- The external-model boundary is policy, not a repository-enforced provider
+  control; its evidence and handling rules live in the matrix and the External
+  AI Review Protocol.
+- `AGENTS.md` and this handoff file are not currently protected paths in
+  `.github/CODEOWNERS` or `tools/kernel_guard.py`. The governance-scoped PR
+  therefore requires explicit human review even though those controls do not
+  request it automatically. Expanding protected paths is a separate scope.
+
 ## Governance Intelligence Boundary
 
 Issue #1694 and PR #1695 are the ratification record for the canonical Governance Intelligence protocol.


### PR DESCRIPTION
> **Status refresh — 2026-07-30:** This remains a human-governance Draft. Head `809e86472f4d21eb0af76a14dfda3bcfef97a2fe` diverges from current `main@b64203fc8c784fd50053872767b179d97f451cc1` (3 commits ahead / 5 behind). Historical head checks were green, but there is no human review or approval and the 471-test/229-file figures below predate the current 487-test/281-file baseline. Reconcile and rerun checks before human review. Codex must not mark this ready or merge it.

## Decision

Define the operational AI access matrix in `AGENTS.md` and synchronize its handoff boundary in `docs/context/AI_HANDOFF.md`.

Related to #1584.

## Scope

- Classify ChatGPT as level 1 for tracked proposal and review.
- Classify Codex and GitHub Copilot as level 2 for scoped implementation and review.
- Classify external and otherwise unlisted models, agents, wrappers, and AI workflows as consultative level 0.
- Define allowed and prohibited actions, source-of-truth rules, GitHub artifacts, audit evidence, and human-review requirements.
- Distinguish governance policy from credentials, repository roles, rulesets, CODEOWNERS enforcement, and tool capabilities.
- Preserve the canonical prohibition against a model merging a governance change it authored.

No runtime, schema, CI, benchmark, workflow, repository setting, permission, or CODEOWNERS change is included.

## Files changed

- `AGENTS.md`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] Matrix includes ChatGPT, Codex, GitHub Copilot, and external models.
- [x] Each actor has an explicit level, role, allowed actions, prohibited actions, and GitHub/audit record.
- [x] External and unlisted models default to consultative level 0.
- [x] Every row is governed by an explicit GitHub source-of-truth rule.
- [x] Any actionable work requires an existing issue or PR.
- [x] An RFC counts only through its linked issue or PR record.
- [x] No chat-only decision changes roadmap, architecture, runtime contracts, or governance.
- [x] No tool permission or enforcement capability is implied by policy text.
- [x] External review packets and output handling remain aligned with the External AI Review Protocol.
- [x] AI-authored governance changes require human review and human merge execution.

## Validation

- Exact remote tree after reconciliation with current `main` matches reviewed local tree `018bef7564e7927f869dd4ef51c83e57a45c5cc5`.
- `git diff --check` passed.
- Mojibake guard: 229 Markdown files passed.
- Governance mirror checker: all 17 paths and maturity declarations valid; this does not certify linguistic parity.
- i18n maturity check passed.
- Full pytest suite: 471 passed; 12 PowerShell-only tests skipped.
- Scenario benchmarks: 3/3 passed.
- Narrative benchmarks: 5/5 passed.
- Links, paths, and the matrix anchor checked.
- Independent policy review found no remaining blocker in the text.

Hosted CI, Link Check, Kernel Guard, and PR Safety Check all passed on latest reconciled head `809e86472f4d21eb0af76a14dfda3bcfef97a2fe`.

## Risks

This is a governance-scoped policy change and requires explicit human review.

`AGENTS.md` and `docs/context/AI_HANDOFF.md` are not currently protected paths in `.github/CODEOWNERS` or `tools/kernel_guard.py`; those controls will not automatically request the required governance review.

The matrix is policy only. Actual access remains constrained by operator authorization, credentials, tool/sandbox capabilities, repository roles, and rulesets. CODEOWNERS enforcement depends on GitHub settings.

**Human merge boundary:** because this governance change was authored with AI assistance, a human authenticated actor must review and perform the merge. Codex must not mark this PR ready or merge it.

## AI_HANDOFF update

Updated because #1584 changes the operational governance posture and contributor handoff requirements. The handoff records actor levels, the fail-closed default, GitHub artifact requirements, enforcement limits, and the human merge boundary.

## Next PR recommendation

If the human steward wants these paths automatically protected, open a separate governance issue to evaluate adding `AGENTS.md` and `docs/context/AI_HANDOFF.md` to CODEOWNERS and Kernel Guard. Do not expand that enforcement surface inside this PR.