### PR TITLE
fix(control): bound the local prototype

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -588,6 +588,28 @@ Operational boundary:
   in the versioned baseline and rejects restoring that checkpoint as a current
   source. It does not replace live GitHub inspection.
 
+## Local Control-Plane Prototype Boundary
+
+The adopted resolution for issue #1766 classifies
+`hub_optimus/hub_optimus_control.py` as a local educational prototype rather
+than an operational control plane.
+
+- It implements only an in-memory actor-to-tool allowlist, `sum` and `echo`
+  stubs, and a process-local inspection log.
+- Time records are timezone-aware UTC values. The log accepts only a restricted
+  built-in snapshot domain and copies it without invoking object-defined copy
+  hooks, so caller mutation cannot rewrite an accepted record. Unsupported
+  values fail as controlled errors for allowed calls and cannot suppress a
+  denied-attempt record.
+- The actor string is not authenticated identity and the allowlist is not a
+  production authorization service.
+- The module is not integrated with the supported scenario runtime, Semantic
+  Engine, Operator, EC2 scripts, or any deployment.
+- It provides no durable or compliance audit, OPA, OpenTelemetry,
+  SPIFFE/SPIRE, cryptography, or post-quantum capability.
+- Log order is process-local append order. No concurrency or durable-ordering
+  guarantee is provided.
+
 ## System Architecture Map Boundary
 
 Issue #1586 establishes

--- a/hub_optimus/hub_optimus_control.py
+++ b/hub_optimus/hub_optimus_control.py
@@ -2,15 +2,13 @@
 hub_optimus_control.py
 -----------------------
 
-This module provides a minimal, self‑contained draft implementation of a
-"control plane" inspired by the HUB_Optimus architecture discussed in the
-previous conversation. The goal of this implementation is to demonstrate
-how a central gateway might mediate access to external tools while
-enforcing simple policies and maintaining an audit trail. It does not
-attempt to integrate with external systems such as OpenTelemetry, SPIFFE,
-or Open Policy Agent; instead, it uses in‑memory data structures and
-Python exceptions to illustrate the core ideas without external
-dependencies.
+Status: local educational prototype.
+
+This module demonstrates how an in-memory gateway can apply a simple
+actor-to-tool allowlist and retain an inspection log. It is not imported by
+the supported scenario runtime, Semantic Engine, Operator, or deployment
+scripts. It provides no authentication, production authorization, durable
+audit, distributed identity, policy service, or telemetry integration.
 
 Key components:
   * ``PolicyEngine`` – Evaluates whether a given actor is allowed to
@@ -23,19 +21,52 @@ Key components:
     ``PermissionError``, while calls to unknown tools raise
     ``ValueError``.
 
-This code is intended for educational purposes and serves as a starting
-point for more sophisticated prototypes. In a production system you
-would likely replace the ``PolicyEngine`` with a call to OPA, replace
-the internal log with structured telemetry (for example, via OpenTelemetry),
-and secure identities using SPIFFE/SPIRE. Nevertheless, this simple
-implementation shows how the core control loop might be structured.
+The names Open Policy Agent (OPA), OpenTelemetry, SPIFFE, and SPIRE describe
+capabilities that this module explicitly does not implement. The actor string
+is only an in-memory lookup key, not an authenticated identity. The log is
+process-local inspection data, not a security or compliance audit record.
+Accepted call arguments are restricted to plain, string-keyed built-in
+containers and scalar values so snapshots never invoke user-defined copy hooks.
 """
 
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, MutableMapping
+
+
+SNAPSHOT_VALUE_ERROR = (
+    "Arguments must contain only snapshot-safe built-in values: "
+    "None, bool, int, float, str, list, tuple, and string-keyed dict."
+)
+
+
+def _snapshot_value(value: Any) -> Any:
+    """Copy the prototype's restricted value domain without user hooks."""
+    value_type = type(value)
+    if value is None or value_type in {bool, int, float, str}:
+        return value
+    if value_type is list:
+        return [_snapshot_value(item) for item in value]
+    if value_type is tuple:
+        return tuple(_snapshot_value(item) for item in value)
+    if value_type is dict:
+        snapshot: Dict[str, Any] = {}
+        for key, item in value.items():
+            if type(key) is not str:
+                raise TypeError(SNAPSHOT_VALUE_ERROR)
+            snapshot[key] = _snapshot_value(item)
+        return snapshot
+    raise TypeError(SNAPSHOT_VALUE_ERROR)
+
+
+def _snapshot_arguments(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy one plain dictionary without invoking mapping hooks."""
+    if type(args) is not dict:
+        raise TypeError(SNAPSHOT_VALUE_ERROR)
+    snapshot = _snapshot_value(args)
+    return snapshot
 
 
 class PolicyEngine:
@@ -97,8 +128,9 @@ class ControlPlane:
       5. Returns the result of the tool or raises an exception if
          unauthorized or unknown.
 
-    All completed and attempted calls (including denied ones) are
-    recorded in ``self._log`` for inspection.
+    All completed and attempted calls (including denied ones) are recorded in
+    ``self._log`` for inspection. Records follow process-local append order;
+    this prototype makes no concurrency or durable-ordering guarantee.
     """
 
     def __init__(self, policies: Mapping[str, List[str]]) -> None:
@@ -106,7 +138,7 @@ class ControlPlane:
         # Internal log of call metadata and results. Each entry is a dict.
         self._log: List[MutableMapping[str, Any]] = []
 
-    def process_tool_call(self, actor: str, tool_name: str, args: Mapping[str, Any]) -> Any:
+    def process_tool_call(self, actor: str, tool_name: str, args: Dict[str, Any]) -> Any:
         """Handle a tool invocation request.
 
         Parameters
@@ -117,9 +149,12 @@ class ControlPlane:
             policy definitions.
         tool_name : str
             The canonical name of the tool to invoke (e.g. ``"sum"``).
-        args : Mapping[str, Any]
-            Arguments for the tool call. The structure depends on
-            individual tool semantics (see ``execute_tool`` for details).
+        args : Dict[str, Any]
+            Arguments for the tool call. Snapshot-safe arguments use plain
+            string-keyed dictionaries containing only ``None``, booleans,
+            numbers, strings, lists, tuples, and dictionaries. The structure
+            otherwise depends on individual tool semantics (see
+            ``execute_tool`` for details).
 
         Returns
         -------
@@ -127,33 +162,74 @@ class ControlPlane:
             The return value of the tool call if allowed and the tool
             exists. The type depends on the tool implementation. If the
             call is forbidden, a ``PermissionError`` is raised. If the
-            tool name is unrecognized, a ``ValueError`` is raised.
+            tool name is unrecognized, a ``ValueError`` is raised. A
+            ``TypeError`` is raised for non-plain actor/tool identifiers.
+            Arguments outside the snapshot-safe built-in value domain raise
+            ``TypeError`` only for an otherwise allowed call; denied calls
+            retain ``PermissionError`` precedence.
         """
         # Unique identifier and timestamp for this call
         call_id = str(uuid.uuid4())
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        if type(actor) is not str or type(tool_name) is not str:
+            self._log.append(
+                {
+                    "call_id": call_id,
+                    "timestamp": timestamp,
+                    "actor": actor if type(actor) is str else "<invalid>",
+                    "tool_name": (
+                        tool_name if type(tool_name) is str else "<invalid>"
+                    ),
+                    "args": {},
+                    "args_snapshot_status": "not-attempted",
+                    "allowed": False,
+                    "status": "error",
+                    "error": "Actor and tool_name must be plain strings.",
+                }
+            )
+            raise TypeError("Actor and tool_name must be plain strings.")
 
         # Check the policy
         decision = self.policy_engine.evaluate(actor, tool_name, args)
         allowed = decision["allowed"]
 
-        # Build log entry; result will be inserted after execution if allowed
+        # Build the base entry before copying arguments so an unsupported value
+        # cannot suppress the attempt record.
         entry: MutableMapping[str, Any] = {
             "call_id": call_id,
             "timestamp": timestamp,
             "actor": actor,
             "tool_name": tool_name,
-            "args": dict(args),
             "allowed": allowed,
         }
+
+        try:
+            execution_args = _snapshot_arguments(args)
+            entry["args"] = _snapshot_value(execution_args)
+            entry["args_snapshot_status"] = "complete"
+        except Exception as error:
+            entry["args"] = {}
+            entry["args_snapshot_status"] = "rejected"
+            if allowed:
+                entry["status"] = "error"
+                entry["error"] = SNAPSHOT_VALUE_ERROR
+                self._log.append(entry)
+                raise TypeError(SNAPSHOT_VALUE_ERROR) from error
+
+            entry["status"] = "denied"
+            self._log.append(entry)
+            raise PermissionError(
+                f"Actor '{actor}' is not permitted to invoke tool '{tool_name}'"
+            ) from None
 
         # Perform action based on policy
         if allowed:
             # Attempt to execute the tool.  Use try/except/else so we can
             # append to the log in both success and failure cases.
             try:
-                result = self.execute_tool(tool_name, args)
-                entry["result"] = result
+                result = self.execute_tool(tool_name, execution_args)
+                entry["result"] = _snapshot_value(result)
                 entry["status"] = "success"
             except Exception as e:
                 # Capture any error raised by the tool and propagate it
@@ -215,8 +291,8 @@ class ControlPlane:
         Returns
         -------
         List[Mapping[str, Any]]
-            A list of dictionaries representing each call attempt in
-            chronological order. The list is a shallow copy to prevent
-            external modification of internal state.
+            A snapshot of each call attempt in process-local append order.
+            Mutating the returned list or any nested value cannot alter the
+            internal log. No cross-thread chronological ordering is promised.
         """
-        return list(self._log)
+        return _snapshot_value(self._log)

--- a/tests/test_control_plane_prototype.py
+++ b/tests/test_control_plane_prototype.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+
+import pytest
+
+from hub_optimus.hub_optimus_control import ControlPlane
+
+
+class SelfCopyingMutable:
+    def __init__(self) -> None:
+        self.items = [1]
+
+    def __deepcopy__(self, _memo):
+        return self
+
+
+class MutableStr(str):
+    def __new__(cls, value):
+        instance = super().__new__(cls, value)
+        instance.items = [1]
+        return instance
+
+
+class HookedMapping(Mapping):
+    def __init__(self) -> None:
+        self.iterations = 0
+
+    def __getitem__(self, key):
+        raise KeyError(key)
+
+    def __iter__(self):
+        self.iterations += 1
+        raise SystemExit("mapping hook must not run")
+
+    def __len__(self):
+        return 0
+
+
+class MutatingControlPlane(ControlPlane):
+    def execute_tool(self, tool_name, args):
+        args["payload"]["items"].append(2)
+        return args
+
+
+def test_echo_log_is_isolated_from_inputs_results_and_returned_snapshots() -> None:
+    plane = ControlPlane({"analyst": ["echo"]})
+    args = {"payload": {"items": [1]}}
+
+    result = plane.process_tool_call("analyst", "echo", args)
+    args["payload"]["items"].append(2)
+    result["payload"]["items"].append(3)
+
+    first_snapshot = plane.get_log()
+    assert first_snapshot[0]["args"] == {"payload": {"items": [1]}}
+    assert first_snapshot[0]["result"] == {"payload": {"items": [1]}}
+
+    first_snapshot[0]["args"]["payload"]["items"].append(4)
+    first_snapshot[0]["result"]["payload"]["items"].append(5)
+    second_snapshot = plane.get_log()
+    assert second_snapshot[0]["args"] == {"payload": {"items": [1]}}
+    assert second_snapshot[0]["result"] == {"payload": {"items": [1]}}
+
+
+def test_log_timestamps_are_timezone_aware_utc() -> None:
+    plane = ControlPlane({"analyst": ["sum"]})
+
+    assert plane.process_tool_call("analyst", "sum", {"a": 2, "b": 3}) == 5
+
+    timestamp = datetime.fromisoformat(plane.get_log()[0]["timestamp"])
+    assert timestamp.utcoffset() == timedelta(0)
+
+
+def test_denied_and_unknown_calls_remain_visible_without_becoming_authority() -> None:
+    plane = ControlPlane({"analyst": ["not-a-tool"]})
+
+    with pytest.raises(PermissionError, match="not permitted"):
+        plane.process_tool_call("guest", "echo", {"text": "hello"})
+    with pytest.raises(ValueError, match="Unknown tool"):
+        plane.process_tool_call("analyst", "not-a-tool", {})
+
+    log = plane.get_log()
+    assert [entry["status"] for entry in log] == ["denied", "error"]
+    assert [entry["allowed"] for entry in log] == [False, True]
+
+
+def test_object_copy_hooks_cannot_create_a_shared_log_reference() -> None:
+    plane = ControlPlane({"analyst": ["echo"]})
+    adversarial = SelfCopyingMutable()
+
+    with pytest.raises(TypeError, match="snapshot-safe built-in values"):
+        plane.process_tool_call("analyst", "echo", {"payload": adversarial})
+
+    adversarial.items.append(2)
+    log = plane.get_log()
+    assert log[0]["args"] == {}
+    assert log[0]["args_snapshot_status"] == "rejected"
+    assert log[0]["status"] == "error"
+    assert "result" not in log[0]
+
+
+def test_uncopyable_denied_arguments_cannot_suppress_the_denial_record() -> None:
+    plane = ControlPlane({})
+
+    with pytest.raises(PermissionError, match="not permitted"):
+        plane.process_tool_call("guest", "echo", {"lock": threading.Lock()})
+
+    log = plane.get_log()
+    assert log[0]["args"] == {}
+    assert log[0]["args_snapshot_status"] == "rejected"
+    assert log[0]["status"] == "denied"
+    assert log[0]["allowed"] is False
+
+
+def test_mutable_string_subclasses_are_not_retained_as_actor_identifiers() -> None:
+    plane = ControlPlane({})
+    actor = MutableStr("guest")
+
+    with pytest.raises(TypeError, match="plain strings"):
+        plane.process_tool_call(actor, "echo", {})
+
+    actor.items.append(2)
+    log = plane.get_log()
+    assert log[0]["actor"] == "<invalid>"
+    assert log[0]["tool_name"] == "echo"
+    assert log[0]["args_snapshot_status"] == "not-attempted"
+    assert log[0]["status"] == "error"
+
+
+def test_mapping_hooks_cannot_suppress_a_denied_attempt_record() -> None:
+    plane = ControlPlane({})
+    args = HookedMapping()
+
+    with pytest.raises(PermissionError, match="not permitted"):
+        plane.process_tool_call("guest", "echo", args)
+
+    assert args.iterations == 0
+    log = plane.get_log()
+    assert log[0]["args_snapshot_status"] == "rejected"
+    assert log[0]["status"] == "denied"
+
+
+def test_execution_uses_an_isolated_validated_argument_snapshot() -> None:
+    plane = MutatingControlPlane({"analyst": ["mutate"]})
+    original = {"payload": {"items": [1]}}
+
+    result = plane.process_tool_call("analyst", "mutate", original)
+
+    assert original == {"payload": {"items": [1]}}
+    assert result == {"payload": {"items": [1, 2]}}
+    log = plane.get_log()
+    assert log[0]["args"] == {"payload": {"items": [1]}}
+    assert log[0]["result"] == {"payload": {"items": [1, 2]}}


### PR DESCRIPTION
## Decision

Retain `hub_optimus/hub_optimus_control.py` only as a local educational prototype. It is not an operational control plane and is not part of the supported runtime, Semantic Engine, Operator, API, or deployment surface.

Related to #1766.

## Scope

- state the component's real lifecycle and capability boundary;
- make timestamps timezone-aware UTC;
- isolate accepted arguments, tool execution, results, and returned log snapshots;
- record denied and rejected attempts without retaining hostile mutable references;
- add focused adversarial regression coverage.

No authentication, durable audit, OPA, OpenTelemetry, SPIFFE/SPIRE, cryptography, post-quantum feature, deployment, API, schema, Operator, or Semantic Engine integration is introduced.

## Files changed

- `hub_optimus/hub_optimus_control.py`
- `tests/test_control_plane_prototype.py`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] The orphan component has an explicit lifecycle classification.
- [x] Documentation does not imply production authorization or authenticated identity.
- [x] Log timestamps are timezone-aware UTC.
- [x] Caller and tool mutation cannot rewrite accepted log records.
- [x] Hostile copy/mapping hooks cannot suppress a controlled record.
- [x] Denied calls retain `PermissionError` precedence.
- [x] Unsupported values fail closed for otherwise allowed calls.
- [x] No supported runtime or deployment surface changes.

## Validation

- full pytest suite: 479 passed, 12 skipped (PowerShell-only);
- focused control-plane selection: 11 passed;
- scenario benchmarks: 3/3;
- narrative checks: 5/5;
- encoding/mojibake scan: 280 documents;
- `git diff --check`: clean;
- two independent adversarial review passes: no remaining correctness or mutation-integrity blocker.

## Risks

The prototype remains process-local and in-memory. It makes no concurrency, durable-ordering, authentication, authorization-service, or compliance-audit guarantee. Its deliberately narrow snapshot domain rejects arbitrary mappings and user-defined value types.

## AI_HANDOFF update

Adds a dedicated “Local Control-Plane Prototype Boundary” section that records the adopted lifecycle, supported stubs, mutation boundary, and explicit non-capabilities.

## Next PR recommendation

Do not expand this file into an operational control plane implicitly. Any runtime integration, identity, external policy, durable audit, or telemetry work should begin with a separately approved issue/RFC and executable acceptance criteria.