### PR TITLE
docs(scenarios): add mediator policy candidate

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -344,6 +344,25 @@ Issue #118 adds a read-only, standard-library report over the current
 - The aggregates describe deterministic synthetic runs; they are not evidence
   of real-world agreement rates, policy quality, or prediction.
 
+## Mediator Policy Comparison Candidate Boundary
+
+Issue #1531 adds one experimental, Spanish-language scenario input at
+`scenarios/candidates/mediator_policy_comparison_es.json` and a reproducibility
+note at `docs/scenarios/mediator_policy_comparison_candidate.md`.
+
+- The input contains two negotiators and one mediator. It does not select a
+  policy; runs must choose `uniform` or `biased` explicitly.
+- The documented seed enumeration covers 0 through 999 and includes a derived,
+  non-persisted in-memory mediator-removal control with the same target and
+  round budget.
+- Under `biased`, the mediator's offer range is 2-4 while negotiators retain
+  1-5. This is a role-aware range restriction, not party favoritism.
+- Runtime success still means that any actor emits the exact target offer. It
+  is not consensus, ratification, durable agreement, or mediation quality.
+- The recorded observations are synthetic candidate evidence. They are not
+  frozen benchmark outputs, and any later promotion remains a separate
+  protected-zone decision under issue #1536.
+
 ## Scenario Generation Provenance Boundary
 
 Issue #1758 scopes the laboratory generator/telemetry correction for stale

--- a/docs/scenarios/catalog.md
+++ b/docs/scenarios/catalog.md
@@ -18,6 +18,7 @@ Scope notes:
 | [`ceasefire_basic`](../../benchmarks/scenarios/ceasefire_basic.json) | Ceasefire Negotiation | benchmark | Simple bilateral ceasefire negotiation with compatible objectives |
 | [`ceasefire_fragile`](../../benchmarks/scenarios/ceasefire_fragile.json) | Ceasefire Negotiation | benchmark | Ceasefire with external mediation and limited rounds, used as a fragile convergence case |
 | [`ceasefire_failure`](../../benchmarks/scenarios/ceasefire_failure.json) | Ceasefire Negotiation | benchmark | Hardline negotiation breakdown with no feasible settlement space |
+| [`mediator_policy_comparison_es`](../../scenarios/candidates/mediator_policy_comparison_es.json) | Mediated Negotiation | experimental | Spanish-language synthetic input for explicit uniform, biased, and mediator-removal controls |
 | [`scenario_001_partial_ceasefire`](../../v1_core/workflow/scenario_001_partial_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing an unverifiable ceasefire as destabilizing |
 | [`scenario_002_verified_ceasefire`](../../v1_core/workflow/scenario_002_verified_ceasefire.md) | Ceasefire Negotiation | workflow reference | Narrative reference scenario showing a verified ceasefire as stabilizing |
 | [`scenario_003_coalition_fracture`](../../v1_core/workflow/scenario_003_coalition_fracture.md) | Coalition Stability | experimental | External negotiation constrained by an internal coalition veto player |

--- a/docs/scenarios/mediator_policy_comparison_candidate.md
+++ b/docs/scenarios/mediator_policy_comparison_candidate.md
@@ -1,0 +1,164 @@
+# Candidato de comparación explícita de políticas con mediación
+
+Issue: [#1531](https://github.com/Voxterrae/HUB_Optimus/issues/1531)
+
+Estado: candidato experimental; no es un benchmark.
+
+## Decisión y alcance
+
+El input canónico es
+[`mediator_policy_comparison_es.json`](../../scenarios/candidates/mediator_policy_comparison_es.json).
+Contiene dos partes negociadoras y una mediación externa. El título, la
+descripción y los nombres están en español; `negotiator` y `mediator` se
+mantienen como identificadores técnicos del runtime.
+
+La comparación usa:
+
+- el mismo criterio exacto, `offer: 5`;
+- el mismo presupuesto de cinco rondas;
+- las semillas enteras de 0 a 999, ambas incluidas;
+- la política `uniform`;
+- la política `biased`; y
+- un control derivado que elimina el rol `mediator` sin cambiar el criterio ni
+  el presupuesto de rondas.
+
+El control sin mediador se construye solo en memoria durante la reproducción.
+No es un segundo escenario canónico ni se añade al catálogo.
+
+## Límite del runtime
+
+El JSON no selecciona una política. `uniform` asigna a todos los roles ofertas
+uniformes entre 1 y 5. `biased` mantiene ese rango para `negotiator` y limita
+`mediator` al rango 2-4.
+
+Por tanto, `biased` es aquí una restricción del rango según el rol. No codifica
+preferencia por una parte, neutralidad, calidad de mediación, capacidad de
+garantía ni influencia política.
+
+El runtime marca éxito cuando cualquier actor emite exactamente `offer: 5`.
+No comprueba consenso, ratificación, estabilidad, cumplimiento ni acuerdo
+duradero.
+
+## Procedencia ejecutable
+
+La observación se generó sobre `main`
+`906d3e47df48dceac2b4abd25fe81c15b9a7b235`, con Python 3.12.13.
+
+| Entrada ejecutable | SHA-256 |
+| --- | --- |
+| `scenarios/candidates/mediator_policy_comparison_es.json` | `d0af7d755ce1018a966bc8a6e162f4670e1577adf7a3f052b06e57a2f2bf6c38` |
+| `run_scenario.py` | `4e69d869104cdc324fb2303b933d66a84abea5252ffd2a44593c9c8b891181ee` |
+| `hub_optimus_simulator.py` | `df00f950f12c08a76a6f54769818313712a9ef292b6f463485a96ca5fa0553bb` |
+| `scenario.schema.json` | `983aa24429c302cff706d26c95c77306e5b44c0b91f9736c9251543a4259bde6` |
+
+## Reproducción
+
+Ejecutar desde la raíz del repositorio. La carga siguiente usa la puerta de
+entrada autoritativa y, por tanto, valida el JSON contra el schema y las
+invariantes de identidad:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from run_scenario import load_validated_scenario
+
+path = Path("scenarios/candidates/mediator_policy_comparison_es.json")
+load_validated_scenario(path)
+print("input validado")
+PY
+```
+
+Las dos políticas se seleccionan explícitamente en el CLI. Estos comandos
+reproducen la semilla 42 sin añadir resultados al catálogo:
+
+```bash
+python run_scenario.py \
+  scenarios/candidates/mediator_policy_comparison_es.json \
+  --seed 42 --policy uniform --output /tmp/mediator-uniform-42.json
+
+python run_scenario.py \
+  scenarios/candidates/mediator_policy_comparison_es.json \
+  --seed 42 --policy biased --output /tmp/mediator-biased-42.json
+```
+
+Este comando reproduce las cuatro configuraciones (dos políticas por cada
+composición de actores) sobre las 1.000 semillas. Usa el input ya validado y el
+mismo `Simulator` que invoca el CLI:
+
+```bash
+python - <<'PY'
+from statistics import fmean
+from pathlib import Path
+
+from hub_optimus_simulator import Scenario, Simulator
+from run_scenario import load_validated_scenario
+
+path = Path("scenarios/candidates/mediator_policy_comparison_es.json")
+candidate = load_validated_scenario(path)
+without_mediator = Scenario(
+    title=candidate.title,
+    description=candidate.description,
+    roles=[role for role in candidate.roles if role["role"] != "mediator"],
+    success_criteria=candidate.success_criteria,
+    max_rounds=candidate.max_rounds,
+)
+
+controls = {
+    "con_mediador": candidate,
+    "sin_mediador": without_mediator,
+}
+for control_name, scenario in controls.items():
+    for policy_name in ("uniform", "biased"):
+        results = [
+            Simulator(scenario, policy_name=policy_name).run(seed=seed)
+            for seed in range(1000)
+        ]
+        successes = [result for result in results if result["status"] == "success"]
+        print(
+            control_name,
+            policy_name,
+            f"{len(successes)}/1000",
+            f"{fmean(result['rounds'] for result in successes):.6f}",
+            results[42]["status"],
+            results[42]["rounds"],
+        )
+PY
+```
+
+## Resultados observados
+
+La media de ronda usa solo ejecuciones con éxito; su denominador es el número
+de éxitos mostrado en la misma fila.
+
+| Control | Política explícita | Éxitos / 1.000 | Media de ronda entre éxitos | Semilla 42 |
+| --- | --- | ---: | ---: | --- |
+| Con mediador | `uniform` | 963 / 1.000 | 1,854621 | éxito, ronda 3 |
+| Con mediador | `biased` | 893 / 1.000 | 2,194849 | éxito, ronda 4 |
+| Sin mediador | `uniform` | 902 / 1.000 | 2,230599 | éxito, ronda 4 |
+| Sin mediador | `biased` | 902 / 1.000 | 2,230599 | éxito, ronda 4 |
+
+**Resultado verificado:** en este conjunto enumerado, el control con mediador
+obtiene menos éxitos y una ronda media condicional posterior con `biased` que
+con `uniform`.
+
+**Resultado verificado:** al retirar el mediador, `uniform` y `biased` producen
+el mismo resumen. Los dos roles restantes usan el rango 1-5 bajo ambas
+políticas.
+
+**Inferencia limitada:** la dirección observada es coherente con que el
+mediador no puede emitir la oferta objetivo bajo `biased`. Añadir o retirar un
+actor también cambia cuántos valores consume el generador aleatorio; esta
+comparación no separa ese efecto.
+
+**Incertidumbre:** las semillas 0-999 son una enumeración determinista del
+prototipo, no una muestra de negociaciones reales. La media condicionada al
+éxito no describe las ejecuciones fallidas. Los resultados no establecen
+causalidad, calidad de política, calidad de mediación, favoritismo, probabilidad
+real ni capacidad predictiva.
+
+## Estado de promoción
+
+El candidato queda fuera de `benchmarks/`. No hay output esperado congelado y
+este cambio no modifica el simulador, el runner, el schema ni CI. Cualquier
+promoción posterior requiere la decisión separada y la revisión de zona
+protegida descritas en [#1536](https://github.com/Voxterrae/HUB_Optimus/issues/1536).

--- a/scenarios/candidates/mediator_policy_comparison_es.json
+++ b/scenarios/candidates/mediator_policy_comparison_es.json
@@ -1,0 +1,22 @@
+{
+  "title": "Comparación explícita de políticas con mediación",
+  "description": "Escenario sintético de sensibilidad del rango de ofertas con dos partes negociadoras y una mediación externa; no representa calidad de mediación, favoritismo ni consenso real.",
+  "roles": [
+    {
+      "name": "Parte negociadora A",
+      "role": "negotiator"
+    },
+    {
+      "name": "Parte negociadora B",
+      "role": "negotiator"
+    },
+    {
+      "name": "Mediación externa",
+      "role": "mediator"
+    }
+  ],
+  "success_criteria": {
+    "offer": 5
+  },
+  "max_rounds": 5
+}

--- a/tests/test_mediator_policy_candidate.py
+++ b/tests/test_mediator_policy_candidate.py
@@ -1,0 +1,37 @@
+"""Contract check for the issue-1531 experimental scenario input."""
+
+from pathlib import Path
+
+from run_scenario import load_validated_scenario
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE = (
+    REPO_ROOT
+    / "scenarios"
+    / "candidates"
+    / "mediator_policy_comparison_es.json"
+)
+
+
+def test_mediator_policy_candidate_uses_the_documented_input_shape() -> None:
+    scenario = load_validated_scenario(CANDIDATE)
+
+    assert scenario.title == "Comparación explícita de políticas con mediación"
+    assert scenario.description == (
+        "Escenario sintético de sensibilidad del rango de ofertas con dos "
+        "partes negociadoras y una mediación externa; no representa calidad "
+        "de mediación, favoritismo ni consenso real."
+    )
+    assert [role["name"] for role in scenario.roles] == [
+        "Parte negociadora A",
+        "Parte negociadora B",
+        "Mediación externa",
+    ]
+    assert [role["role"] for role in scenario.roles] == [
+        "negotiator",
+        "negotiator",
+        "mediator",
+    ]
+    assert scenario.success_criteria == {"offer": 5}
+    assert scenario.max_rounds == 5


### PR DESCRIPTION
## Decision

Add one persisted Spanish-language experimental candidate for an explicit mediator-policy comparison. Preserve it outside `benchmarks/`; the observation is reproducible synthetic evidence, not a quality or real-world mediation claim.

Related to #1531.

## Scope

- add two negotiators and one mediator with the same exact target and five-round budget;
- document explicit `uniform` and `biased` runs over every integer seed from 0 through 999;
- include an in-memory mediator-removal control under both policies;
- record denominators, conditional round means, seed-42 outcomes, uncertainty, provenance, and executable commands;
- catalog the persisted candidate as `experimental`;
- add an input-contract test without freezing observed outputs.

No simulator, runner, schema, CI, generated-scenario catalog entry, expected output, or benchmark changes.

## Files changed

- `scenarios/candidates/mediator_policy_comparison_es.json`
- `docs/scenarios/mediator_policy_comparison_candidate.md`
- `docs/scenarios/catalog.md`
- `tests/test_mediator_policy_candidate.py`
- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] The input passes the authoritative loader and schema.
- [x] Commands select `uniform` and `biased` explicitly.
- [x] A mediator-removal control keeps the threshold and round budget.
- [x] Seeds 0–999 and all denominators are stated.
- [x] `biased` is described only as the mediator's 2–4 role-aware range restriction.
- [x] Success remains “any actor emits offer 5,” not consensus or durable agreement.
- [x] Names, title, description, and documentation are Spanish.
- [x] No runtime, runner, schema, benchmark, or CI file changes.
- [x] Later benchmark promotion remains a separate #1536 decision.

## Validation

- full pytest suite: 485 passed, 12 skipped (PowerShell-only);
- focused candidate test: 1 passed;
- independent replay of seeds 0–999:
  - mediator/uniform: 963/1000 successes, mean successful round 1.854621, seed 42 round 3;
  - mediator/biased: 893/1000, mean 2.194849, seed 42 round 4;
  - without mediator/uniform: 902/1000, mean 2.230599, seed 42 round 4;
  - without mediator/biased: 902/1000, mean 2.230599, seed 42 round 4;
- scenario benchmarks: 3/3;
- narrative benchmarks: 5/5;
- encoding/mojibake scan: 281 Markdown files;
- `git diff --check`: clean;
- independent review: no correctness blocker; the test does not freeze or promote benchmark outputs.

## Risks

The results are deterministic behavior of a synthetic prototype. Adding/removing an actor also changes RNG consumption. The conditional mean excludes failures. Nothing here establishes causality, policy quality, mediator quality, neutrality, favoritism, prediction, consensus, ratification, or real-world probability.

## AI_HANDOFF update

Adds a “Mediator Policy Comparison Candidate Boundary” that records the persisted artifact, explicit policy selection, enumerated seed/control design, runtime success semantics, and non-benchmark status.

## Next PR recommendation

Do not promote this candidate implicitly. If maintainers want protected benchmark status, use #1536 to review stable candidates, expected bytes, scientific framing, and the protected-zone change separately.