### PR TITLE
docs: define system and runtime glossary

### DIFF
--- a/docs/context/GLOSSARY.md
+++ b/docs/context/GLOSSARY.md
@@ -1,15 +1,30 @@
 # GLOSSARY
 
+These definitions classify current HUB_Optimus repository artifacts. They do
+not add capabilities or replace the applicable source, contract, governance
+text, or [source-of-truth hierarchy](SOURCE_OF_TRUTH.md).
+
 - `Agreement`: Declared commitment between actors in a scenario.
 - `Canonical`: The authoritative version when parallel language variants differ.
 - `CI`: Continuous Integration checks executed on `pull_request` and `push`.
 - `Classification`: Final scenario label derived from structural evidence.
 - `Consensus process`: Governance path for high-impact kernel decisions.
 - `Custodian`: Reviewer role responsible for protected governance/kernel areas.
+- `Dataset / evidence artifact`: Versioned input, fixture, expected output,
+  provisional corpus, or reproducible observation. Its evidence status is
+  artifact-specific; it is not automatically a verified real-world fact.
+- `Documentation`: Versioned material that describes, indexes, constrains, or
+  proposes. Its authority follows the source-of-truth hierarchy, and its
+  presence does not prove that a described capability is implemented.
 - `Drift`: Meaning divergence between docs, languages, or policy statements.
 - `Evaluation standard`: Rules used to score structure, verification, and incentives.
 - `Fail-fast`: Immediate stop on invalid input with a stable, actionable error.
-- `Governance`: Rules, ownership, and review protocol for repository decisions.
+- `Framework / methodology`: Human-readable concepts, workflows, templates,
+  and evaluation method that guide human use. It is broader than the current
+  programs and is not automatically executed by them.
+- `Governance`: Human-authored rules, stewardship, accountability, and
+  change-control records for repository decisions. It is not executable AI
+  authority or automatic ratification.
 - `Incentive structure`: What behavior the scenario rewards over time.
 - `Kernel`: Core normative framework and protected conceptual backbone.
 - `Legitimacy model`: Criteria used to assess whether outcomes remain acceptable over time.
@@ -18,11 +33,33 @@
 - `MVP`: Minimum set of features required for a stable first public workflow.
 - `No-go zone`: Explicitly out-of-scope area to prevent scope creep.
 - `Parity reference`: Non-canonical language variant maintained close to canonical meaning.
+- `Program`: Concrete executable surface whose supported behavior is bounded by
+  its applicable source, contracts, and tests. Its presence does not establish
+  deployment or implementation of the full framework.
 - `Protected path`: Repository path that requires stricter review/guard rules.
 - `RFC`: Structured proposal required for kernel/governance-impacting changes.
+- `Runtime`: The supported execution boundary of a program or program family,
+  including accepted inputs, implemented behavior, and outputs as defined by
+  applicable source, schemas or contracts, and tests.
 - `Scenario`: Structured case description used for evaluation and comparison.
 - `Schema`: Contract defining required fields/types for scenario input.
-- `Source-of-truth`: Document that resolves contradictions (`docs/context/STATUS.md`).
+- `Source-of-truth`: The question-specific authority selected through
+  `docs/context/SOURCE_OF_TRUTH.md`; `STATUS.md` resolves canonical-language
+  and parity questions only.
+- `System`: The governed repository-level project: its programs,
+  framework/methodology, documentation, datasets/evidence artifacts,
+  governance, and source-of-truth relationships. It is not one executable
+  program.
 - `Trust layer`: Integrity lens that tests whether a claim is verifiable and stable.
 - `Verification`: Evidence step that confirms claims beyond declarations.
 - `Workflow`: Ordered procedure used to run, review, and iterate scenarios.
+
+## Required distinctions
+
+- **System vs. program:** the system is the governed project and the
+  relationships among its artifact categories; a program is one concrete
+  executable surface within that system.
+- **Runtime vs. framework:** a runtime is an implemented execution boundary;
+  the framework/methodology guides human use and is broader than the current
+  runtimes. The current programs do not automatically execute the full
+  framework.


### PR DESCRIPTION
## Decision

Add the minimal normative glossary required by #1587, aligned with the merged system architecture map and current source-of-truth hierarchy.

Related to #1587.

## Scope

- Define `System`, `Program`, `Runtime`, `Framework / methodology`, `Documentation`, `Dataset / evidence artifact`, and `Governance`.
- Make the system/program and runtime/framework distinctions explicit.
- Correct the existing source-of-truth definition so `STATUS.md` is limited to canonical-language and parity questions.
- State that glossary definitions classify repository artifacts without adding capabilities or replacing applicable contracts or authority sources.

No runtime, schema, simulator, CI, benchmark, governance, roadmap, deployment, or capability change is included.

## Files changed

- `docs/context/GLOSSARY.md`

## Acceptance criteria

- [x] System and program are clearly differentiated.
- [x] Runtime and framework/methodology are not treated as synonyms.
- [x] Documentation, datasets/evidence artifacts, and governance have short, operational definitions.
- [x] Definitions align with `system_architecture_map.md`, `STATUS.md`, `SOURCE_OF_TRUTH.md`, and `runtime_contract.md`.
- [x] The glossary does not redefine implementation contracts or add capabilities.
- [x] Scope remains a concise glossary-only delta.

## Validation

- Exact remote tree matches reviewed local tree `8c61b20230fbf7e1b459ad2db065990eb9aca63b`.
- `git diff --check` passed.
- Mojibake guard: 230 selected Markdown files and 279 repository-wide Markdown files passed.
- Full pytest suite: 471 passed; 12 PowerShell-only tests skipped.
- Scenario benchmarks: 3/3 passed.
- Narrative benchmarks: 5/5 passed.
- Narrative consistency: 0 errors, 0 warnings, 0 info.
- New relative link resolves locally.
- Independent review found no blocker.

Hosted GitHub CI and Link Check remain pending.

## Risks

The definitions are normative for terminology only. The introductory boundary and source links prevent the glossary from being read as a runtime contract, deployment attestation, capability claim, or alternate governance authority.

## AI_HANDOFF update

Not updated. This glossary records terminology already established by #1586 and does not change operational state, executable architecture, governance posture, runtime, CI, benchmarks, or contributor handoff requirements.

## Next PR recommendation

No follow-up is required for this scope. After review and green hosted checks, #1587 can close. Any broader onboarding or translated-glossary changes should use a separate issue.