### PR TITLE
feat(operator): add local learning candidate model and store (#1836)

### DIFF
--- a/docs/rfc/operator_local_learning_candidate.md
+++ b/docs/rfc/operator_local_learning_candidate.md
@@ -1,0 +1,148 @@
+# Operator local learning candidates
+
+## Status
+
+Lifecycle: **Model-only prototype contract; not integrated into Operator**.
+
+The module can construct and validate a local, human-authored learning candidate
+when it is called explicitly. The current Operator UI does not load this module,
+does not expose the workflow, and does not persist candidates. This patch is the
+executable data model and test boundary for a future browser integration, not a
+claim that meta-learning is already a product feature. It is not model training,
+institutional memory, a truth score, or an automatic update to Core, the Semantic
+Engine, GitHub, or any remote service.
+
+The versioned data contract is
+[`operator_learning_candidate.v1.schema.json`](../../site/operator/schemas/operator_learning_candidate.v1.schema.json).
+The executable validator and state machine are in
+[`learning-candidate.v1.js`](../../site/operator/learning-candidate.v1.js). The
+method reference remains the versioned repository workflow
+[`v1_core/workflow/05_meta_learning.md`](../../v1_core/workflow/05_meta_learning.md),
+whose exact SHA-256 is bound into every candidate.
+
+## What the loop does
+
+In a future, separately reviewed integration, after Operator has prepared a
+source-bound local draft, a human could explicitly:
+
+1. state the actual outcome in one sentence;
+2. record three to ten observable signals and link each one to existing claim
+   and evidence records;
+3. write a diagnosis using the repository's explicit diagnostic categories;
+4. identify one gap and one minimum proposed change;
+5. record three to five manual metrics, the next experiment, and the closure
+   checklist;
+6. inspect the candidate and choose `draft`, `accepted`, or `rejected`.
+
+Creating a candidate does not imply acceptance. Every state transition requires
+a human note and is appended to visible history. A candidate can move from
+`draft` to `accepted` or `rejected`, and from either reviewed state back to
+`draft`; it cannot flip directly between `accepted` and `rejected`.
+Local acceptance additionally requires a current live-case snapshot and all
+five closure checks set to `true`; the model enforces both requirements rather
+than relying on a future UI to disable a button.
+
+## Structural links
+
+The record is a small explicit graph rather than a free-form memory blob.
+
+| From | Relation | To | Meaning |
+| --- | --- | --- | --- |
+| Outcome | `OUTCOME_OF_CASE` | Case | The recorded outcome belongs to this case revision. |
+| Evidence | `SUPPORTS_ATTRIBUTION`, `SUPPORTS_CLAIM`, or `CONTRADICTS_CLAIM` | Claim | Existing source-bound relation; no truth is inferred. |
+| Signal | `SIGNAL_REFERENCES_CLAIM` | Claim | The human linked an observation to an existing claim. |
+| Signal | `SIGNAL_GROUNDED_IN_EVIDENCE` | Evidence | The signal retains evidence provenance. |
+| Diagnosis | `DIAGNOSIS_INTERPRETS_SIGNAL` | Signal | The diagnosis explicitly covers every recorded signal. |
+| Diagnosis | `DIAGNOSIS_REFERENCES_EVIDENCE` | Evidence | The diagnosis retains evidence provenance. |
+| Gap | `GAP_IDENTIFIED_BY_DIAGNOSIS` | Diagnosis | The proposed gap follows from the recorded diagnosis. |
+| Action | `ACTION_ADDRESSES_GAP` | Gap | The minimum change addresses that gap. |
+
+Dangling references, duplicate semantic edges, invalid relation signatures, and
+candidates without an evidence-to-claim relation are rejected before insertion
+into the in-memory store model or export. Version 1 rejects every
+`system-suggested` relation; it accepts only human-authored learning links and
+the source-bound case relations imported from the live case snapshot. Any later
+automated suggestion requires a new version and separate governance review.
+
+## State and freshness are different
+
+`state` records a human decision. `freshness` compares the candidate with the
+current case revision and is never allowed to rewrite that decision.
+
+| Freshness | Meaning | Local acceptance allowed? |
+| --- | --- | --- |
+| `current` | Case identity, revision, claims, and evidence still match. | Yes, by explicit human action. |
+| `stale` | The same case exists but its revision changed. | No. Review again and use a new candidate ID for changed content. |
+| `invalid` | The case identity changed or referenced claim/evidence disappeared. | No. |
+
+Editing source input or structural case records therefore makes derived
+candidates stale or invalid. It never silently edits, accepts, rejects, or
+deletes their history.
+
+## In-memory store model, export, and deletion
+
+The candidate module defines pure store operations and does not call browser
+storage, the DOM, or any network API. A separate model-layer adapter now exists
+in [`learning-store.v1.js`](../../site/operator/learning-store.v1.js), but the
+current Operator HTML and service worker do not load or cache it. Consequently,
+refreshing the current Operator still cannot recover a candidate and this RFC
+does not claim a user-facing persistence feature.
+
+- Maximum 50 candidates in the in-memory store model.
+- Maximum 256 KiB per candidate entry.
+- Maximum 1 MiB per imported export envelope.
+- JSON is canonicalized to Unicode NFC, LF line endings, and sorted object keys
+  before checksumming.
+- Export/import preserves IDs, links, state, method reference, and history and
+  rejects unknown versions, checksum drift, or ID conflicts.
+- A full store never evicts an older record silently.
+- Deleting candidates for a case removes the candidate graph as one unit, so no
+  orphaned local relations remain.
+
+The model-layer adapter uses IndexedDB database
+`hub_optimus_operator_learning_v1`, version 1. Its sole object store contains
+exactly one keyed `operator_learning_store.v1` record: the complete validated
+store. Each mutation reads and validates the latest untrusted record, checks
+the caller's expected entry SHA-256 as the compare-and-swap token, retains the
+candidate SHA-256 and case revision as diagnostic tokens, constructs and
+validates the next complete store, and writes it within one read-write
+transaction. The entry digest covers both candidate and freshness binding, so
+a concurrent binding-only update also causes a conflict. Export requires the
+same current tokens and never silently exports a newer local candidate.
+Candidate and entry limits remain enforced and the complete store has an
+additional hard ceiling of 16 MiB.
+
+Version 1 is append-only per candidate ID in every state. A binding-only
+freshness update may retain the exact candidate. The only candidate-byte change
+permitted under that ID is a pure state transition: all content and the complete
+history prefix remain byte-identical, while state, update time, and exactly one
+appended transition event advance. Editing outcome, metrics, learning nodes,
+provenance, creation time, or history requires a new candidate ID. Acceptance
+additionally requires complete closure and a current binding. This intentionally
+means that the model-layer prototype does not yet expose an edit-in-place API.
+Version 1 also defines no `supersedes` or successor relation between candidate
+IDs; adding a lineage link or same-ID draft editor is a future contract decision,
+not behavior that the current adapter may infer.
+
+The adapter has no storage fallback, network path, implicit database reset, or
+silent eviction. It classifies failures as unavailable, blocked, corrupt,
+quota, or conflict; handles blocked upgrades and version changes; and requires
+explicit confirmation plus the expected store digest before clearing all
+records. Import, export, candidate deletion, and case deletion preserve the
+same validation and optimistic-concurrency boundary. Stored bytes are treated
+as untrusted on every read.
+
+Only a public URL origin or an opaque stable ID may be retained as a source
+reference. URL paths, queries, fragments, and credentials are not stored in a
+learning candidate. No learning candidate is included in the analysis request,
+case JSON, WhatsApp text, or shared draft summary.
+
+## Boundary for future work
+
+Loading either model-layer module from Operator, adding UI, performing browser
+integration and end-to-end QA, or claiming the workflow is available to users
+requires a separate implementation change. Promotion to repository knowledge, a remote database,
+cross-device sync, ranking, model training, or an automatic Core/Semantic Engine
+update requires a separate governance-reviewed decision. If a future local UI
+uses `accepted`, it will mean only that the operator accepted that candidate on
+that device.

--- a/docs/rfc/registry.v1.json
+++ b/docs/rfc/registry.v1.json
@@ -218,6 +218,27 @@
       "note": "A local/private, single-URL prototype, browser fallback, and versioned application payload schema exist. This does not ratify the RFC, verify retrieved content, or prove a public deployment."
     },
     {
+      "id": "operator-local-learning-candidate",
+      "path": "docs/rfc/operator_local_learning_candidate.md",
+      "title": "Operator Local Learning Candidate",
+      "lifecycle": "Draft",
+      "proposal_issue": 1836,
+      "record_pr": null,
+      "decision_pr": null,
+      "implementation_prs": [],
+      "owner": null,
+      "ratifier": null,
+      "evidence_paths": [
+        "docs/rfc/operator_local_learning_candidate.md",
+        "site/operator/learning-candidate.v1.js",
+        "site/operator/schemas/operator_learning_candidate.v1.schema.json",
+        "site/operator/learning-store.v1.js",
+        "tests/test_operator_learning_candidate.py",
+        "tests/test_operator_learning_store.py"
+      ],
+      "note": "An executable local data model and an unloaded IndexedDB adapter prototype exist. Operator and its service worker do not load them, no user-facing persistence or learning workflow is available, and no training, remote memory, automatic promotion, or governance ratification is claimed."
+    },
+    {
       "id": "post-quantum-control-plane",
       "path": "docs/rfc/post_quantum_control_plane.md",
       "title": "Post-Quantum Control Plane",

--- a/site/operator/learning-candidate.v1.js
+++ b/site/operator/learning-candidate.v1.js
@@ -1,0 +1,1032 @@
+(() => {
+  "use strict";
+
+  const SCHEMA_VERSION = "operator_learning_candidate.v1";
+  const STORE_VERSION = "operator_learning_store.v1";
+  const EXPORT_VERSION = "operator_learning_export.v1";
+  const METHOD_PATH = "v1_core/workflow/05_meta_learning.md";
+  const METHOD_SHA256 = "74f4e5ff32de47f4ec970de606f5674c5cd40c7eed7d356fc0a12a23acc3561c";
+  const MAX_ENTRIES = 50;
+  const MAX_ENTRY_BYTES = 256 * 1024;
+  const MAX_IMPORT_BYTES = 1024 * 1024;
+
+  const STATES = new Set(["draft", "accepted", "rejected"]);
+  const CATEGORIES = new Set([
+    "ambiguity",
+    "weak_verification",
+    "misaligned_incentives",
+    "wrong_sequence",
+    "political_overload",
+    "spoilers",
+    "information_asymmetry"
+  ]);
+  const DECISIONS = new Set([
+    "repeat_same_scenario",
+    "escalate_variant",
+    "change_approach"
+  ]);
+  const METRICS = new Set([
+    "clarity",
+    "verifiability",
+    "viability",
+    "time_to_draft_minutes",
+    "open_points"
+  ]);
+  const RELATION_SIGNATURES = Object.freeze({
+    OUTCOME_OF_CASE: ["outcome", "case"],
+    SUPPORTS_ATTRIBUTION: ["evidence", "claim"],
+    SUPPORTS_CLAIM: ["evidence", "claim"],
+    CONTRADICTS_CLAIM: ["evidence", "claim"],
+    SIGNAL_REFERENCES_CLAIM: ["signal", "claim"],
+    SIGNAL_GROUNDED_IN_EVIDENCE: ["signal", "evidence"],
+    DIAGNOSIS_INTERPRETS_SIGNAL: ["diagnosis", "signal"],
+    DIAGNOSIS_REFERENCES_EVIDENCE: ["diagnosis", "evidence"],
+    GAP_IDENTIFIED_BY_DIAGNOSIS: ["gap", "diagnosis"],
+    ACTION_ADDRESSES_GAP: ["action", "gap"]
+  });
+  const RELATION_EPISTEMIC_STATUS = Object.freeze({
+    OUTCOME_OF_CASE: "observation",
+    SUPPORTS_ATTRIBUTION: "submitted-claim",
+    SUPPORTS_CLAIM: "corroboration",
+    CONTRADICTS_CLAIM: "corroboration",
+    SIGNAL_REFERENCES_CLAIM: "observation",
+    SIGNAL_GROUNDED_IN_EVIDENCE: "observation",
+    DIAGNOSIS_INTERPRETS_SIGNAL: "inference",
+    DIAGNOSIS_REFERENCES_EVIDENCE: "inference",
+    GAP_IDENTIFIED_BY_DIAGNOSIS: "inference",
+    ACTION_ADDRESSES_GAP: "proposal"
+  });
+  const IMPORTED_RELATION_TYPES = new Set([
+    "SUPPORTS_ATTRIBUTION",
+    "SUPPORTS_CLAIM",
+    "CONTRADICTS_CLAIM"
+  ]);
+  const NODE_KEYS = Object.freeze({
+    case: ["node_id", "node_type", "case_id", "core_version_ref", "revision_sha256"],
+    claim: ["node_id", "node_type", "record_id", "text", "text_sha256", "source_ref"],
+    evidence: ["node_id", "node_type", "record_id", "text", "text_sha256", "source_ref", "limitations"],
+    outcome: ["node_id", "node_type", "text"],
+    signal: ["node_id", "node_type", "text", "claim_refs", "evidence_refs"],
+    diagnosis: ["node_id", "node_type", "text", "categories", "signal_refs", "evidence_refs"],
+    gap: ["node_id", "node_type", "text"],
+    action: ["node_id", "node_type", "change", "reason", "verification_criterion"]
+  });
+  const REQUIRED_CASE_FIELDS = Object.freeze([
+    "case_id",
+    "core_version_ref",
+    "revision_sha256",
+    "claims",
+    "evidence",
+    "relationships"
+  ]);
+
+  function normalizeString(value) {
+    if (value === null || value === undefined) return "";
+    return String(value).replace(/\r\n?/g, "\n").normalize("NFC");
+  }
+
+  function hasUnpairedSurrogate(value) {
+    if (typeof value !== "string") return false;
+    for (let index = 0; index < value.length; index += 1) {
+      const code = value.charCodeAt(index);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(index + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+        index += 1;
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function canonicalValue(value) {
+    if (typeof value === "string") return normalizeString(value);
+    if (Array.isArray(value)) {
+      const canonical = [];
+      for (let index = 0; index < value.length; index += 1) canonical.push(canonicalValue(value[index]));
+      return canonical;
+    }
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.keys(value)
+          .sort()
+          .map((key) => [key, canonicalValue(value[key])])
+      );
+    }
+    return value;
+  }
+
+  function stableStringify(value) {
+    return JSON.stringify(canonicalValue(value));
+  }
+
+  function byteLength(value) {
+    return new TextEncoder().encode(String(value)).byteLength;
+  }
+
+  function isObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function isNonEmptyString(value) {
+    return typeof value === "string"
+      && !hasUnpairedSurrogate(value)
+      && value.trim().length > 0
+      && value.length <= 20000;
+  }
+
+  function isId(value) {
+    return typeof value === "string" && /^[A-Za-z][A-Za-z0-9._:-]{0,127}$/.test(value);
+  }
+
+  function isSha256(value) {
+    return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+  }
+
+  function isTimestamp(value) {
+    if (typeof value !== "string") return false;
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/.exec(value);
+    if (!match) return false;
+    const epoch = Date.parse(value);
+    if (!Number.isFinite(epoch)) return false;
+    const instant = new Date(epoch);
+    return instant.getUTCFullYear() === Number(match[1])
+      && instant.getUTCMonth() + 1 === Number(match[2])
+      && instant.getUTCDate() === Number(match[3])
+      && instant.getUTCHours() === Number(match[4])
+      && instant.getUTCMinutes() === Number(match[5])
+      && instant.getUTCSeconds() === Number(match[6]);
+  }
+
+  function sameKeys(value, expected) {
+    if (!isObject(value)) return false;
+    const actual = Object.keys(value).sort();
+    const wanted = [...expected].sort();
+    return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+  }
+
+  function uniqueStrings(value) {
+    return Array.isArray(value)
+      && value.length <= 128
+      && value.every(isNonEmptyString)
+      && new Set(value).size === value.length;
+  }
+
+  function safeSourceRef(value) {
+    const normalized = normalizeString(value);
+    if (!/^https?:\/\//i.test(normalized)) return isId(normalized) ? normalized : "";
+    if (typeof URL !== "function") return "";
+    try {
+      const parsed = new URL(normalized);
+      if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password || parsed.port) return "";
+      const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+      const blockedSuffixes = ["localhost", "local", "internal", "localdomain", "home.arpa"];
+      const dnsName = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
+      if (hostname.length > 253 || !dnsName.test(hostname)) return "";
+      if (blockedSuffixes.some((suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`))) return "";
+      if (/^\d+(?:\.\d+){1,3}$/.test(hostname)) return "";
+      return `${parsed.protocol}//${hostname}`;
+    } catch { return ""; }
+  }
+
+  function isSafeSourceRef(value) {
+    if (!isNonEmptyString(value) || value.length > 2048) return false;
+    return safeSourceRef(value) === value;
+  }
+
+  function findNonCanonicalString(value, path = "$") {
+    if (typeof value === "string") {
+      return value === normalizeString(value) && !hasUnpairedSurrogate(value) ? null : path;
+    }
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        const found = findNonCanonicalString(value[index], `${path}[${index}]`);
+        if (found) return found;
+      }
+      return null;
+    }
+    if (isObject(value)) {
+      for (const [key, child] of Object.entries(value)) {
+        const found = findNonCanonicalString(child, `${path}.${key}`);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+
+  function snapshotJsonValue(value, maxDepth = 32, maxNodes = 50000) {
+    let seen = 0;
+    function visit(current, depth) {
+      seen += 1;
+      if (seen > maxNodes || depth > maxDepth) throw new Error("JSON structure limit exceeded");
+      if (current === null || typeof current === "boolean") return current;
+      if (typeof current === "number") {
+        if (!Number.isFinite(current)) throw new Error("non-finite number");
+        return current;
+      }
+      if (typeof current === "string") {
+        if (hasUnpairedSurrogate(current)) throw new Error("unpaired surrogate");
+        return current;
+      }
+      if (Array.isArray(current)) {
+        if (Object.getPrototypeOf(current) !== Array.prototype) throw new Error("non-plain array");
+        const keys = Object.keys(current);
+        const names = Object.getOwnPropertyNames(current);
+        if (Object.getOwnPropertySymbols(current).length
+          || keys.length !== current.length
+          || names.length !== current.length + 1) throw new Error("non-JSON array properties");
+        const snapshot = [];
+        for (let index = 0; index < current.length; index += 1) {
+          if (keys[index] !== String(index)) throw new Error("sparse array");
+          const descriptor = Object.getOwnPropertyDescriptor(current, String(index));
+          if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) throw new Error("array accessor");
+          snapshot.push(visit(descriptor.value, depth + 1));
+        }
+        return snapshot;
+      }
+      if (typeof current === "object") {
+        const prototype = Object.getPrototypeOf(current);
+        if (prototype !== null && prototype !== Object.prototype) throw new Error("non-plain object");
+        if (Object.getOwnPropertySymbols(current).length) throw new Error("symbol property");
+        const entries = [];
+        for (const key of Object.getOwnPropertyNames(current)) {
+          if (hasUnpairedSurrogate(key) || key !== normalizeString(key)) {
+            throw new Error("non-canonical object key");
+          }
+          const descriptor = Object.getOwnPropertyDescriptor(current, key);
+          if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) throw new Error("object accessor");
+          entries.push([key, visit(descriptor.value, depth + 1)]);
+        }
+        return Object.fromEntries(entries);
+      }
+      throw new Error("non-JSON value");
+    }
+    try {
+      const snapshot = visit(value, 0);
+      if (value !== null && typeof value === "object") {
+        if (typeof globalThis.structuredClone !== "function") {
+          throw new Error("structured clone validation is unavailable");
+        }
+        // The descriptor walk above rejects accessors and unsafe JSON values
+        // without invoking them. A structured clone then supplies the browser's
+        // native, fail-closed Proxy check: even a transparent Proxy is not
+        // structured-cloneable.
+        globalThis.structuredClone(value);
+      }
+      return { valid: true, value: snapshot };
+    } catch {
+      return { valid: false, value: null };
+    }
+  }
+
+  function hasSafeJsonShape(value, maxDepth = 32, maxNodes = 50000) {
+    return snapshotJsonValue(value, maxDepth, maxNodes).valid;
+  }
+
+  function relationKey(type, fromRef, toRef) {
+    return `${type}\u0000${fromRef}\u0000${toRef}`;
+  }
+
+  function ownCanonicalCaseRecord(caseRecord) {
+    const captured = snapshotJsonValue(caseRecord);
+    if (!captured.valid || !isObject(captured.value)
+      || REQUIRED_CASE_FIELDS.some((field) => !Object.prototype.hasOwnProperty.call(captured.value, field))) return null;
+    const structured = Array.isArray(captured.value.claims)
+      && captured.value.claims.every((record) => isObject(record)
+        && ["claim_id", "text", "source_ref"].every((field) => typeof record[field] === "string"))
+      && Array.isArray(captured.value.evidence)
+      && captured.value.evidence.every((record) => isObject(record)
+        && ["evidence_id", "text", "source_ref"].every((field) => typeof record[field] === "string")
+        && Array.isArray(record.limitations)
+        && record.limitations.every((item) => typeof item === "string"))
+      && Array.isArray(captured.value.relationships)
+      && captured.value.relationships.every((record) => isObject(record)
+        && ["type", "from_ref", "to_ref"].every((field) => typeof record[field] === "string"))
+      && typeof captured.value.case_id === "string"
+      && typeof captured.value.core_version_ref === "string"
+      && typeof captured.value.revision_sha256 === "string";
+    if (!structured) return null;
+    return canonicalValue(captured.value);
+  }
+
+  function caseRevisionMaterial(caseRecord) {
+    const snapshot = ownCanonicalCaseRecord(caseRecord);
+    if (!snapshot) return null;
+    return canonicalValue(Object.fromEntries(
+      Object.entries(snapshot).filter(([key]) => key !== "revision_sha256")
+    ));
+  }
+
+  function computeCaseRevision(caseRecord, options = {}) {
+    if (typeof options.hashText !== "function") throw new Error("hashText dependency is required");
+    const material = caseRevisionMaterial(caseRecord);
+    if (!material) throw new Error("case record is required");
+    return options.hashText(stableStringify(material));
+  }
+
+  function boundedLimit(value, fallback, label) {
+    if (value === undefined) return fallback;
+    if (!Number.isInteger(value) || value < 1) throw new Error(`${label} must be a positive integer`);
+    return Math.min(value, fallback);
+  }
+
+  function addError(errors, path, message) {
+    errors.push({ path, message });
+  }
+
+  function validateNode(node, index, hashText, errors) {
+    const path = `nodes[${index}]`;
+    const expected = NODE_KEYS[node?.node_type];
+    if (!expected || !sameKeys(node, expected)) {
+      addError(errors, path, "unknown node type or properties");
+      return;
+    }
+    if (!isId(node.node_id)) addError(errors, `${path}.node_id`, "invalid ID");
+
+    if (node.node_type === "case") {
+      if (!isNonEmptyString(node.case_id)) addError(errors, `${path}.case_id`, "required");
+      if (!isNonEmptyString(node.core_version_ref)) addError(errors, `${path}.core_version_ref`, "required");
+      if (!isSha256(node.revision_sha256)) addError(errors, `${path}.revision_sha256`, "invalid SHA-256");
+      return;
+    }
+
+    if (["claim", "evidence"].includes(node.node_type)) {
+      if (!isId(node.record_id)) addError(errors, `${path}.record_id`, "invalid record ID");
+      if (!isNonEmptyString(node.text)) addError(errors, `${path}.text`, "required");
+      if (node.text !== normalizeString(node.text)) addError(errors, `${path}.text`, "must use NFC and LF canonical form");
+      if (!isSafeSourceRef(node.source_ref)) addError(errors, `${path}.source_ref`, "must be an opaque ref or URL origin only");
+      if (!isSha256(node.text_sha256)) {
+        addError(errors, `${path}.text_sha256`, "invalid SHA-256");
+      } else if (hashText(normalizeString(node.text)) !== node.text_sha256) {
+        addError(errors, `${path}.text_sha256`, "does not match canonical text");
+      }
+      if (node.node_type === "evidence" && !uniqueStrings(node.limitations)) {
+        addError(errors, `${path}.limitations`, "must be a unique string list");
+      }
+      return;
+    }
+
+    if (["outcome", "signal", "diagnosis", "gap"].includes(node.node_type)) {
+      if (!isNonEmptyString(node.text)) addError(errors, `${path}.text`, "required");
+    }
+    if (node.node_type === "signal") {
+      if (!uniqueStrings(node.claim_refs)) addError(errors, `${path}.claim_refs`, "must be unique strings");
+      if (!uniqueStrings(node.evidence_refs)) addError(errors, `${path}.evidence_refs`, "must be unique strings");
+      if (!node.claim_refs.length) addError(errors, `${path}.claim_refs`, "at least one claim reference is required");
+      if (!node.evidence_refs.length) addError(errors, `${path}.evidence_refs`, "at least one evidence reference is required");
+    }
+    if (node.node_type === "diagnosis") {
+      if (!Array.isArray(node.categories) || !node.categories.length || new Set(node.categories).size !== node.categories.length || node.categories.some((item) => !CATEGORIES.has(item))) {
+        addError(errors, `${path}.categories`, "invalid diagnosis categories");
+      }
+      if (!uniqueStrings(node.signal_refs) || !node.signal_refs.length) {
+        addError(errors, `${path}.signal_refs`, "must cite at least one signal");
+      }
+      if (!uniqueStrings(node.evidence_refs) || !node.evidence_refs.length) addError(errors, `${path}.evidence_refs`, "at least one unique evidence reference is required");
+    }
+    if (node.node_type === "action") {
+      ["change", "reason", "verification_criterion"].forEach((field) => {
+        if (!isNonEmptyString(node[field])) addError(errors, `${path}.${field}`, "required");
+      });
+    }
+  }
+
+  function validateHistory(history, state, createdAt, updatedAt, errors) {
+    if (!Array.isArray(history) || !history.length || history.length > 512) {
+      addError(errors, "history", "at least one history event is required");
+      return;
+    }
+    const ids = new Set();
+    let expectedState = null;
+    let previousTime = -Infinity;
+    history.forEach((event, index) => {
+      const path = `history[${index}]`;
+      const keys = ["event_id", "at_utc", "actor", "action", "from_state", "to_state", "note"];
+      if (!sameKeys(event, keys)) {
+        addError(errors, path, "unknown history properties");
+        return;
+      }
+      if (!isId(event.event_id) || ids.has(event.event_id)) addError(errors, `${path}.event_id`, "invalid or duplicate ID");
+      ids.add(event.event_id);
+      if (!isTimestamp(event.at_utc)) addError(errors, `${path}.at_utc`, "invalid timestamp");
+      const time = Date.parse(event.at_utc);
+      if (time < previousTime) addError(errors, `${path}.at_utc`, "history is not chronological");
+      previousTime = time;
+      if (event.actor !== "human-operator") addError(errors, `${path}.actor`, "must remain human-operator");
+      if (!["created", "edited", "state-change", "imported", "revalidated"].includes(event.action)) addError(errors, `${path}.action`, "unknown action");
+      if (event.from_state !== expectedState) addError(errors, `${path}.from_state`, "does not continue history state");
+      if (!STATES.has(event.to_state)) addError(errors, `${path}.to_state`, "unknown state");
+      if (!isNonEmptyString(event.note)) addError(errors, `${path}.note`, "human note required");
+      if (index === 0 && (event.action !== "created" || event.from_state !== null || event.to_state !== "draft")) {
+        addError(errors, path, "first event must create a draft");
+      }
+      if (index > 0 && event.action === "created") addError(errors, path, "created is allowed only for the first history event");
+      if (["edited", "imported", "revalidated"].includes(event.action) && event.from_state !== event.to_state) {
+        addError(errors, path, "non-transition event cannot change state");
+      }
+      if (index > 0 && event.from_state !== event.to_state && event.action !== "state-change") {
+        addError(errors, path, "state changes require a state-change event");
+      }
+      if (event.action === "state-change") {
+        const allowed = (
+          (event.from_state === "draft" && ["accepted", "rejected"].includes(event.to_state))
+          || (["accepted", "rejected"].includes(event.from_state) && event.to_state === "draft")
+        );
+        if (!allowed) addError(errors, path, "forbidden state transition");
+      }
+      expectedState = event.to_state;
+    });
+    if (history[0]?.at_utc !== createdAt) addError(errors, "created_at_utc", "must match the first history event");
+    if (history[history.length - 1]?.at_utc !== updatedAt) addError(errors, "updated_at_utc", "must match the last history event");
+    if (expectedState !== state) addError(errors, "state", "does not match history tail");
+  }
+
+  function validateCandidate(candidate, options = {}) {
+    const errors = [];
+    const hashText = options.hashText;
+    if (typeof hashText !== "function") {
+      return { valid: false, errors: [{ path: "$", message: "hashText dependency is required" }] };
+    }
+    if (!hasSafeJsonShape(candidate)) {
+      return { valid: false, errors: [{ path: "$", message: "candidate exceeds nesting, node, or Unicode safety limits" }] };
+    }
+    const topKeys = [
+      "schema_version", "candidate_id", "method_ref", "authority", "case_ref", "state",
+      "created_at_utc", "updated_at_utc", "nodes", "relations", "metrics",
+      "iteration_decision", "next_experiment", "closure_check", "history"
+    ];
+    if (!sameKeys(candidate, topKeys)) {
+      return { valid: false, errors: [{ path: "$", message: "unknown or missing top-level properties" }] };
+    }
+    const nonCanonicalPath = findNonCanonicalString(candidate);
+    if (nonCanonicalPath) addError(errors, nonCanonicalPath, "must use NFC and LF canonical form");
+    if (candidate.schema_version !== SCHEMA_VERSION) addError(errors, "schema_version", "unsupported version");
+    if (!isId(candidate.candidate_id) || !/^learning-[A-Za-z0-9._:-]+$/.test(candidate.candidate_id)) addError(errors, "candidate_id", "must be a learning-* ID");
+    if (!sameKeys(candidate.method_ref, ["path", "sha256"]) || candidate.method_ref.path !== METHOD_PATH || candidate.method_ref.sha256 !== METHOD_SHA256) {
+      addError(errors, "method_ref", "method path or digest differs from the versioned workflow");
+    }
+    if (candidate.authority !== "local-non-canonical") addError(errors, "authority", "must remain local-non-canonical");
+    if (!isNonEmptyString(candidate.case_ref)) addError(errors, "case_ref", "required");
+    if (!STATES.has(candidate.state)) addError(errors, "state", "unknown state");
+    if (!isTimestamp(candidate.created_at_utc)) addError(errors, "created_at_utc", "invalid timestamp");
+    if (!isTimestamp(candidate.updated_at_utc)) addError(errors, "updated_at_utc", "invalid timestamp");
+    if (Date.parse(candidate.updated_at_utc) < Date.parse(candidate.created_at_utc)) addError(errors, "updated_at_utc", "precedes creation");
+    if (byteLength(stableStringify(candidate)) > MAX_ENTRY_BYTES) addError(errors, "$", "candidate exceeds 256 KiB record limit");
+
+    if (!Array.isArray(candidate.nodes)) {
+      addError(errors, "nodes", "must be an array");
+      return { valid: false, errors };
+    }
+    if (candidate.nodes.length < 8 || candidate.nodes.length > 512) addError(errors, "nodes", "node count outside contract");
+    candidate.nodes.forEach((node, index) => validateNode(node, index, hashText, errors));
+    const nodesById = new Map();
+    const recordIds = new Set();
+    candidate.nodes.forEach((node, index) => {
+      if (nodesById.has(node.node_id)) addError(errors, `nodes[${index}].node_id`, "duplicate node ID");
+      nodesById.set(node.node_id, node);
+      if (node.record_id) {
+        if (recordIds.has(node.record_id)) addError(errors, `nodes[${index}].record_id`, "duplicate record ID");
+        recordIds.add(node.record_id);
+      }
+    });
+    const counts = Object.fromEntries([...Object.keys(NODE_KEYS)].map((type) => [type, 0]));
+    candidate.nodes.forEach((node) => { if (Object.hasOwn(counts, node.node_type)) counts[node.node_type] += 1; });
+    [["case", 1, 1], ["claim", 1, Infinity], ["evidence", 1, Infinity], ["outcome", 1, 1], ["signal", 3, 10], ["diagnosis", 1, 1], ["gap", 1, 1], ["action", 1, 1]].forEach(([type, min, max]) => {
+      if (counts[type] < min || counts[type] > max) addError(errors, "nodes", `${type} count outside contract`);
+    });
+    const caseNode = candidate.nodes.find((node) => node.node_type === "case");
+    if (caseNode && caseNode.case_id !== candidate.case_ref) addError(errors, "case_ref", "does not match case node");
+    if (options.caseRevisionSha256 && caseNode?.revision_sha256 !== options.caseRevisionSha256) addError(errors, "nodes.case.revision_sha256", "does not match current case revision");
+
+    if (!Array.isArray(candidate.relations)) {
+      addError(errors, "relations", "must be an array");
+    } else {
+      if (candidate.relations.length < 8 || candidate.relations.length > 2048) addError(errors, "relations", "relation count outside contract");
+      const relationIds = new Set();
+      const relationKeys = new Set();
+      candidate.relations.forEach((relation, index) => {
+        const path = `relations[${index}]`;
+        const keys = ["relation_id", "type", "from_ref", "to_ref", "origin", "epistemic_status"];
+        if (!sameKeys(relation, keys)) {
+          addError(errors, path, "unknown relation properties");
+          return;
+        }
+        if (!isId(relation.relation_id) || relationIds.has(relation.relation_id)) addError(errors, `${path}.relation_id`, "invalid or duplicate ID");
+        relationIds.add(relation.relation_id);
+        const key = relationKey(relation.type, relation.from_ref, relation.to_ref);
+        if (relationKeys.has(key)) addError(errors, path, "duplicate semantic edge");
+        relationKeys.add(key);
+        const signature = RELATION_SIGNATURES[relation.type];
+        const from = nodesById.get(relation.from_ref);
+        const to = nodesById.get(relation.to_ref);
+        if (!signature) addError(errors, `${path}.type`, "unknown relation type");
+        if (!from || !to) addError(errors, path, "dangling relation reference");
+        if (signature && from && to && (from.node_type !== signature[0] || to.node_type !== signature[1])) addError(errors, path, "relation signature mismatch");
+        if (relation.origin === "system-suggested") {
+          addError(errors, `${path}.origin`, "system-suggested relations are forbidden in v1");
+        } else if (!["human-authored", "imported"].includes(relation.origin)) {
+          addError(errors, `${path}.origin`, "unknown origin");
+        }
+        const expectedOrigin = IMPORTED_RELATION_TYPES.has(relation.type) ? "imported" : "human-authored";
+        if (RELATION_SIGNATURES[relation.type] && relation.origin !== expectedOrigin) {
+          addError(errors, `${path}.origin`, `${relation.type} must be ${expectedOrigin}`);
+        }
+        if (!["observation", "submitted-claim", "corroboration", "inference", "proposal"].includes(relation.epistemic_status)) addError(errors, `${path}.epistemic_status`, "unknown epistemic status");
+        if (RELATION_EPISTEMIC_STATUS[relation.type] && relation.epistemic_status !== RELATION_EPISTEMIC_STATUS[relation.type]) {
+          addError(errors, `${path}.epistemic_status`, `must be ${RELATION_EPISTEMIC_STATUS[relation.type]} for ${relation.type}`);
+        }
+        if (from?.node_type === "signal") {
+          const expectedList = relation.type === "SIGNAL_REFERENCES_CLAIM" ? from.claim_refs : from.evidence_refs;
+          if (!expectedList?.includes(relation.to_ref)) addError(errors, path, "signal relation is not declared in node references");
+        }
+        if (from?.node_type === "diagnosis") {
+          const expectedList = relation.type === "DIAGNOSIS_INTERPRETS_SIGNAL" ? from.signal_refs : from.evidence_refs;
+          if (!expectedList?.includes(relation.to_ref)) addError(errors, path, "diagnosis relation is not declared in node references");
+        }
+      });
+      const evidenceClaimEdges = candidate.relations.filter((relation) => (
+        ["SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM"].includes(relation.type)
+      ));
+      if (!evidenceClaimEdges.length) addError(errors, "relations", "at least one evidence-to-claim relation is required");
+
+      candidate.nodes.filter((node) => node.node_type === "signal").forEach((node) => {
+        node.claim_refs.forEach((ref) => {
+          if (!relationKeys.has(relationKey("SIGNAL_REFERENCES_CLAIM", node.node_id, ref))) addError(errors, node.node_id, `missing claim relation to ${ref}`);
+        });
+        node.evidence_refs.forEach((ref) => {
+          if (!relationKeys.has(relationKey("SIGNAL_GROUNDED_IN_EVIDENCE", node.node_id, ref))) addError(errors, node.node_id, `missing evidence relation to ${ref}`);
+        });
+      });
+      const diagnosis = candidate.nodes.find((node) => node.node_type === "diagnosis");
+      if (diagnosis) {
+        const signalNodeIds = candidate.nodes
+          .filter((node) => node.node_type === "signal")
+          .map((node) => node.node_id)
+          .sort();
+        if (stableStringify([...diagnosis.signal_refs].sort()) !== stableStringify(signalNodeIds)) {
+          addError(errors, diagnosis.node_id, "diagnosis must interpret every signal exactly once");
+        }
+        diagnosis.signal_refs.forEach((ref) => {
+          if (!relationKeys.has(relationKey("DIAGNOSIS_INTERPRETS_SIGNAL", diagnosis.node_id, ref))) addError(errors, diagnosis.node_id, `missing signal relation to ${ref}`);
+        });
+        diagnosis.evidence_refs.forEach((ref) => {
+          if (!relationKeys.has(relationKey("DIAGNOSIS_REFERENCES_EVIDENCE", diagnosis.node_id, ref))) addError(errors, diagnosis.node_id, `missing evidence relation to ${ref}`);
+        });
+      }
+      const outcome = candidate.nodes.find((node) => node.node_type === "outcome");
+      const gap = candidate.nodes.find((node) => node.node_type === "gap");
+      const action = candidate.nodes.find((node) => node.node_type === "action");
+      if (outcome && caseNode && !relationKeys.has(relationKey("OUTCOME_OF_CASE", outcome.node_id, caseNode.node_id))) addError(errors, "relations", "outcome is not linked to case");
+      if (gap && diagnosis && !relationKeys.has(relationKey("GAP_IDENTIFIED_BY_DIAGNOSIS", gap.node_id, diagnosis.node_id))) addError(errors, "relations", "gap is not linked to diagnosis");
+      if (action && gap && !relationKeys.has(relationKey("ACTION_ADDRESSES_GAP", action.node_id, gap.node_id))) addError(errors, "relations", "action is not linked to gap");
+    }
+
+    if (!Array.isArray(candidate.metrics) || candidate.metrics.length < 3 || candidate.metrics.length > 5) {
+      addError(errors, "metrics", "three to five manual metrics are required");
+    } else {
+      const metricNames = new Set();
+      candidate.metrics.forEach((metric, index) => {
+        const path = `metrics[${index}]`;
+        if (!sameKeys(metric, ["name", "value"]) || !METRICS.has(metric.name) || metricNames.has(metric.name)) {
+          addError(errors, path, "unknown or duplicate metric");
+          return;
+        }
+        metricNames.add(metric.name);
+        const bounded = ["clarity", "verifiability", "viability"].includes(metric.name);
+        if (bounded && (!Number.isInteger(metric.value) || metric.value < 0 || metric.value > 5)) addError(errors, `${path}.value`, "must be an integer from 0 to 5");
+        if (metric.name === "open_points" && (!Number.isInteger(metric.value) || metric.value < 0)) addError(errors, `${path}.value`, "must be a non-negative integer");
+        if (metric.name === "open_points" && metric.value > 1000000) addError(errors, `${path}.value`, "exceeds metric limit");
+        if (metric.name === "time_to_draft_minutes" && (!Number.isFinite(metric.value) || metric.value < 0 || metric.value > 1000000)) addError(errors, `${path}.value`, "must be within the metric limit");
+      });
+    }
+    if (!DECISIONS.has(candidate.iteration_decision)) addError(errors, "iteration_decision", "unknown decision");
+    if (!isNonEmptyString(candidate.next_experiment)) addError(errors, "next_experiment", "required");
+    const closureKeys = ["final_text", "verification_owner", "scope_and_deadlines", "open_points", "minimum_patch"];
+    const validClosure = sameKeys(candidate.closure_check, closureKeys)
+      && closureKeys.every((key) => typeof candidate.closure_check[key] === "boolean");
+    if (!validClosure) addError(errors, "closure_check", "invalid closure checklist");
+    if (candidate.state === "accepted" && validClosure
+      && closureKeys.some((key) => candidate.closure_check[key] !== true)) {
+      addError(errors, "closure_check", "accepted candidates require all closure checks");
+    }
+    validateHistory(candidate.history, candidate.state, candidate.created_at_utc, candidate.updated_at_utc, errors);
+    return { valid: errors.length === 0, errors };
+  }
+
+  function safeNodeId(prefix, recordId) {
+    const cleaned = normalizeString(recordId).replace(/[^A-Za-z0-9._:-]/g, "-");
+    return `${prefix}:${cleaned}`.slice(0, 128);
+  }
+
+  function nextHistoryEventId(history) {
+    let maximum = 0n;
+    history.forEach((event) => {
+      const match = /^history:(\d+)$/.exec(event.event_id);
+      if (match) maximum = maximum > BigInt(match[1]) ? maximum : BigInt(match[1]);
+    });
+    const eventId = `history:${String(maximum + 1n).padStart(3, "0")}`;
+    if (!isId(eventId)) throw new Error("History event ID space is exhausted");
+    return eventId;
+  }
+
+  function candidateSnapshotMatchesLiveCase(candidate, liveCase, hashText) {
+    const caseNode = candidate.nodes.find((node) => node.node_type === "case");
+    if (!caseNode || !isObject(liveCase) || !Array.isArray(liveCase.claims)
+      || !Array.isArray(liveCase.evidence) || !Array.isArray(liveCase.relationships)) return false;
+    if (caseNode.case_id !== normalizeString(liveCase.case_id)
+      || caseNode.core_version_ref !== normalizeString(liveCase.core_version_ref)
+      || caseNode.revision_sha256 !== liveCase.revision_sha256) return false;
+
+    const claimNodes = candidate.nodes.filter((node) => node.node_type === "claim");
+    const evidenceNodes = candidate.nodes.filter((node) => node.node_type === "evidence");
+    if (claimNodes.length !== liveCase.claims.length || evidenceNodes.length !== liveCase.evidence.length) return false;
+    const claimsByRecord = new Map(claimNodes.map((node) => [node.record_id, node]));
+    const evidenceByRecord = new Map(evidenceNodes.map((node) => [node.record_id, node]));
+    if (claimsByRecord.size !== claimNodes.length || evidenceByRecord.size !== evidenceNodes.length) return false;
+
+    for (const record of liveCase.claims) {
+      const node = claimsByRecord.get(record.claim_id);
+      const text = normalizeString(record.text);
+      const sourceRef = safeSourceRef(record.source_ref);
+      if (!node || !sourceRef || node.node_id !== safeNodeId("claim", record.claim_id)
+        || node.text !== text || node.text_sha256 !== hashText(text)
+        || node.source_ref !== sourceRef) return false;
+    }
+    for (const record of liveCase.evidence) {
+      const node = evidenceByRecord.get(record.evidence_id);
+      const text = normalizeString(record.text);
+      const sourceRef = safeSourceRef(record.source_ref);
+      const limitations = Array.isArray(record.limitations) ? record.limitations.map(normalizeString) : [];
+      if (!node || !sourceRef || node.node_id !== safeNodeId("evidence", record.evidence_id)
+        || node.text !== text || node.text_sha256 !== hashText(text)
+        || node.source_ref !== sourceRef
+        || stableStringify(node.limitations) !== stableStringify(limitations)) return false;
+    }
+
+    const expectedRelations = [];
+    for (const relation of liveCase.relationships) {
+      if (!isObject(relation) || !["SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM"].includes(relation.type)) return false;
+      const from = evidenceByRecord.get(relation.from_ref);
+      const to = claimsByRecord.get(relation.to_ref);
+      if (!from || !to) return false;
+      expectedRelations.push(stableStringify({
+        type: relation.type,
+        from_ref: from.node_id,
+        to_ref: to.node_id,
+        origin: "imported",
+        epistemic_status: RELATION_EPISTEMIC_STATUS[relation.type]
+      }));
+    }
+    const actualRelations = candidate.relations
+      .filter((relation) => ["SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM"].includes(relation.type))
+      .map((relation) => stableStringify({
+        type: relation.type,
+        from_ref: relation.from_ref,
+        to_ref: relation.to_ref,
+        origin: relation.origin,
+        epistemic_status: relation.epistemic_status
+      }));
+    return stableStringify(expectedRelations.sort()) === stableStringify(actualRelations.sort());
+  }
+
+  function buildCandidate(input, options = {}) {
+    const hashText = options.hashText;
+    const nowValue = options.now === undefined ? new Date().toISOString() : options.now;
+    if (typeof hashText !== "function") throw new Error("hashText dependency is required");
+    if (typeof nowValue !== "string") throw new Error("A valid UTC creation timestamp is required");
+    const now = normalizeString(nowValue);
+    const capturedInput = snapshotJsonValue(input);
+    if (!capturedInput.valid || !isObject(capturedInput.value)) {
+      throw new Error("Learning candidate input must contain only own, plain JSON data");
+    }
+    const submitted = capturedInput.value;
+    const requiredInputKeys = [
+      "candidate_id", "case_record", "outcome", "signals", "diagnosis", "gap",
+      "action", "metrics", "iteration_decision", "next_experiment", "closure_check"
+    ];
+    const allowedInputKeys = new Set([...requiredInputKeys, "creation_note"]);
+    const inputShapeValid = requiredInputKeys.every((key) => Object.prototype.hasOwnProperty.call(submitted, key))
+      && Object.keys(submitted).every((key) => allowedInputKeys.has(key))
+      && typeof submitted.candidate_id === "string"
+      && typeof submitted.outcome === "string"
+      && typeof submitted.gap === "string"
+      && typeof submitted.iteration_decision === "string"
+      && typeof submitted.next_experiment === "string"
+      && (submitted.creation_note === undefined || typeof submitted.creation_note === "string")
+      && Array.isArray(submitted.signals)
+      && submitted.signals.every((signal) => sameKeys(signal, ["text", "claim_refs", "evidence_refs"])
+        && typeof signal.text === "string"
+        && Array.isArray(signal.claim_refs) && signal.claim_refs.every((ref) => typeof ref === "string")
+        && Array.isArray(signal.evidence_refs) && signal.evidence_refs.every((ref) => typeof ref === "string"))
+      && sameKeys(submitted.diagnosis, ["text", "categories", "evidence_refs"])
+      && typeof submitted.diagnosis.text === "string"
+      && Array.isArray(submitted.diagnosis.categories)
+      && submitted.diagnosis.categories.every((item) => typeof item === "string")
+      && Array.isArray(submitted.diagnosis.evidence_refs)
+      && submitted.diagnosis.evidence_refs.every((ref) => typeof ref === "string")
+      && sameKeys(submitted.action, ["change", "reason", "verification_criterion"])
+      && ["change", "reason", "verification_criterion"].every((key) => typeof submitted.action[key] === "string")
+      && Array.isArray(submitted.metrics)
+      && submitted.metrics.every((metric) => sameKeys(metric, ["name", "value"])
+        && typeof metric.name === "string" && typeof metric.value === "number")
+      && isObject(submitted.closure_check);
+    if (!inputShapeValid) throw new Error("Learning candidate input shape is invalid");
+    if (!isObject(submitted.case_record)) throw new Error("case_record is required");
+    const caseRecord = ownCanonicalCaseRecord(submitted.case_record);
+    if (!caseRecord) throw new Error("case_record must contain only own, plain JSON data");
+    if (!isSha256(caseRecord.revision_sha256) || computeCaseRevision(caseRecord, { hashText }) !== caseRecord.revision_sha256) {
+      throw new Error("case_record revision_sha256 does not match its canonical content");
+    }
+    const caseNodeId = safeNodeId("case", caseRecord.case_id);
+    const claimMap = new Map();
+    const evidenceMap = new Map();
+    const nodes = [{
+      node_id: caseNodeId,
+      node_type: "case",
+      case_id: normalizeString(caseRecord.case_id),
+      core_version_ref: normalizeString(caseRecord.core_version_ref),
+      revision_sha256: normalizeString(caseRecord.revision_sha256)
+    }];
+    (caseRecord.claims || []).forEach((record) => {
+      const nodeId = safeNodeId("claim", record.claim_id);
+      claimMap.set(record.claim_id, nodeId);
+      const text = normalizeString(record.text);
+      nodes.push({ node_id: nodeId, node_type: "claim", record_id: record.claim_id, text, text_sha256: hashText(text), source_ref: safeSourceRef(record.source_ref) });
+    });
+    (caseRecord.evidence || []).forEach((record) => {
+      const nodeId = safeNodeId("evidence", record.evidence_id);
+      evidenceMap.set(record.evidence_id, nodeId);
+      const text = normalizeString(record.text);
+      nodes.push({ node_id: nodeId, node_type: "evidence", record_id: record.evidence_id, text, text_sha256: hashText(text), source_ref: safeSourceRef(record.source_ref), limitations: (record.limitations || []).map(normalizeString) });
+    });
+    const outcomeId = "outcome:001";
+    const diagnosisId = "diagnosis:001";
+    const gapId = "gap:001";
+    const actionId = "action:001";
+    nodes.push({ node_id: outcomeId, node_type: "outcome", text: normalizeString(submitted.outcome) });
+    const signalIds = [];
+    submitted.signals.forEach((signal, index) => {
+      const nodeId = `signal:${String(index + 1).padStart(3, "0")}`;
+      signalIds.push(nodeId);
+      nodes.push({
+        node_id: nodeId,
+        node_type: "signal",
+        text: normalizeString(signal.text),
+        claim_refs: (signal.claim_refs || []).map((ref) => claimMap.get(ref) || ref),
+        evidence_refs: (signal.evidence_refs || []).map((ref) => evidenceMap.get(ref) || ref)
+      });
+    });
+    const diagnosisEvidenceRefs = submitted.diagnosis.evidence_refs.map((ref) => evidenceMap.get(ref) || ref);
+    nodes.push({ node_id: diagnosisId, node_type: "diagnosis", text: normalizeString(submitted.diagnosis.text), categories: [...submitted.diagnosis.categories], signal_refs: [...signalIds], evidence_refs: diagnosisEvidenceRefs });
+    nodes.push({ node_id: gapId, node_type: "gap", text: normalizeString(submitted.gap) });
+    nodes.push({ node_id: actionId, node_type: "action", change: normalizeString(submitted.action.change), reason: normalizeString(submitted.action.reason), verification_criterion: normalizeString(submitted.action.verification_criterion) });
+
+    const relations = [];
+    function addRelation(type, fromRef, toRef, epistemicStatus, origin = "human-authored") {
+      relations.push({ relation_id: `relation:${String(relations.length + 1).padStart(3, "0")}`, type, from_ref: fromRef, to_ref: toRef, origin, epistemic_status: epistemicStatus });
+    }
+    addRelation("OUTCOME_OF_CASE", outcomeId, caseNodeId, "observation");
+    (caseRecord.relationships || []).forEach((relation) => {
+      const from = evidenceMap.get(relation.from_ref);
+      const to = claimMap.get(relation.to_ref);
+      if (!from || !to || !["SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM"].includes(relation.type)) return;
+      addRelation(relation.type, from, to, relation.type === "SUPPORTS_ATTRIBUTION" ? "submitted-claim" : "corroboration", "imported");
+    });
+    nodes.filter((node) => node.node_type === "signal").forEach((signal) => {
+      signal.claim_refs.forEach((ref) => addRelation("SIGNAL_REFERENCES_CLAIM", signal.node_id, ref, "observation"));
+      signal.evidence_refs.forEach((ref) => addRelation("SIGNAL_GROUNDED_IN_EVIDENCE", signal.node_id, ref, "observation"));
+      addRelation("DIAGNOSIS_INTERPRETS_SIGNAL", diagnosisId, signal.node_id, "inference");
+    });
+    diagnosisEvidenceRefs.forEach((ref) => addRelation("DIAGNOSIS_REFERENCES_EVIDENCE", diagnosisId, ref, "inference"));
+    addRelation("GAP_IDENTIFIED_BY_DIAGNOSIS", gapId, diagnosisId, "inference");
+    addRelation("ACTION_ADDRESSES_GAP", actionId, gapId, "proposal");
+
+    const candidate = {
+      schema_version: SCHEMA_VERSION,
+      candidate_id: normalizeString(submitted.candidate_id),
+      method_ref: { path: METHOD_PATH, sha256: METHOD_SHA256 },
+      authority: "local-non-canonical",
+      case_ref: normalizeString(caseRecord.case_id),
+      state: "draft",
+      created_at_utc: now,
+      updated_at_utc: now,
+      nodes,
+      relations,
+      metrics: submitted.metrics.map((metric) => ({ name: metric.name, value: metric.value })),
+      iteration_decision: submitted.iteration_decision,
+      next_experiment: normalizeString(submitted.next_experiment),
+      closure_check: { ...submitted.closure_check },
+      history: [{ event_id: "history:001", at_utc: now, actor: "human-operator", action: "created", from_state: null, to_state: "draft", note: normalizeString(submitted.creation_note || "Created by the human operator as a local candidate.") }]
+    };
+    const validation = validateCandidate(candidate, { hashText });
+    if (!validation.valid) throw new Error(`Invalid learning candidate: ${validation.errors.map((item) => `${item.path}: ${item.message}`).join("; ")}`);
+    if (!candidateSnapshotMatchesLiveCase(candidate, caseRecord, hashText)) {
+      throw new Error("Learning candidate snapshot does not match the supplied case record");
+    }
+    return canonicalValue(candidate);
+  }
+
+  function transitionCandidate(candidate, nextState, note, options = {}) {
+    const hashText = options.hashText;
+    const before = validateCandidate(candidate, { hashText });
+    if (!before.valid) throw new Error("Cannot transition an invalid learning candidate");
+    if (!STATES.has(nextState)) throw new Error("Unknown candidate state");
+    if (!isNonEmptyString(note)) throw new Error("A human transition note is required");
+    if (nextState === "accepted") {
+      const closureKeys = ["final_text", "verification_owner", "scope_and_deadlines", "open_points", "minimum_patch"];
+      if (closureKeys.some((key) => candidate.closure_check[key] !== true)) {
+        throw new Error("All closure checks must be satisfied before local acceptance");
+      }
+      const liveBinding = evaluateFreshness(candidate, options.liveCase, { hashText, now: options.now });
+      if (liveBinding.freshness !== "current") throw new Error("Only a current candidate can be accepted locally");
+    }
+    const fromState = candidate.state;
+    const allowed = (
+      (fromState === "draft" && ["accepted", "rejected"].includes(nextState))
+      || (["accepted", "rejected"].includes(fromState) && nextState === "draft")
+    );
+    if (!allowed) throw new Error(`Forbidden state transition: ${fromState} -> ${nextState}`);
+    const nowValue = options.now === undefined ? new Date().toISOString() : options.now;
+    if (typeof nowValue !== "string") throw new Error("A valid UTC transition timestamp is required");
+    const now = normalizeString(nowValue);
+    const updated = canonicalValue(candidate);
+    updated.state = nextState;
+    updated.updated_at_utc = now;
+    updated.history.push({ event_id: nextHistoryEventId(updated.history), at_utc: now, actor: "human-operator", action: "state-change", from_state: fromState, to_state: nextState, note: normalizeString(note) });
+    const validation = validateCandidate(updated, { hashText });
+    if (!validation.valid) throw new Error("State transition produced an invalid learning candidate");
+    return canonicalValue(updated);
+  }
+
+  function evaluateFreshness(candidate, liveCase, options = {}) {
+    const nowValue = options.now === undefined ? new Date().toISOString() : options.now;
+    if (typeof nowValue !== "string") throw new Error("A valid UTC freshness timestamp is required");
+    const checkedAt = normalizeString(nowValue);
+    const hashText = options.hashText;
+    if (!isTimestamp(checkedAt)) throw new Error("A valid UTC freshness timestamp is required");
+    if (typeof hashText !== "function") {
+      return { freshness: "invalid", checked_case_sha256: null, reason: "hash dependency is unavailable", checked_at_utc: checkedAt };
+    }
+    const candidateValidation = validateCandidate(candidate, { hashText });
+    if (!candidateValidation.valid) {
+      return { freshness: "invalid", checked_case_sha256: null, reason: "learning candidate is invalid", checked_at_utc: checkedAt };
+    }
+    const caseNode = candidate.nodes.find((node) => node.node_type === "case");
+    const liveSnapshot = ownCanonicalCaseRecord(liveCase);
+    if (!liveSnapshot) {
+      return { freshness: "invalid", checked_case_sha256: null, reason: "live case is not own, plain JSON data", checked_at_utc: checkedAt };
+    }
+    if (liveSnapshot.case_id !== candidate.case_ref || liveSnapshot.case_id !== caseNode?.case_id) {
+      return { freshness: "invalid", checked_case_sha256: liveSnapshot.revision_sha256 || null, reason: "case identity changed", checked_at_utc: checkedAt };
+    }
+    let computedRevision;
+    try {
+      computedRevision = computeCaseRevision(liveSnapshot, { hashText });
+    } catch {
+      return { freshness: "invalid", checked_case_sha256: null, reason: "case revision cannot be computed", checked_at_utc: checkedAt };
+    }
+    if (!isSha256(liveSnapshot.revision_sha256) || computedRevision !== liveSnapshot.revision_sha256) {
+      return { freshness: "invalid", checked_case_sha256: computedRevision, reason: "declared case revision does not match current content", checked_at_utc: checkedAt };
+    }
+    const claimIds = new Set((liveSnapshot.claims || []).map((record) => record.claim_id));
+    const evidenceIds = new Set((liveSnapshot.evidence || []).map((record) => record.evidence_id));
+    const missing = candidate.nodes.some((node) => (
+      (node.node_type === "claim" && !claimIds.has(node.record_id))
+      || (node.node_type === "evidence" && !evidenceIds.has(node.record_id))
+    ));
+    if (missing) return { freshness: "invalid", checked_case_sha256: computedRevision, reason: "referenced claim or evidence is missing", checked_at_utc: checkedAt };
+    if (computedRevision !== caseNode.revision_sha256) return { freshness: "stale", checked_case_sha256: computedRevision, reason: "case content changed", checked_at_utc: checkedAt };
+    if (!candidateSnapshotMatchesLiveCase(candidate, liveSnapshot, hashText)) {
+      return { freshness: "invalid", checked_case_sha256: computedRevision, reason: "candidate snapshot differs from the live case", checked_at_utc: checkedAt };
+    }
+    return { freshness: "current", checked_case_sha256: computedRevision, reason: "case identity, full snapshot and revision match", checked_at_utc: checkedAt };
+  }
+
+  function createStore() {
+    return { store_version: STORE_VERSION, entries: [] };
+  }
+
+  function validateStore(store, options = {}) {
+    if (typeof options.hashText !== "function") return false;
+    if (!hasSafeJsonShape(store, 32, 2000000)) return false;
+    const structurallyValid = sameKeys(store, ["store_version", "entries"])
+      && store.store_version === STORE_VERSION
+      && Array.isArray(store.entries)
+      && store.entries.length <= MAX_ENTRIES
+      && store.entries.every((entry) => sameKeys(entry, ["candidate", "binding"]));
+    if (!structurallyValid) return false;
+    const ids = store.entries.map((entry) => entry.candidate?.candidate_id);
+    if (new Set(ids).size !== ids.length) return false;
+    return store.entries.every((entry) => (
+      byteLength(stableStringify(entry)) <= MAX_ENTRY_BYTES
+      && validateBinding(entry.binding)
+      && validateCandidate(entry.candidate, { hashText: options.hashText }).valid
+      && bindingMatchesCandidate(entry.binding, entry.candidate)
+    ));
+  }
+
+  function validateBinding(binding) {
+    return sameKeys(binding, ["freshness", "checked_case_sha256", "reason", "checked_at_utc"])
+      && ["current", "stale", "invalid"].includes(binding.freshness)
+      && (binding.checked_case_sha256 === null || isSha256(binding.checked_case_sha256))
+      && isNonEmptyString(binding.reason)
+      && isTimestamp(binding.checked_at_utc);
+  }
+
+  function bindingMatchesCandidate(binding, candidate) {
+    const caseNode = candidate.nodes.find((node) => node.node_type === "case");
+    if (!caseNode) return false;
+    if (binding.freshness === "current") return binding.checked_case_sha256 === caseNode.revision_sha256;
+    if (binding.freshness === "stale") {
+      return isSha256(binding.checked_case_sha256)
+        && binding.checked_case_sha256 !== caseNode.revision_sha256;
+    }
+    return binding.freshness === "invalid";
+  }
+
+  function insertEntry(store, entry, options = {}) {
+    if (!validateStore(store, { hashText: options.hashText })) throw new Error("Invalid learning store");
+    if (!sameKeys(entry, ["candidate", "binding"])) throw new Error("Invalid learning entry");
+    if (!validateBinding(entry.binding)) throw new Error("Invalid learning freshness binding");
+    const validation = validateCandidate(entry.candidate, { hashText: options.hashText });
+    if (!validation.valid) throw new Error("Invalid learning candidate cannot be stored");
+    if (!bindingMatchesCandidate(entry.binding, entry.candidate)) throw new Error("Learning freshness binding does not match candidate revision");
+    const maxEntries = boundedLimit(options.maxEntries, MAX_ENTRIES, "maxEntries");
+    const maxEntryBytes = boundedLimit(options.maxEntryBytes, MAX_ENTRY_BYTES, "maxEntryBytes");
+    if (byteLength(stableStringify(entry)) > maxEntryBytes) throw new Error("Learning candidate exceeds local size limit");
+    const existing = store.entries.find((item) => item.candidate.candidate_id === entry.candidate.candidate_id);
+    if (existing) {
+      if (stableStringify(existing) === stableStringify(entry)) return canonicalValue(store);
+      throw new Error("Candidate ID conflict; existing local record was not overwritten");
+    }
+    if (store.entries.length >= maxEntries) throw new Error("Learning store is full; export or delete records before saving another");
+    return canonicalValue({ store_version: STORE_VERSION, entries: [...store.entries, entry] });
+  }
+
+  function deleteCaseEntries(store, caseId, options = {}) {
+    if (typeof options.hashText !== "function") throw new Error("hashText dependency is required");
+    if (!validateStore(store, { hashText: options.hashText })) throw new Error("Invalid learning store");
+    const removed = store.entries.filter((entry) => entry.candidate.case_ref === caseId).length;
+    return { removed, store: canonicalValue({ store_version: STORE_VERSION, entries: store.entries.filter((entry) => entry.candidate.case_ref !== caseId) }) };
+  }
+
+  function createExport(candidate, options = {}) {
+    const hashText = options.hashText;
+    if (typeof hashText !== "function") throw new Error("hashText dependency is required");
+    const validation = validateCandidate(candidate, { hashText });
+    if (!validation.valid) throw new Error("Invalid learning candidate cannot be exported");
+    const nowValue = options.now === undefined ? new Date().toISOString() : options.now;
+    if (typeof nowValue !== "string") throw new Error("A valid UTC export timestamp is required");
+    const exportedAt = normalizeString(nowValue);
+    if (!isTimestamp(exportedAt)) throw new Error("A valid UTC export timestamp is required");
+    return canonicalValue({
+      export_version: EXPORT_VERSION,
+      candidate_sha256: hashText(stableStringify(candidate)),
+      exported_at_utc: exportedAt,
+      candidate: canonicalValue(candidate)
+    });
+  }
+
+  function parseImport(text, options = {}) {
+    const hashText = options.hashText;
+    if (typeof hashText !== "function") throw new Error("hashText dependency is required");
+    if (typeof text !== "string") throw new Error("Import must be a JSON string");
+    const maxImportBytes = boundedLimit(options.maxImportBytes, MAX_IMPORT_BYTES, "maxImportBytes");
+    if (byteLength(text) > maxImportBytes) throw new Error("Import exceeds 1 MiB limit");
+    let payload;
+    try { payload = JSON.parse(text); } catch { throw new Error("Import is not valid JSON"); }
+    if (!hasSafeJsonShape(payload)) throw new Error("Import exceeds nesting, node, or Unicode safety limits");
+    if (!sameKeys(payload, ["export_version", "candidate_sha256", "exported_at_utc", "candidate"])) throw new Error("Unknown or missing export properties");
+    if (payload.export_version !== EXPORT_VERSION) throw new Error("Unsupported learning export version");
+    if (!isTimestamp(payload.exported_at_utc)) throw new Error("Invalid export timestamp");
+    if (hashText(stableStringify(payload.candidate)) !== payload.candidate_sha256) throw new Error("Learning export checksum mismatch");
+    const validation = validateCandidate(payload.candidate, { hashText });
+    if (!validation.valid) throw new Error(`Invalid imported candidate: ${validation.errors.map((item) => `${item.path}: ${item.message}`).join("; ")}`);
+    return canonicalValue(payload.candidate);
+  }
+
+  globalThis.HUB_OPTIMUS_LEARNING_CANDIDATE_V1 = Object.freeze({
+    schemaVersion: SCHEMA_VERSION,
+    storeVersion: STORE_VERSION,
+    exportVersion: EXPORT_VERSION,
+    methodPath: METHOD_PATH,
+    methodSha256: METHOD_SHA256,
+    limits: Object.freeze({ maxEntries: MAX_ENTRIES, maxEntryBytes: MAX_ENTRY_BYTES, maxImportBytes: MAX_IMPORT_BYTES }),
+    normalizeString,
+    canonicalValue,
+    stableStringify,
+    hasSafeJsonShape,
+    computeCaseRevision,
+    validateCandidate,
+    buildCandidate,
+    transitionCandidate,
+    evaluateFreshness,
+    createStore,
+    validateStore,
+    insertEntry,
+    deleteCaseEntries,
+    createExport,
+    parseImport
+  });
+})();

--- a/site/operator/learning-store.v1.js
+++ b/site/operator/learning-store.v1.js
@@ -1,0 +1,694 @@
+(() => {
+  "use strict";
+
+  const DB_NAME = "hub_optimus_operator_learning_v1";
+  const DB_VERSION = 1;
+  const OBJECT_STORE_NAME = "learning_store";
+  const RECORD_KEY = "operator_learning_store.v1";
+  const STORE_VERSION = "operator_learning_store.v1";
+  const MAX_AGGREGATE_BYTES = 16 * 1024 * 1024;
+  const CLEAR_CONFIRMATION = "DELETE ALL LOCAL LEARNING CANDIDATES";
+  const SHA256_TEST_VECTORS = Object.freeze([
+    Object.freeze(["", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]),
+    Object.freeze(["abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"])
+  ]);
+  const REVIEWED_STATES = new Set(["accepted", "rejected"]);
+  const CLOSURE_KEYS = Object.freeze([
+    "final_text",
+    "verification_owner",
+    "scope_and_deadlines",
+    "open_points",
+    "minimum_patch"
+  ]);
+  const ERROR_CODES = Object.freeze([
+    "unavailable",
+    "blocked",
+    "corrupt",
+    "quota",
+    "conflict"
+  ]);
+
+  class LearningStoreError extends Error {
+    constructor(code, message, cause) {
+      super(message);
+      this.name = "LearningStoreError";
+      this.code = ERROR_CODES.includes(code) ? code : "corrupt";
+      if (cause !== undefined) this.cause = cause;
+    }
+  }
+
+  function classified(error, fallback = "corrupt") {
+    if (error instanceof LearningStoreError) return error;
+    const name = String(error?.name || "");
+    if (name === "QuotaExceededError") {
+      return new LearningStoreError("quota", "IndexedDB quota prevented the learning-store write", error);
+    }
+    if (["VersionError", "InvalidStateError", "NotSupportedError", "SecurityError"].includes(name)) {
+      return new LearningStoreError("unavailable", "IndexedDB is unavailable for the learning store", error);
+    }
+    return new LearningStoreError(fallback, "The local learning store operation failed closed", error);
+  }
+
+  function requestResult(request, fallback = "corrupt") {
+    return new Promise((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(classified(request.error, fallback));
+    });
+  }
+
+  function transactionCompletion(transaction) {
+    return new Promise((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onabort = () => reject(classified(transaction.error, "corrupt"));
+      transaction.onerror = () => {};
+    });
+  }
+
+  function objectStoreNames(database) {
+    const names = [];
+    for (let index = 0; index < database.objectStoreNames.length; index += 1) {
+      names.push(database.objectStoreNames[index]);
+    }
+    return names;
+  }
+
+  function indexNames(objectStore) {
+    const names = [];
+    for (let index = 0; index < objectStore.indexNames.length; index += 1) {
+      names.push(objectStore.indexNames[index]);
+    }
+    return names;
+  }
+
+  function hasExpectedObjectStoreSchema(objectStore) {
+    try {
+      return objectStore.keyPath === null
+        && objectStore.autoIncrement === false
+        && indexNames(objectStore).length === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  function exactKeys(value, keys) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length
+      && actual.every((key, index) => key === expected[index]);
+  }
+
+  function isSha256(value) {
+    return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+  }
+
+  function isCandidateId(value) {
+    return typeof value === "string" && /^learning-[A-Za-z0-9._:-]+$/.test(value) && value.length <= 128;
+  }
+
+  function boundedAggregateLimit(value) {
+    if (value === undefined) return MAX_AGGREGATE_BYTES;
+    if (!Number.isInteger(value) || value < 1) {
+      throw new LearningStoreError("unavailable", "maxAggregateBytes must be a positive integer");
+    }
+    return Math.min(value, MAX_AGGREGATE_BYTES);
+  }
+
+  function isSha256Dependency(hashText) {
+    if (typeof hashText !== "function") return false;
+    try {
+      return SHA256_TEST_VECTORS.every(([input, expected]) => hashText(input) === expected);
+    } catch {
+      return false;
+    }
+  }
+
+  function createAdapter(options = {}) {
+    const model = options.model || globalThis.HUB_OPTIMUS_LEARNING_CANDIDATE_V1;
+    const factory = Object.prototype.hasOwnProperty.call(options, "indexedDB")
+      ? options.indexedDB
+      : globalThis.indexedDB;
+    const hashText = options.hashText;
+    const maxAggregateBytes = boundedAggregateLimit(options.maxAggregateBytes);
+    const now = typeof options.now === "function" ? options.now : () => new Date().toISOString();
+
+    const requiredModelMethods = [
+      "createStore",
+      "validateStore",
+      "insertEntry",
+      "deleteCaseEntries",
+      "stableStringify",
+      "canonicalValue",
+      "hasSafeJsonShape",
+      "parseImport",
+      "createExport"
+    ];
+    if (!model || requiredModelMethods.some((name) => typeof model[name] !== "function")) {
+      throw new LearningStoreError("unavailable", "The versioned learning-candidate model is unavailable");
+    }
+    if (model.storeVersion !== STORE_VERSION || !isSha256Dependency(hashText)) {
+      throw new LearningStoreError("unavailable", "The learning-store model version or hash dependency is unavailable");
+    }
+    if (!model.limits || model.limits.maxEntries !== 50 || model.limits.maxEntryBytes !== 256 * 1024) {
+      throw new LearningStoreError("unavailable", "The learning-store entry limits do not match version 1");
+    }
+    if (!factory || typeof factory.open !== "function" || typeof TextEncoder !== "function") {
+      throw new LearningStoreError("unavailable", "IndexedDB is unavailable for the learning store");
+    }
+
+    function byteLength(value) {
+      return new TextEncoder().encode(String(value)).byteLength;
+    }
+
+    function canonicalClone(value) {
+      return JSON.parse(model.stableStringify(value));
+    }
+
+    function digest(value) {
+      const result = hashText(model.stableStringify(value));
+      if (!isSha256(result)) {
+        throw new LearningStoreError("unavailable", "The hash dependency did not return a SHA-256 digest");
+      }
+      return result;
+    }
+
+    function caseRevision(candidate) {
+      const caseNodes = candidate.nodes.filter((node) => node.node_type === "case");
+      if (caseNodes.length !== 1 || !isSha256(caseNodes[0].revision_sha256)) {
+        throw new LearningStoreError("corrupt", "The candidate has no unique case revision");
+      }
+      return caseNodes[0].revision_sha256;
+    }
+
+    function candidateToken(entry) {
+      return Object.freeze({
+        candidate_id: entry.candidate.candidate_id,
+        candidate_sha256: digest(entry.candidate),
+        case_revision_sha256: caseRevision(entry.candidate),
+        entry_sha256: digest(entry)
+      });
+    }
+
+    function presentEntry(entry) {
+      return Object.freeze({
+        ...candidateToken(entry),
+        entry: canonicalClone(entry)
+      });
+    }
+
+    function assertStore(store, phase = "load") {
+      let valid = false;
+      try {
+        valid = model.validateStore(store, { hashText });
+      } catch (error) {
+        throw new LearningStoreError("corrupt", "The local learning store could not be validated", error);
+      }
+      if (!valid) {
+        throw new LearningStoreError("corrupt", "The local learning store failed model validation");
+      }
+      const bytes = byteLength(model.stableStringify(store));
+      if (bytes > maxAggregateBytes) {
+        const code = phase === "write" ? "quota" : "corrupt";
+        throw new LearningStoreError(code, "The local learning store exceeds the aggregate byte limit");
+      }
+      return canonicalClone(store);
+    }
+
+    function normalizeEntry(entry) {
+      if (!model.hasSafeJsonShape(entry)) {
+        throw new LearningStoreError("corrupt", "The learning entry is not safe plain JSON data");
+      }
+      let entryBytes;
+      try {
+        entryBytes = byteLength(model.stableStringify(entry));
+      } catch (error) {
+        throw new LearningStoreError("corrupt", "The learning entry is not canonical JSON", error);
+      }
+      if (entryBytes > model.limits.maxEntryBytes) {
+        throw new LearningStoreError("quota", "The learning entry exceeds the 256 KiB limit");
+      }
+      const single = { store_version: STORE_VERSION, entries: [entry] };
+      const validated = assertStore(single, "write");
+      return validated.entries[0];
+    }
+
+    function storeDigest(store) {
+      return digest(store);
+    }
+
+    function transitionInvariant(candidate) {
+      const invariant = canonicalClone(candidate);
+      delete invariant.state;
+      delete invariant.updated_at_utc;
+      delete invariant.history;
+      return invariant;
+    }
+
+    function assertPureTransition(previous, next) {
+      if (model.stableStringify(transitionInvariant(previous))
+        !== model.stableStringify(transitionInvariant(next))) {
+        throw new LearningStoreError("conflict", "A reviewed-state transition cannot bundle candidate edits");
+      }
+      if (!Array.isArray(previous.history) || !Array.isArray(next.history)
+        || next.history.length !== previous.history.length + 1) {
+        throw new LearningStoreError("conflict", "A reviewed-state transition must append exactly one history event");
+      }
+      for (let index = 0; index < previous.history.length; index += 1) {
+        if (model.stableStringify(previous.history[index]) !== model.stableStringify(next.history[index])) {
+          throw new LearningStoreError("conflict", "A reviewed-state transition cannot rewrite history");
+        }
+      }
+      const event = next.history[next.history.length - 1];
+      if (!event || event.action !== "state-change"
+        || event.from_state !== previous.state
+        || event.to_state !== next.state
+        || event.at_utc !== next.updated_at_utc) {
+        throw new LearningStoreError("conflict", "The appended history event does not match the state transition");
+      }
+    }
+
+    function assertCandidateReplacement(previous, next, binding) {
+      if (model.stableStringify(previous) === model.stableStringify(next)) return;
+      const from = previous.state;
+      const to = next.state;
+      if (REVIEWED_STATES.has(from) && to === "draft") {
+        assertPureTransition(previous, next);
+        return;
+      }
+      if (from === "draft" && REVIEWED_STATES.has(to)) {
+        assertPureTransition(previous, next);
+        if (to === "accepted") {
+          if (CLOSURE_KEYS.some((key) => next.closure_check?.[key] !== true)
+            || binding.freshness !== "current") {
+            throw new LearningStoreError("conflict", "Local acceptance requires complete closure and a current binding");
+          }
+        }
+        return;
+      }
+      throw new LearningStoreError("conflict", "Candidate content is append-only for a candidate ID; create a new draft ID for edited content");
+    }
+
+    function expectedState(expectations, existing) {
+      const keys = [
+        "expectedCandidateSha256",
+        "expectedCaseRevisionSha256",
+        "expectedEntrySha256"
+      ];
+      if (!model.hasSafeJsonShape(expectations) || !exactKeys(expectations, keys)) {
+        throw new LearningStoreError("conflict", "All previous entry tokens are required");
+      }
+      if (!existing) {
+        if (expectations.expectedCandidateSha256 !== null
+          || expectations.expectedCaseRevisionSha256 !== null
+          || expectations.expectedEntrySha256 !== null) {
+          throw new LearningStoreError("conflict", "The expected candidate no longer matches local state");
+        }
+        return;
+      }
+      if (!isSha256(expectations.expectedCandidateSha256)
+        || !isSha256(expectations.expectedCaseRevisionSha256)
+        || !isSha256(expectations.expectedEntrySha256)) {
+        throw new LearningStoreError("conflict", "The expected entry tokens are invalid");
+      }
+      const actual = candidateToken(existing);
+      if (actual.candidate_sha256 !== expectations.expectedCandidateSha256
+        || actual.case_revision_sha256 !== expectations.expectedCaseRevisionSha256
+        || actual.entry_sha256 !== expectations.expectedEntrySha256) {
+        throw new LearningStoreError("conflict", "The candidate changed since it was read");
+      }
+    }
+
+    function expectedCaseSet(store, caseId, expectedCandidates) {
+      if (!model.hasSafeJsonShape(expectedCandidates) || !Array.isArray(expectedCandidates)) {
+        throw new LearningStoreError("conflict", "Expected case candidate tokens are required");
+      }
+      const actual = store.entries
+        .filter((entry) => entry.candidate.case_ref === caseId)
+        .map(candidateToken)
+        .sort((left, right) => left.candidate_id.localeCompare(right.candidate_id));
+      const expected = expectedCandidates.map((item) => {
+        if (!exactKeys(item, ["candidate_id", "candidate_sha256", "case_revision_sha256", "entry_sha256"])
+          || !isCandidateId(item.candidate_id)
+          || !isSha256(item.candidate_sha256)
+          || !isSha256(item.case_revision_sha256)
+          || !isSha256(item.entry_sha256)) {
+          throw new LearningStoreError("conflict", "Expected case candidate tokens are invalid");
+        }
+        return { ...item };
+      }).sort((left, right) => left.candidate_id.localeCompare(right.candidate_id));
+      if (model.stableStringify(actual) !== model.stableStringify(expected)) {
+        throw new LearningStoreError("conflict", "The case candidate set changed since it was read");
+      }
+    }
+
+    function openDatabase() {
+      return new Promise((resolve, reject) => {
+        let request;
+        let settled = false;
+        let upgradeError = null;
+        try {
+          request = factory.open(DB_NAME, DB_VERSION);
+        } catch (error) {
+          reject(classified(error, "unavailable"));
+          return;
+        }
+        request.onupgradeneeded = (event) => {
+          if (settled) {
+            try { request.transaction.abort(); } catch {}
+            return;
+          }
+          try {
+            if (event.oldVersion !== 0 || request.result.objectStoreNames.length !== 0) {
+              throw new LearningStoreError("corrupt", "Unexpected IndexedDB schema during initial upgrade");
+            }
+            const objectStore = request.result.createObjectStore(OBJECT_STORE_NAME);
+            const seedRequest = objectStore.put(model.createStore(), RECORD_KEY);
+            seedRequest.onerror = () => {
+              upgradeError = classified(seedRequest.error, "corrupt");
+            };
+          } catch (error) {
+            upgradeError = classified(error, "corrupt");
+            try { request.transaction.abort(); } catch {}
+          }
+        };
+        request.onblocked = () => {
+          if (settled) return;
+          settled = true;
+          reject(new LearningStoreError("blocked", "IndexedDB open or upgrade is blocked by another page"));
+        };
+        request.onerror = () => {
+          if (settled) return;
+          settled = true;
+          reject(upgradeError || classified(request.error, "unavailable"));
+        };
+        request.onsuccess = () => {
+          const database = request.result;
+          if (settled) {
+            database.close();
+            return;
+          }
+          const names = objectStoreNames(database);
+          if (names.length !== 1 || names[0] !== OBJECT_STORE_NAME) {
+            settled = true;
+            database.close();
+            reject(new LearningStoreError("corrupt", "IndexedDB contains an unexpected learning-store schema"));
+            return;
+          }
+          database.onversionchange = () => database.close();
+          settled = true;
+          resolve(database);
+        };
+      });
+    }
+
+    async function withTransaction(mode, operation) {
+      const database = await openDatabase();
+      let transaction;
+      try {
+        transaction = database.transaction(OBJECT_STORE_NAME, mode);
+      } catch (error) {
+        database.close();
+        throw classified(error, "unavailable");
+      }
+      const completion = transactionCompletion(transaction);
+      try {
+        const objectStore = transaction.objectStore(OBJECT_STORE_NAME);
+        if (!hasExpectedObjectStoreSchema(objectStore)) {
+          throw new LearningStoreError("corrupt", "IndexedDB contains incompatible learning-store metadata");
+        }
+        const result = await operation(objectStore, transaction);
+        await completion;
+        return result;
+      } catch (error) {
+        try { transaction.abort(); } catch {}
+        try { await completion; } catch {}
+        throw classified(error, error instanceof LearningStoreError ? error.code : "corrupt");
+      } finally {
+        database.close();
+      }
+    }
+
+    async function readLatest(objectStore) {
+      const countRequest = objectStore.count();
+      const getRequest = objectStore.get(RECORD_KEY);
+      const [count, stored] = await Promise.all([
+        requestResult(countRequest),
+        requestResult(getRequest)
+      ]);
+      if (count !== 1) {
+        throw new LearningStoreError("corrupt", "IndexedDB must contain exactly one learning-store record");
+      }
+      if (stored === undefined) {
+        throw new LearningStoreError("corrupt", "The versioned learning-store record is missing");
+      }
+      return assertStore(stored, "load");
+    }
+
+    async function mutate(transform) {
+      const database = await openDatabase();
+      return new Promise((resolve, reject) => {
+        let transaction;
+        let failure = null;
+        let result;
+        try {
+          transaction = database.transaction(OBJECT_STORE_NAME, "readwrite");
+          const objectStore = transaction.objectStore(OBJECT_STORE_NAME);
+          if (!hasExpectedObjectStoreSchema(objectStore)) {
+            try { transaction.abort(); } catch {}
+            database.close();
+            reject(new LearningStoreError("corrupt", "IndexedDB contains incompatible learning-store metadata"));
+            return;
+          }
+          const countRequest = objectStore.count();
+          countRequest.onerror = () => {
+            failure = classified(countRequest.error, "corrupt");
+          };
+          countRequest.onsuccess = () => {
+            if (countRequest.result !== 1) {
+              failure = new LearningStoreError("corrupt", "IndexedDB must contain exactly one learning-store record");
+              try { transaction.abort(); } catch {}
+              return;
+            }
+            const getRequest = objectStore.get(RECORD_KEY);
+            getRequest.onerror = () => {
+              failure = classified(getRequest.error, "corrupt");
+            };
+            getRequest.onsuccess = () => {
+              try {
+                if (getRequest.result === undefined) {
+                  throw new LearningStoreError("corrupt", "The versioned learning-store record is missing");
+                }
+                const current = assertStore(getRequest.result, "load");
+                const change = transform(current);
+                if (!change || !exactKeys(change, ["store", "result"])) {
+                  throw new LearningStoreError("corrupt", "The learning-store mutation returned an invalid result");
+                }
+                const written = assertStore(change.store, "write");
+                const putRequest = objectStore.put(written, RECORD_KEY);
+                putRequest.onerror = () => {
+                  failure = classified(putRequest.error, "corrupt");
+                };
+                putRequest.onsuccess = () => {
+                  result = typeof change.result === "function" ? change.result(written) : change.result;
+                };
+              } catch (error) {
+                failure = classified(error, error instanceof LearningStoreError ? error.code : "corrupt");
+                try { transaction.abort(); } catch {}
+              }
+            };
+          };
+          transaction.oncomplete = () => {
+            database.close();
+            resolve(result);
+          };
+          transaction.onabort = () => {
+            database.close();
+            reject(failure || classified(transaction.error, "corrupt"));
+          };
+          transaction.onerror = () => {};
+        } catch (error) {
+          database.close();
+          reject(classified(error, "unavailable"));
+        }
+      });
+    }
+
+    function upsertChange(current, entry, expectations) {
+      const normalized = normalizeEntry(entry);
+      const candidateId = normalized.candidate.candidate_id;
+      const index = current.entries.findIndex((item) => item.candidate.candidate_id === candidateId);
+      const existing = index >= 0 ? current.entries[index] : null;
+      expectedState(expectations, existing);
+      if (existing) {
+        assertCandidateReplacement(existing.candidate, normalized.candidate, normalized.binding);
+      }
+      let next;
+      if (!existing) {
+        if (current.entries.length >= model.limits.maxEntries) {
+          throw new LearningStoreError("quota", "The learning store already contains 50 candidates");
+        }
+        try {
+          next = model.insertEntry(current, normalized, { hashText });
+        } catch (error) {
+          throw new LearningStoreError("corrupt", "The candidate could not be inserted into the validated store", error);
+        }
+      } else {
+        next = {
+          store_version: STORE_VERSION,
+          entries: current.entries.map((item, itemIndex) => itemIndex === index ? normalized : item)
+        };
+      }
+      return {
+        store: next,
+        result: (written) => ({
+          store_sha256: storeDigest(written),
+          entry: presentEntry(written.entries.find((item) => item.candidate.candidate_id === candidateId))
+        })
+      };
+    }
+
+    async function list() {
+      return withTransaction("readonly", async (objectStore) => {
+        const store = await readLatest(objectStore);
+        return {
+          store_sha256: storeDigest(store),
+          entries: store.entries
+            .map(presentEntry)
+            .sort((left, right) => left.candidate_id.localeCompare(right.candidate_id))
+        };
+      });
+    }
+
+    async function get(candidateId) {
+      if (!isCandidateId(candidateId)) {
+        throw new LearningStoreError("conflict", "A valid learning candidate ID is required");
+      }
+      return withTransaction("readonly", async (objectStore) => {
+        const store = await readLatest(objectStore);
+        const entry = store.entries.find((item) => item.candidate.candidate_id === candidateId);
+        return entry ? presentEntry(entry) : null;
+      });
+    }
+
+    async function upsert(entry, expectations) {
+      return mutate((current) => upsertChange(current, entry, expectations));
+    }
+
+    async function deleteCandidate(candidateId, expectations) {
+      if (!isCandidateId(candidateId)) {
+        throw new LearningStoreError("conflict", "A valid learning candidate ID is required");
+      }
+      return mutate((current) => {
+        const existing = current.entries.find((item) => item.candidate.candidate_id === candidateId) || null;
+        expectedState(expectations, existing);
+        if (!existing) {
+          throw new LearningStoreError("conflict", "The candidate no longer exists");
+        }
+        const next = {
+          store_version: STORE_VERSION,
+          entries: current.entries.filter((item) => item.candidate.candidate_id !== candidateId)
+        };
+        return {
+          store: next,
+          result: (written) => ({ removed: 1, store_sha256: storeDigest(written) })
+        };
+      });
+    }
+
+    async function deleteCase(caseId, expectedCandidates) {
+      if (typeof caseId !== "string" || !caseId.trim()) {
+        throw new LearningStoreError("conflict", "A case ID is required for explicit case deletion");
+      }
+      return mutate((current) => {
+        expectedCaseSet(current, caseId, expectedCandidates);
+        let deletion;
+        try {
+          deletion = model.deleteCaseEntries(current, caseId, { hashText });
+        } catch (error) {
+          throw new LearningStoreError("corrupt", "The case candidates could not be deleted", error);
+        }
+        return {
+          store: deletion.store,
+          result: (written) => ({ removed: deletion.removed, store_sha256: storeDigest(written) })
+        };
+      });
+    }
+
+    async function clearExplicit(confirmation, expectedStoreSha256) {
+      if (confirmation !== CLEAR_CONFIRMATION || !isSha256(expectedStoreSha256)) {
+        throw new LearningStoreError("conflict", "Explicit clear confirmation and the expected store digest are required");
+      }
+      return mutate((current) => {
+        if (storeDigest(current) !== expectedStoreSha256) {
+          throw new LearningStoreError("conflict", "The learning store changed before explicit clear");
+        }
+        const removed = current.entries.length;
+        return {
+          store: model.createStore(),
+          result: (written) => ({ removed, store_sha256: storeDigest(written) })
+        };
+      });
+    }
+
+    async function importCandidate(text, binding, expectations) {
+      let candidate;
+      try {
+        candidate = model.parseImport(text, { hashText });
+      } catch (error) {
+        throw new LearningStoreError("corrupt", "The learning candidate import failed validation", error);
+      }
+      return mutate((current) => upsertChange(current, { candidate, binding }, expectations));
+    }
+
+    async function exportCandidate(candidateId, exportOptions = {}) {
+      if (!isCandidateId(candidateId)) {
+        throw new LearningStoreError("conflict", "A valid learning candidate ID is required");
+      }
+      return withTransaction("readonly", async (objectStore) => {
+        const store = await readLatest(objectStore);
+        const entry = store.entries.find((item) => item.candidate.candidate_id === candidateId);
+        if (!entry) throw new LearningStoreError("conflict", "The candidate no longer exists");
+        if (!model.hasSafeJsonShape(exportOptions)
+          || !exportOptions || typeof exportOptions !== "object"
+          || !Object.prototype.hasOwnProperty.call(exportOptions, "expectations")) {
+          throw new LearningStoreError("conflict", "Current candidate tokens are required for export");
+        }
+        expectedState(exportOptions.expectations, entry);
+        try {
+          return model.createExport(entry.candidate, {
+            hashText,
+            now: exportOptions.now || now()
+          });
+        } catch (error) {
+          throw new LearningStoreError("corrupt", "The learning candidate could not be exported", error);
+        }
+      });
+    }
+
+    return Object.freeze({
+      list,
+      get,
+      upsert,
+      delete: deleteCandidate,
+      deleteCase,
+      clearExplicit,
+      import: importCandidate,
+      export: exportCandidate,
+      importCandidate,
+      exportCandidate
+    });
+  }
+
+  globalThis.HUB_OPTIMUS_LEARNING_STORE_V1 = Object.freeze({
+    dbName: DB_NAME,
+    dbVersion: DB_VERSION,
+    objectStoreName: OBJECT_STORE_NAME,
+    recordKey: RECORD_KEY,
+    storeVersion: STORE_VERSION,
+    clearConfirmation: CLEAR_CONFIRMATION,
+    limits: Object.freeze({ maxAggregateBytes: MAX_AGGREGATE_BYTES }),
+    errorCodes: ERROR_CODES,
+    LearningStoreError,
+    createAdapter
+  });
+})();

--- a/site/operator/schemas/operator_learning_candidate.v1.schema.json
+++ b/site/operator/schemas/operator_learning_candidate.v1.schema.json
@@ -1,0 +1,414 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://huboptimus.dev/operator/schemas/operator_learning_candidate.v1.schema.json",
+  "title": "HUB_Optimus Operator learning candidate v1",
+  "description": "Local, human-authored and non-canonical meta-learning record. This contract does not train a model, update Core, or create authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "method_ref",
+    "authority",
+    "case_ref",
+    "state",
+    "created_at_utc",
+    "updated_at_utc",
+    "nodes",
+    "relations",
+    "metrics",
+    "iteration_decision",
+    "next_experiment",
+    "closure_check",
+    "history"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": {"const": "accepted"}
+        },
+        "required": ["state"]
+      },
+      "then": {
+        "properties": {
+          "closure_check": {
+            "properties": {
+              "final_text": {"const": true},
+              "verification_owner": {"const": true},
+              "scope_and_deadlines": {"const": true},
+              "open_points": {"const": true},
+              "minimum_patch": {"const": true}
+            }
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "operator_learning_candidate.v1"
+    },
+    "candidate_id": {
+      "allOf": [
+        {"$ref": "#/$defs/id"},
+        {"pattern": "^learning-[A-Za-z0-9._:-]+$"}
+      ]
+    },
+    "method_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "v1_core/workflow/05_meta_learning.md"
+        },
+        "sha256": {
+          "const": "74f4e5ff32de47f4ec970de606f5674c5cd40c7eed7d356fc0a12a23acc3561c"
+        }
+      }
+    },
+    "authority": {
+      "const": "local-non-canonical"
+    },
+    "case_ref": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "state": {
+      "enum": ["draft", "accepted", "rejected"]
+    },
+    "created_at_utc": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "updated_at_utc": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 512,
+      "items": {
+        "$ref": "#/$defs/node"
+      },
+      "allOf": [
+        {"contains": {"properties": {"node_type": {"const": "case"}}, "required": ["node_type"]}, "minContains": 1, "maxContains": 1},
+        {"contains": {"properties": {"node_type": {"const": "claim"}}, "required": ["node_type"]}, "minContains": 1},
+        {"contains": {"properties": {"node_type": {"const": "evidence"}}, "required": ["node_type"]}, "minContains": 1},
+        {"contains": {"properties": {"node_type": {"const": "outcome"}}, "required": ["node_type"]}, "minContains": 1, "maxContains": 1},
+        {"contains": {"properties": {"node_type": {"const": "signal"}}, "required": ["node_type"]}, "minContains": 3, "maxContains": 10},
+        {"contains": {"properties": {"node_type": {"const": "diagnosis"}}, "required": ["node_type"]}, "minContains": 1, "maxContains": 1},
+        {"contains": {"properties": {"node_type": {"const": "gap"}}, "required": ["node_type"]}, "minContains": 1, "maxContains": 1},
+        {"contains": {"properties": {"node_type": {"const": "action"}}, "required": ["node_type"]}, "minContains": 1, "maxContains": 1}
+      ]
+    },
+    "relations": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 2048,
+      "items": {
+        "$ref": "#/$defs/relation"
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 5,
+      "items": {
+        "$ref": "#/$defs/metric"
+      }
+    },
+    "iteration_decision": {
+      "enum": ["repeat_same_scenario", "escalate_variant", "change_approach"]
+    },
+    "next_experiment": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "closure_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["final_text", "verification_owner", "scope_and_deadlines", "open_points", "minimum_patch"],
+      "properties": {
+        "final_text": {"type": "boolean"},
+        "verification_owner": {"type": "boolean"},
+        "scope_and_deadlines": {"type": "boolean"},
+        "open_points": {"type": "boolean"},
+        "minimum_patch": {"type": "boolean"}
+      }
+    },
+    "history": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 512,
+      "items": {
+        "$ref": "#/$defs/history_event"
+      }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$"
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20000,
+      "allOf": [
+        {"pattern": ".*\\S.*"},
+        {"pattern": "^[^\\uD800-\\uDFFF]*$"}
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+    },
+    "source_ref": {
+      "oneOf": [
+        {"$ref": "#/$defs/id"},
+        {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 2048,
+          "pattern": "^https?://(?=[^/]{1,253}$)(?!(?:[a-z0-9-]+\\.)*(?:localhost|local|internal|localdomain|home\\.arpa)$)(?!\\d+(?:\\.\\d+){1,3}$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$"
+        }
+      ]
+    },
+    "string_list": {
+      "type": "array",
+      "maxItems": 128,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/non_empty_string"
+      }
+    },
+    "case_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "case_id", "core_version_ref", "revision_sha256"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "case"},
+        "case_id": {"$ref": "#/$defs/non_empty_string"},
+        "core_version_ref": {"$ref": "#/$defs/non_empty_string"},
+        "revision_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "claim_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "record_id", "text", "text_sha256", "source_ref"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "claim"},
+        "record_id": {"$ref": "#/$defs/id"},
+        "text": {"$ref": "#/$defs/non_empty_string"},
+        "text_sha256": {"$ref": "#/$defs/sha256"},
+        "source_ref": {"$ref": "#/$defs/source_ref"}
+      }
+    },
+    "evidence_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "record_id", "text", "text_sha256", "source_ref", "limitations"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "evidence"},
+        "record_id": {"$ref": "#/$defs/id"},
+        "text": {"$ref": "#/$defs/non_empty_string"},
+        "text_sha256": {"$ref": "#/$defs/sha256"},
+        "source_ref": {"$ref": "#/$defs/source_ref"},
+        "limitations": {"$ref": "#/$defs/string_list"}
+      }
+    },
+    "outcome_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "text"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "outcome"},
+        "text": {"$ref": "#/$defs/non_empty_string"}
+      }
+    },
+    "signal_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "text", "claim_refs", "evidence_refs"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "signal"},
+        "text": {"$ref": "#/$defs/non_empty_string"},
+        "claim_refs": {
+          "allOf": [
+            {"$ref": "#/$defs/string_list"},
+            {"minItems": 1}
+          ]
+        },
+        "evidence_refs": {
+          "allOf": [
+            {"$ref": "#/$defs/string_list"},
+            {"minItems": 1}
+          ]
+        }
+      }
+    },
+    "diagnosis_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "text", "categories", "signal_refs", "evidence_refs"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "diagnosis"},
+        "text": {"$ref": "#/$defs/non_empty_string"},
+        "categories": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 7,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["ambiguity", "weak_verification", "misaligned_incentives", "wrong_sequence", "political_overload", "spoilers", "information_asymmetry"]
+          }
+        },
+        "signal_refs": {
+          "allOf": [
+            {"$ref": "#/$defs/string_list"},
+            {"minItems": 1}
+          ]
+        },
+        "evidence_refs": {
+          "allOf": [
+            {"$ref": "#/$defs/string_list"},
+            {"minItems": 1}
+          ]
+        }
+      }
+    },
+    "gap_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "text"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "gap"},
+        "text": {"$ref": "#/$defs/non_empty_string"}
+      }
+    },
+    "action_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_id", "node_type", "change", "reason", "verification_criterion"],
+      "properties": {
+        "node_id": {"$ref": "#/$defs/id"},
+        "node_type": {"const": "action"},
+        "change": {"$ref": "#/$defs/non_empty_string"},
+        "reason": {"$ref": "#/$defs/non_empty_string"},
+        "verification_criterion": {"$ref": "#/$defs/non_empty_string"}
+      }
+    },
+    "node": {
+      "oneOf": [
+        {"$ref": "#/$defs/case_node"},
+        {"$ref": "#/$defs/claim_node"},
+        {"$ref": "#/$defs/evidence_node"},
+        {"$ref": "#/$defs/outcome_node"},
+        {"$ref": "#/$defs/signal_node"},
+        {"$ref": "#/$defs/diagnosis_node"},
+        {"$ref": "#/$defs/gap_node"},
+        {"$ref": "#/$defs/action_node"}
+      ]
+    },
+    "relation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relation_id", "type", "from_ref", "to_ref", "origin", "epistemic_status"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": ["SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM"]
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "origin": {"const": "imported"}
+            }
+          },
+          "else": {
+            "properties": {
+              "origin": {"const": "human-authored"}
+            }
+          }
+        }
+      ],
+      "properties": {
+        "relation_id": {"$ref": "#/$defs/id"},
+        "type": {
+          "enum": ["OUTCOME_OF_CASE", "SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM", "SIGNAL_REFERENCES_CLAIM", "SIGNAL_GROUNDED_IN_EVIDENCE", "DIAGNOSIS_INTERPRETS_SIGNAL", "DIAGNOSIS_REFERENCES_EVIDENCE", "GAP_IDENTIFIED_BY_DIAGNOSIS", "ACTION_ADDRESSES_GAP"]
+        },
+        "from_ref": {"$ref": "#/$defs/id"},
+        "to_ref": {"$ref": "#/$defs/id"},
+        "origin": {
+          "enum": ["human-authored", "imported"]
+        },
+        "epistemic_status": {
+          "enum": ["observation", "submitted-claim", "corroboration", "inference", "proposal"]
+        }
+      }
+    },
+    "metric": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "value"],
+          "properties": {
+            "name": {"enum": ["clarity", "verifiability", "viability"]},
+            "value": {"type": "integer", "minimum": 0, "maximum": 5}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "value"],
+          "properties": {
+            "name": {"const": "time_to_draft_minutes"},
+            "value": {"type": "number", "minimum": 0, "maximum": 1000000}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "value"],
+          "properties": {
+            "name": {"const": "open_points"},
+            "value": {"type": "integer", "minimum": 0, "maximum": 1000000}
+          }
+        }
+      ]
+    },
+    "history_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_id", "at_utc", "actor", "action", "from_state", "to_state", "note"],
+      "properties": {
+        "event_id": {"$ref": "#/$defs/id"},
+        "at_utc": {"$ref": "#/$defs/timestamp"},
+        "actor": {"const": "human-operator"},
+        "action": {"enum": ["created", "edited", "state-change", "imported", "revalidated"]},
+        "from_state": {"type": ["string", "null"], "enum": [null, "draft", "accepted", "rejected"]},
+        "to_state": {"enum": ["draft", "accepted", "rejected"]},
+        "note": {"$ref": "#/$defs/non_empty_string"}
+      }
+    }
+  }
+}

--- a/tests/test_operator_learning_candidate.py
+++ b/tests/test_operator_learning_candidate.py
@@ -1,0 +1,890 @@
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "site" / "operator" / "learning-candidate.v1.js"
+SCHEMA = (
+    ROOT
+    / "site"
+    / "operator"
+    / "schemas"
+    / "operator_learning_candidate.v1.schema.json"
+)
+METHOD = ROOT / "v1_core" / "workflow" / "05_meta_learning.md"
+RFC = ROOT / "docs" / "rfc" / "operator_local_learning_candidate.md"
+NODE = shutil.which("node")
+
+
+def run_model_smoke(body: str):
+    assert NODE, "Node.js is required for Operator learning model tests"
+    harness = r"""
+const fs = require("fs");
+const vm = require("vm");
+const crypto = require("crypto");
+vm.runInThisContext(fs.readFileSync(process.env.LEARNING_MODULE, "utf8"));
+const api = globalThis.HUB_OPTIMUS_LEARNING_CANDIDATE_V1;
+const hashText = (value) => crypto.createHash("sha256").update(value, "utf8").digest("hex");
+
+const caseRecord = {
+  case_id: "operator-case-001",
+  core_version_ref: "v1",
+  revision_sha256: "",
+  claims: [{
+    claim_id: "claim-001",
+    text: "The source states that review is delayed.",
+    source_ref: "operator-source-001"
+  }],
+  evidence: [{
+    evidence_id: "evidence-001",
+    text: "The extracted source contains the submitted delay statement.",
+    source_ref: "operator-source-001",
+    limitations: ["Attribution only; not independent corroboration."]
+  }],
+  relationships: [{
+    type: "SUPPORTS_ATTRIBUTION",
+    from_ref: "evidence-001",
+    to_ref: "claim-001"
+  }]
+};
+caseRecord.revision_sha256 = api.computeCaseRevision(caseRecord, {hashText});
+
+function build(overrides = {}) {
+  return api.buildCandidate({
+    candidate_id: "learning-00000000-0000-4000-8000-000000000001",
+    case_record: caseRecord,
+    outcome: "A source-bound local draft was prepared; the reported delay remains unverified.",
+    signals: [
+      {text: "The submitted text describes a delay.", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]},
+      {text: "The source does not identify an independent verifier.", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]},
+      {text: "The next escalation step is not defined in the submitted material.", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]}
+    ],
+    diagnosis: {
+      text: "The draft exposes a verification and sequencing gap.",
+      categories: ["weak_verification", "wrong_sequence"],
+      evidence_refs: ["evidence-001"]
+    },
+    gap: "No accountable verifier or escalation sequence is recorded.",
+    action: {
+      change: "Add one named verification owner and one escalation deadline.",
+      reason: "This is the smallest change that makes follow-up inspectable.",
+      verification_criterion: "A reviewer can identify both the owner and deadline in the next draft."
+    },
+    metrics: [
+      {name: "clarity", value: 3},
+      {name: "verifiability", value: 1},
+      {name: "open_points", value: 2}
+    ],
+    iteration_decision: "repeat_same_scenario",
+    next_experiment: "Prepare the same case with a named verifier and deadline, then compare metrics.",
+    closure_check: {
+      final_text: true,
+      verification_owner: true,
+      scope_and_deadlines: true,
+      open_points: true,
+      minimum_patch: true
+    },
+    creation_note: "Recorded manually after reviewing the draft.",
+    ...overrides
+  }, {hashText, now: "2026-08-01T12:00:00.000Z"});
+}
+"""
+    completed = subprocess.run(
+        [NODE, "-e", harness + body],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={"LEARNING_MODULE": str(MODULE)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout
+
+
+def test_learning_schema_is_strict_versioned_and_bound_to_repository_method():
+    import jsonschema
+
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    method_digest = hashlib.sha256(METHOD.read_bytes()).hexdigest()
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["schema_version"]["const"] == (
+        "operator_learning_candidate.v1"
+    )
+    assert schema["properties"]["authority"]["const"] == "local-non-canonical"
+    assert schema["properties"]["method_ref"]["properties"]["sha256"]["const"] == (
+        method_digest
+    )
+    assert schema["properties"]["state"]["enum"] == [
+        "draft",
+        "accepted",
+        "rejected",
+    ]
+    assert schema["properties"]["nodes"]["allOf"][4]["minContains"] == 3
+    assert schema["properties"]["nodes"]["allOf"][4]["maxContains"] == 10
+    assert schema["$defs"]["relation"]["properties"]["origin"]["enum"] == [
+        "human-authored",
+        "imported",
+    ]
+    assert schema["$defs"]["signal_node"]["properties"]["claim_refs"][
+        "allOf"
+    ][1]["minItems"] == 1
+
+    for name, definition in schema["$defs"].items():
+        if definition.get("type") == "object":
+            assert definition.get("additionalProperties") is False, name
+
+
+def test_learning_builder_produces_a_valid_connected_human_draft():
+    import jsonschema
+
+    output = run_model_smoke(
+        r"""
+const candidate = build();
+const validation = api.validateCandidate(candidate, {hashText});
+if (!validation.valid) throw new Error(JSON.stringify(validation.errors));
+if (candidate.state !== "draft" || candidate.authority !== "local-non-canonical") {
+  throw new Error("builder promoted authority or state");
+}
+if (candidate.nodes.filter((node) => node.node_type === "signal").length !== 3) {
+  throw new Error("signal count changed");
+}
+if (!candidate.relations.some((edge) => edge.type === "ACTION_ADDRESSES_GAP")) {
+  throw new Error("action is disconnected from the diagnosed gap");
+}
+if (candidate.relations.some((edge) => edge.origin === "system-suggested")) {
+  throw new Error("v1 builder invented a system suggestion");
+}
+process.stdout.write(JSON.stringify(candidate));
+"""
+    )
+    candidate = json.loads(output)
+    validator = jsonschema.Draft202012Validator(
+        json.loads(SCHEMA.read_text(encoding="utf-8")),
+        format_checker=jsonschema.FormatChecker(),
+    )
+    validator.validate(candidate)
+    assert candidate["history"] == [
+        {
+            "action": "created",
+            "actor": "human-operator",
+            "at_utc": "2026-08-01T12:00:00.000Z",
+            "event_id": "history:001",
+            "from_state": None,
+            "note": "Recorded manually after reviewing the draft.",
+            "to_state": "draft",
+        }
+    ]
+
+
+def test_learning_schema_and_runtime_require_complete_closure_for_acceptance():
+    import jsonschema
+
+    accepted = json.loads(
+        run_model_smoke(
+            r"""
+const candidate = build();
+const accepted = api.transitionCandidate(
+  candidate,
+  "accepted",
+  "Accepted after an explicit local review.",
+  {hashText, liveCase: caseRecord, now: "2026-08-01T12:05:00.000Z"}
+);
+process.stdout.write(JSON.stringify(accepted));
+"""
+        )
+    )
+    validator = jsonschema.Draft202012Validator(
+        json.loads(SCHEMA.read_text(encoding="utf-8")),
+        format_checker=jsonschema.FormatChecker(),
+    )
+    validator.validate(accepted)
+
+    incomplete = json.loads(json.dumps(accepted))
+    incomplete["closure_check"]["minimum_patch"] = False
+    assert list(validator.iter_errors(incomplete))
+
+    run_model_smoke(
+        r"""
+const accepted = api.transitionCandidate(
+  build(),
+  "accepted",
+  "Accepted after an explicit local review.",
+  {hashText, liveCase: caseRecord, now: "2026-08-01T12:05:00.000Z"}
+);
+accepted.closure_check.minimum_patch = false;
+if (api.validateCandidate(accepted, {hashText}).valid) {
+  throw new Error("runtime accepted incomplete closure");
+}
+"""
+    )
+
+
+def test_learning_builder_rejects_non_json_input_without_coercion():
+    run_model_smoke(
+        r"""
+const statefulOutcome = {
+  calls: 0,
+  toString() {
+    this.calls += 1;
+    return "coerced outcome";
+  }
+};
+try {
+  build({outcome: statefulOutcome});
+  throw new Error("stateful outcome was accepted");
+} catch (error) {
+  if (!`${error.message}`.includes("plain JSON")) throw error;
+}
+if (statefulOutcome.calls !== 0) throw new Error("builder coerced stateful outcome input");
+
+for (const [label, value] of [
+  ["object outcome", {}],
+  ["numeric signal", 42],
+  ["object metric name", {}]
+]) {
+  try {
+    if (label === "object outcome") build({outcome: value});
+    if (label === "numeric signal") {
+      const candidateSignals = [
+        {text: value, claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]},
+        {text: "signal two", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]},
+        {text: "signal three", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]}
+      ];
+      build({signals: candidateSignals});
+    }
+    if (label === "object metric name") {
+      build({metrics: [{name: value, value: 1}, {name: "clarity", value: 1}, {name: "open_points", value: 1}]});
+    }
+    throw new Error(`${label} was coerced`);
+  } catch (error) {
+    if (!`${error.message}`.includes("shape")) throw error;
+  }
+}
+const candidate = build();
+const statefulNow = {
+  calls: 0,
+  toString() {
+    this.calls += 1;
+    return "2026-08-01T12:10:00.000Z";
+  }
+};
+for (const operation of [
+  () => api.transitionCandidate(candidate, "rejected", "Rejected.", {hashText, now: statefulNow}),
+  () => api.evaluateFreshness(candidate, caseRecord, {hashText, now: statefulNow}),
+  () => api.createExport(candidate, {hashText, now: statefulNow})
+]) {
+  try { operation(); throw new Error("stateful timestamp was accepted"); }
+  catch (error) { if (!`${error.message}`.includes("timestamp")) throw error; }
+}
+if (statefulNow.calls !== 0) throw new Error("model coerced a stateful timestamp");
+"""
+    )
+
+
+def test_learning_validator_rejects_tampering_dangling_edges_and_wrong_signatures():
+    run_model_smoke(
+        r"""
+function mustFail(mutator, needle) {
+  const candidate = build();
+  mutator(candidate);
+  const validation = api.validateCandidate(candidate, {hashText});
+  if (validation.valid || !validation.errors.some((item) => `${item.path} ${item.message}`.includes(needle))) {
+    throw new Error(`expected failure containing ${needle}: ${JSON.stringify(validation.errors)}`);
+  }
+}
+mustFail((candidate) => { candidate.unexpected = true; }, "top-level");
+mustFail((candidate) => { candidate.nodes[1].node_id = candidate.nodes[0].node_id; }, "duplicate node ID");
+mustFail((candidate) => { candidate.nodes[1].text = "tampered"; }, "canonical text");
+mustFail((candidate) => { candidate.relations[0].to_ref = "missing:node"; }, "dangling");
+mustFail((candidate) => { candidate.relations[0].to_ref = "claim:claim-001"; }, "signature mismatch");
+mustFail((candidate) => { candidate.nodes.find((node) => node.node_type === "diagnosis").categories = ["automatic_truth_score"]; }, "categories");
+mustFail((candidate) => { candidate.metrics[1].name = "clarity"; }, "duplicate metric");
+mustFail((candidate) => { candidate.candidate_id = "learning-"; }, "learning-*");
+mustFail((candidate) => { candidate.candidate_id = `learning-${"a".repeat(500)}`; }, "learning-*");
+mustFail((candidate) => { candidate.created_at_utc = "2026-02-30T12:00:00Z"; }, "timestamp");
+mustFail((candidate) => {
+  const diagnosis = candidate.nodes.find((node) => node.node_type === "diagnosis");
+  diagnosis.signal_refs.pop();
+}, "every signal");
+mustFail((candidate) => {
+  candidate.relations = candidate.relations.filter((edge) => !["SUPPORTS_ATTRIBUTION", "SUPPORTS_CLAIM", "CONTRADICTS_CLAIM"].includes(edge.type));
+}, "evidence-to-claim");
+mustFail((candidate) => {
+  const edge = candidate.relations.find((item) => item.type === "DIAGNOSIS_INTERPRETS_SIGNAL");
+  edge.origin = "system-suggested";
+}, "forbidden in v1");
+mustFail((candidate) => {
+  candidate.relations.find((edge) => edge.type === "SUPPORTS_ATTRIBUTION").origin = "human-authored";
+}, "must be imported");
+mustFail((candidate) => {
+  candidate.relations.find((edge) => edge.type === "ACTION_ADDRESSES_GAP").origin = "imported";
+}, "must be human-authored");
+mustFail((candidate) => {
+  const actionEdge = candidate.relations.find((edge) => edge.type === "ACTION_ADDRESSES_GAP");
+  actionEdge.epistemic_status = "inference";
+}, "must be proposal");
+mustFail((candidate) => {
+  candidate.nodes.find((node) => node.node_type === "signal").claim_refs = [];
+  candidate.relations = candidate.relations.filter((edge) => edge.type !== "SIGNAL_REFERENCES_CLAIM" || edge.from_ref !== "signal:001");
+}, "claim reference");
+mustFail((candidate) => {
+  candidate.created_at_utc = "2026-08-01T11:59:00.000Z";
+}, "first history event");
+mustFail((candidate) => {
+  candidate.updated_at_utc = "2026-08-01T12:30:00.000Z";
+}, "last history event");
+mustFail((candidate) => {
+  const claim = candidate.nodes.find((node) => node.node_type === "claim");
+  claim.text = "\ud800";
+  claim.text_sha256 = hashText("\ufffd");
+}, "Unicode safety");
+mustFail((candidate) => {
+  const evidenceNode = candidate.nodes.find((node) => node.node_type === "evidence");
+  const extraEvidence = {...evidenceNode, node_id: "evidence:evidence-002", record_id: "evidence-002"};
+  candidate.nodes.push(extraEvidence);
+  candidate.relations.push({
+    relation_id: "relation:999",
+    type: "DIAGNOSIS_REFERENCES_EVIDENCE",
+    from_ref: "diagnosis:001",
+    to_ref: extraEvidence.node_id,
+    origin: "human-authored",
+    epistemic_status: "inference"
+  });
+}, "not declared");
+"""
+    )
+
+
+def test_learning_source_references_are_redacted_and_canonical_text_is_stable():
+    output = run_model_smoke(
+        r"""
+const privateCase = JSON.parse(JSON.stringify(caseRecord));
+privateCase.claims[0].text = "Cafe\u0301\r\nline two";
+privateCase.claims[0].source_ref = "https://Example.COM:443/private/case?token=secret#fragment";
+privateCase.evidence[0].source_ref = "https://example.com/another/private/path?session=hidden";
+privateCase.revision_sha256 = api.computeCaseRevision(privateCase, {hashText});
+const candidate = build({case_record: privateCase});
+const claim = candidate.nodes.find((node) => node.node_type === "claim");
+const evidence = candidate.nodes.find((node) => node.node_type === "evidence");
+if (claim.text !== "Café\nline two") throw new Error("text was not normalized to NFC/LF");
+if (claim.source_ref !== "https://example.com" || evidence.source_ref !== "https://example.com") {
+  throw new Error("source URL was not reduced to its origin");
+}
+const serialized = api.stableStringify(candidate);
+if (serialized.includes("token") || serialized.includes("secret") || serialized.includes("/private") || serialized.includes("session")) {
+  throw new Error("sensitive URL components leaked into the learning candidate");
+}
+let rejected = false;
+try {
+  const unsafeOpaque = JSON.parse(JSON.stringify(caseRecord));
+  unsafeOpaque.claims[0].source_ref = "private?token=secret";
+  unsafeOpaque.revision_sha256 = api.computeCaseRevision(unsafeOpaque, {hashText});
+  build({case_record: unsafeOpaque});
+} catch (error) {
+  rejected = `${error.message}`.includes("source_ref");
+}
+if (!rejected) throw new Error("unsafe opaque source reference was accepted");
+for (const privateOrigin of ["http://localhost/private", "http://192.168.1.10/secret", "http://127.1/admin", "http://[::1]/admin"]) {
+  let privateRejected = false;
+  try {
+    const unsafePrivate = JSON.parse(JSON.stringify(caseRecord));
+    unsafePrivate.claims[0].source_ref = privateOrigin;
+    unsafePrivate.revision_sha256 = api.computeCaseRevision(unsafePrivate, {hashText});
+    build({case_record: unsafePrivate});
+  } catch (error) {
+    privateRejected = `${error.message}`.includes("source_ref");
+  }
+  if (!privateRejected) throw new Error(`private source origin was accepted: ${privateOrigin}`);
+}
+process.stdout.write(serialized);
+"""
+    )
+    assert "token" not in output
+    assert "secret" not in output
+    assert "/private" not in output
+
+
+def test_learning_source_reference_schema_and_runtime_reject_the_same_private_forms():
+    import jsonschema
+
+    candidate = json.loads(
+        run_model_smoke(
+            r"""
+const candidate = build();
+for (const unsafe of [
+  "http://localhost",
+  "https://service.internal",
+  "https://home.arpa",
+  "http://192.168.1.10",
+  "https://Example.COM",
+  "https://example.com:8443"
+]) {
+  const mutated = JSON.parse(JSON.stringify(candidate));
+  mutated.nodes.find((node) => node.node_type === "claim").source_ref = unsafe;
+  if (api.validateCandidate(mutated, {hashText}).valid) {
+    throw new Error(`runtime accepted unsafe source ref: ${unsafe}`);
+  }
+}
+process.stdout.write(JSON.stringify(candidate));
+"""
+        )
+    )
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+    claim = next(node for node in candidate["nodes"] if node["node_type"] == "claim")
+    claim_index = candidate["nodes"].index(claim)
+
+    for unsafe in (
+        "http://localhost",
+        "https://service.internal",
+        "https://home.arpa",
+        "http://192.168.1.10",
+        "https://Example.COM",
+        "https://example.com:8443",
+    ):
+        mutated = json.loads(json.dumps(candidate))
+        mutated["nodes"][claim_index]["source_ref"] = unsafe
+        assert list(validator.iter_errors(mutated)), unsafe
+
+    surrogate = json.loads(json.dumps(candidate))
+    surrogate["nodes"][claim_index]["text"] = "\ud800"
+    assert list(validator.iter_errors(surrogate))
+
+    wrong_source_origin = json.loads(json.dumps(candidate))
+    next(
+        edge
+        for edge in wrong_source_origin["relations"]
+        if edge["type"] == "SUPPORTS_ATTRIBUTION"
+    )["origin"] = "human-authored"
+    assert list(validator.iter_errors(wrong_source_origin))
+
+    wrong_learning_origin = json.loads(json.dumps(candidate))
+    next(
+        edge
+        for edge in wrong_learning_origin["relations"]
+        if edge["type"] == "ACTION_ADDRESSES_GAP"
+    )["origin"] = "imported"
+    assert list(validator.iter_errors(wrong_learning_origin))
+
+    validator.validate(candidate)
+
+
+def test_learning_state_machine_requires_current_freshness_and_human_notes():
+    run_model_smoke(
+        r"""
+const candidate = build();
+function mustThrow(callback, needle) {
+  try { callback(); } catch (error) {
+    if (`${error.message}`.includes(needle)) return;
+    throw error;
+  }
+  throw new Error(`expected error containing ${needle}`);
+}
+const changedLiveCase = JSON.parse(JSON.stringify(caseRecord));
+changedLiveCase.claims[0].text = "The source text changed after the candidate was created.";
+changedLiveCase.revision_sha256 = api.computeCaseRevision(changedLiveCase, {hashText});
+mustThrow(() => api.transitionCandidate(candidate, "accepted", "reviewed", {hashText, freshness: "current", liveCase: changedLiveCase}), "current");
+mustThrow(() => api.transitionCandidate(candidate, "accepted", "", {hashText, liveCase: caseRecord}), "note");
+const incompleteClosure = build({closure_check: {
+  final_text: true,
+  verification_owner: false,
+  scope_and_deadlines: true,
+  open_points: true,
+  minimum_patch: true
+}});
+mustThrow(() => api.transitionCandidate(incompleteClosure, "accepted", "reviewed", {hashText, liveCase: caseRecord}), "closure checks");
+const accepted = api.transitionCandidate(candidate, "accepted", "Human review accepted this local candidate.", {hashText, liveCase: caseRecord, now: "2026-08-01T12:05:00.000Z"});
+if (accepted.state !== "accepted" || candidate.state !== "draft") throw new Error("transition mutated its input or failed");
+const forgedIncompleteAcceptance = JSON.parse(JSON.stringify(accepted));
+forgedIncompleteAcceptance.closure_check.minimum_patch = false;
+if (api.validateCandidate(forgedIncompleteAcceptance, {hashText}).valid) throw new Error("accepted candidate bypassed closure checks during validation");
+const nonSequentialId = build();
+nonSequentialId.history[0].event_id = "history:002";
+if (!api.validateCandidate(nonSequentialId, {hashText}).valid) throw new Error("non-sequential imported history ID did not reproduce");
+const acceptedWithoutCollision = api.transitionCandidate(nonSequentialId, "accepted", "Accepted after reviewing imported history.", {hashText, liveCase: caseRecord, now: "2026-08-01T12:05:00.000Z"});
+if (acceptedWithoutCollision.history[1].event_id !== "history:003") throw new Error("history event ID did not advance from the numeric maximum");
+mustThrow(() => api.transitionCandidate(accepted, "rejected", "direct flip", {hashText}), "Forbidden");
+const bypass = JSON.parse(JSON.stringify(accepted));
+bypass.state = "rejected";
+bypass.updated_at_utc = "2026-08-01T12:06:00.000Z";
+bypass.history.push({event_id: "history:003", at_utc: bypass.updated_at_utc, actor: "human-operator", action: "created", from_state: "accepted", to_state: "rejected", note: "Attempted bypass."});
+if (api.validateCandidate(bypass, {hashText}).valid) throw new Error("created event bypassed the state machine");
+const draftAgain = api.transitionCandidate(accepted, "draft", "Returned for revision.", {hashText, now: "2026-08-01T12:06:00.000Z"});
+const rejected = api.transitionCandidate(draftAgain, "rejected", "Human review rejected this revision.", {hashText, now: "2026-08-01T12:07:00.000Z"});
+if (rejected.state !== "rejected" || rejected.history.length !== 4) throw new Error("history was not preserved");
+"""
+    )
+
+
+def test_learning_freshness_changes_without_rewriting_human_state():
+    run_model_smoke(
+        r"""
+const candidate = build();
+const current = api.evaluateFreshness(candidate, caseRecord, {hashText, now: "2026-08-01T12:01:00.000Z"});
+if (current.freshness !== "current" || candidate.state !== "draft") throw new Error("current binding failed");
+const changed = JSON.parse(JSON.stringify(caseRecord));
+changed.claims[0].text = "The current claim text changed.";
+changed.revision_sha256 = api.computeCaseRevision(changed, {hashText});
+const stale = api.evaluateFreshness(candidate, changed, {hashText, now: "2026-08-01T12:02:00.000Z"});
+if (stale.freshness !== "stale" || candidate.state !== "draft") throw new Error("stale changed candidate state");
+const forged = JSON.parse(JSON.stringify(caseRecord));
+forged.claims[0].text = "Tampered text under the old declared revision.";
+const forgedBinding = api.evaluateFreshness(candidate, forged, {hashText, now: "2026-08-01T12:02:30.000Z"});
+if (forgedBinding.freshness === "current") throw new Error("forged declared revision was accepted as current");
+const missing = {...changed, evidence: []};
+missing.revision_sha256 = api.computeCaseRevision(missing, {hashText});
+const invalid = api.evaluateFreshness(candidate, missing, {hashText, now: "2026-08-01T12:03:00.000Z"});
+if (invalid.freshness !== "invalid" || candidate.state !== "draft") throw new Error("invalid changed candidate state");
+"""
+    )
+
+
+def test_case_revision_rejects_non_json_values_before_canonical_hashing():
+    run_model_smoke(
+        r"""
+function mustReject(label, extension) {
+  const unsafe = {...caseRecord, extension};
+  try {
+    api.computeCaseRevision(unsafe, {hashText});
+    throw new Error(`${label} was canonicalized instead of rejected`);
+  } catch (error) {
+    if (!`${error.message}`.includes("case record")) throw error;
+  }
+}
+const nullCase = {...caseRecord, extension: {score: null}};
+const missingCase = {...caseRecord, extension: {}};
+const nullRevision = api.computeCaseRevision(nullCase, {hashText});
+const missingRevision = api.computeCaseRevision(missingCase, {hashText});
+if (nullRevision === missingRevision) throw new Error("valid null and missing values shared a revision");
+mustReject("NaN", {score: NaN});
+mustReject("positive Infinity", {score: Infinity});
+mustReject("negative Infinity", {score: -Infinity});
+mustReject("undefined", {score: undefined});
+mustReject("function", {score: () => 1});
+mustReject("symbol", {score: Symbol("score")});
+mustReject("bigint", {score: 1n});
+mustReject("Date", {score: new Date("2026-08-01T12:00:00Z")});
+const sparse = [];
+sparse.length = 2;
+sparse[1] = "present";
+mustReject("sparse array", {score: sparse});
+const arrayPrototype = Object.create(Array.prototype);
+arrayPrototype.map = () => [];
+const customArray = ["Alice"];
+Object.setPrototypeOf(customArray, arrayPrototype);
+mustReject("custom array prototype", {review_owner: customArray});
+const candidate = build();
+const customArrayCase = {...caseRecord, extension: customArray};
+if (api.evaluateFreshness(candidate, customArrayCase, {hashText, now: "2026-08-01T12:01:00.000Z"}).freshness === "current") {
+  throw new Error("custom array prototype was current");
+}
+customArray[0] = "Mallory";
+if (api.evaluateFreshness(candidate, customArrayCase, {hashText, now: "2026-08-01T12:01:01.000Z"}).freshness === "current") {
+  throw new Error("mutated custom array prototype was current");
+}
+const getterObject = {};
+Object.defineProperty(getterObject, "review_owner", {enumerable: true, get() { return "Alice"; }});
+mustReject("getter", getterObject);
+const throwingProxy = new Proxy({}, {ownKeys() { throw new Error("proxy trap"); }});
+mustReject("throwing proxy", throwingProxy);
+const transparentProxy = new Proxy({review_owner: "Alice"}, {});
+mustReject("transparent proxy", transparentProxy);
+const proxiedCandidate = new Proxy(candidate, {});
+if (api.validateCandidate(proxiedCandidate, {hashText}).valid) {
+  throw new Error("transparent candidate Proxy passed validation");
+}
+if (api.evaluateFreshness(candidate, new Proxy(caseRecord, {}), {hashText, now: "2026-08-01T12:01:01.000Z"}).freshness !== "invalid") {
+  throw new Error("transparent live-case Proxy was not invalid");
+}
+const decomposedKey = {};
+decomposedKey["e\u0301"] = "value";
+mustReject("non-NFC object key", decomposedKey);
+const surrogateKey = {};
+surrogateKey["\ud800"] = "value";
+mustReject("surrogate object key", surrogateKey);
+
+const inheritedPrototype = {...caseRecord, extension: {review_owner: "Alice"}, constructor: Object};
+const inheritedCase = Object.create(inheritedPrototype);
+inheritedCase.revision_sha256 = "0".repeat(64);
+try {
+  api.computeCaseRevision(inheritedCase, {hashText});
+  throw new Error("inherited structural case fields were hashed");
+} catch (error) {
+  if (!`${error.message}`.includes("case record")) throw error;
+}
+inheritedPrototype.extension.review_owner = "Mallory";
+if (api.evaluateFreshness(candidate, inheritedCase, {hashText, now: "2026-08-01T12:01:02.000Z"}).freshness === "current") {
+  throw new Error("mutated inherited case was current");
+}
+try {
+  build({case_record: inheritedCase});
+  throw new Error("inherited structural case fields entered the builder");
+} catch (error) {
+  if (!`${error.message}`.includes("plain JSON")) throw error;
+}
+
+const customObjectPrototype = {extension: {review_owner: "Alice"}, constructor: Object};
+const ownFieldsOnCustomPrototype = Object.assign(Object.create(customObjectPrototype), caseRecord);
+if (api.evaluateFreshness(candidate, ownFieldsOnCustomPrototype, {hashText, now: "2026-08-01T12:01:03.000Z"}).freshness === "current") {
+  throw new Error("own fields on a custom prototype were current");
+}
+try {
+  api.computeCaseRevision(ownFieldsOnCustomPrototype, {hashText});
+  throw new Error("custom object prototype entered the revision hash");
+} catch (error) {
+  if (!`${error.message}`.includes("case record")) throw error;
+}
+"""
+    )
+
+
+def test_learning_acceptance_requires_the_embedded_snapshot_to_match_the_live_case():
+    run_model_smoke(
+        r"""
+function assertSnapshotRejected(label, mutate) {
+  const candidate = build();
+  mutate(candidate);
+  const intrinsic = api.validateCandidate(candidate, {hashText});
+  if (!intrinsic.valid) throw new Error(`${label} did not reproduce: ${JSON.stringify(intrinsic.errors)}`);
+  const binding = api.evaluateFreshness(candidate, caseRecord, {hashText, now: "2026-08-01T12:01:00.000Z"});
+  if (binding.freshness === "current") throw new Error(`${label} snapshot was considered current`);
+  try {
+    api.transitionCandidate(candidate, "accepted", `Reviewed ${label}.`, {hashText, liveCase: caseRecord, now: "2026-08-01T12:02:00.000Z"});
+    throw new Error(`${label} snapshot was accepted`);
+  } catch (error) {
+    if (!`${error.message}`.includes("current")) throw error;
+  }
+}
+assertSnapshotRejected("claim text/hash", (candidate) => {
+  const claim = candidate.nodes.find((node) => node.node_type === "claim");
+  claim.text = "A different but internally hashed claim.";
+  claim.text_sha256 = hashText(claim.text);
+});
+assertSnapshotRejected("claim source", (candidate) => {
+  candidate.nodes.find((node) => node.node_type === "claim").source_ref = "operator-source-002";
+});
+assertSnapshotRejected("core version", (candidate) => {
+  candidate.nodes.find((node) => node.node_type === "case").core_version_ref = "v999";
+});
+assertSnapshotRejected("evidence limitations", (candidate) => {
+  candidate.nodes.find((node) => node.node_type === "evidence").limitations = ["A different limitation."];
+});
+assertSnapshotRejected("source relation semantics", (candidate) => {
+  const relation = candidate.relations.find((edge) => edge.type === "SUPPORTS_ATTRIBUTION");
+  relation.type = "SUPPORTS_CLAIM";
+  relation.epistemic_status = "corroboration";
+});
+"""
+    )
+
+
+def test_learning_freshness_returns_invalid_for_malformed_case_collections():
+    run_model_smoke(
+        r"""
+const candidate = build();
+for (const [field, value] of [
+  ["claims", {}],
+  ["evidence", {}],
+  ["relationships", {}],
+  ["claims", [null]],
+  ["evidence", [{evidence_id: "evidence-001"}]],
+  ["relationships", [null]]
+]) {
+  const malformed = JSON.parse(JSON.stringify(caseRecord));
+  malformed[field] = value;
+  const result = api.evaluateFreshness(candidate, malformed, {
+    hashText,
+    now: "2026-08-01T12:02:00.000Z"
+  });
+  if (result.freshness !== "invalid") {
+    throw new Error(`${field} malformed collection returned ${result.freshness}`);
+  }
+  try {
+    api.computeCaseRevision(malformed, {hashText});
+    throw new Error(`${field} malformed collection was hashed`);
+  } catch (error) {
+    if (!`${error.message}`.includes("case record")) throw error;
+  }
+}
+"""
+    )
+
+
+def test_learning_export_import_store_limits_conflicts_and_case_delete_are_fail_closed():
+    run_model_smoke(
+        r"""
+const candidate = build();
+const binding = api.evaluateFreshness(candidate, caseRecord, {hashText, now: "2026-08-01T12:01:00.000Z"});
+const exported = api.createExport(candidate, {hashText, now: "2026-08-01T12:02:00.000Z"});
+const imported = api.parseImport(JSON.stringify(exported), {hashText});
+if (api.stableStringify(imported) !== api.stableStringify(candidate)) throw new Error("round trip drifted");
+
+let store = api.insertEntry(api.createStore(), {candidate, binding}, {hashText});
+if (api.validateStore(store) !== false) throw new Error("store validation succeeded without hash dependency");
+const wrongBinding = {...binding, checked_case_sha256: hashText("different revision")};
+try {
+  api.insertEntry(api.createStore(), {candidate, binding: wrongBinding}, {hashText});
+  throw new Error("mismatched current binding was accepted");
+} catch (error) {
+  if (!`${error.message}`.includes("binding")) throw error;
+}
+const same = api.insertEntry(store, {candidate, binding}, {hashText});
+if (same.entries.length !== 1) throw new Error("exact duplicate was added twice");
+const conflicting = JSON.parse(JSON.stringify(candidate));
+conflicting.next_experiment = "Different bytes under the same ID.";
+try {
+  store = api.insertEntry(store, {candidate: conflicting, binding}, {hashText});
+  throw new Error("conflict overwrote local record");
+} catch (error) {
+  if (!`${error.message}`.includes("conflict")) throw error;
+}
+try {
+  api.insertEntry(store, {candidate: build({candidate_id: "learning-00000000-0000-4000-8000-000000000002"}), binding}, {hashText, maxEntries: 1});
+  throw new Error("store silently evicted an entry");
+} catch (error) {
+  if (!`${error.message}`.includes("full")) throw error;
+}
+let boundedStore = api.createStore();
+for (let index = 0; index < 50; index += 1) {
+  const item = build({candidate_id: `learning-bounded-${String(index).padStart(3, "0")}`});
+  boundedStore = api.insertEntry(boundedStore, {candidate: item, binding}, {hashText, maxEntries: 51});
+}
+try {
+  const item = build({candidate_id: "learning-bounded-050"});
+  api.insertEntry(boundedStore, {candidate: item, binding}, {hashText, maxEntries: 51});
+  throw new Error("caller expanded the hard 50-entry limit");
+} catch (error) {
+  if (!`${error.message}`.includes("full")) throw error;
+}
+const removed = api.deleteCaseEntries(store, "operator-case-001", {hashText});
+if (removed.removed !== 1 || removed.store.entries.length !== 0) throw new Error("case cascade failed");
+
+const badChecksum = JSON.parse(JSON.stringify(exported));
+badChecksum.candidate_sha256 = "0".repeat(64);
+try { api.parseImport(JSON.stringify(badChecksum), {hashText}); throw new Error("bad checksum accepted"); }
+catch (error) { if (!`${error.message}`.includes("checksum")) throw error; }
+const badVersion = JSON.parse(JSON.stringify(exported));
+badVersion.export_version = "operator_learning_export.v999";
+try { api.parseImport(JSON.stringify(badVersion), {hashText}); throw new Error("unknown version accepted"); }
+catch (error) { if (!`${error.message}`.includes("version")) throw error; }
+try { api.createExport(candidate, {hashText, now: "not-a-timestamp"}); throw new Error("invalid export timestamp accepted"); }
+catch (error) { if (!`${error.message}`.includes("timestamp")) throw error; }
+const deepImport = `{"export_version":"operator_learning_export.v1","candidate_sha256":"${"0".repeat(64)}","exported_at_utc":"2026-08-01T12:00:00.000Z","candidate":${"[".repeat(12000)}null${"]".repeat(12000)}}`;
+try { api.parseImport(deepImport, {hashText}); throw new Error("deep import accepted"); }
+catch (error) {
+  if (error instanceof RangeError || !`${error.message}`.includes("nesting")) throw error;
+}
+const statefulText = {
+  calls: 0,
+  toString() {
+    this.calls += 1;
+    return this.calls === 1 ? "{}" : " ".repeat(api.limits.maxImportBytes + 1) + JSON.stringify(exported);
+  }
+};
+try { api.parseImport(statefulText, {hashText}); throw new Error("non-string import accepted"); }
+catch (error) { if (!`${error.message}`.includes("JSON string")) throw error; }
+if (statefulText.calls !== 0) throw new Error("import coerced an untrusted object");
+"""
+    )
+
+
+def test_learning_store_validation_enforces_the_entry_byte_limit_on_reload():
+    run_model_smoke(
+        r"""
+const largeCase = JSON.parse(JSON.stringify(caseRecord));
+largeCase.claims = [];
+largeCase.evidence = [];
+largeCase.relationships = [];
+for (let index = 0; index < 6; index += 1) {
+  const suffix = String(index + 1).padStart(3, "0");
+  largeCase.claims.push({claim_id: `claim-${suffix}`, text: `claim-${suffix}:` + "x".repeat(19800), source_ref: "operator-source-001"});
+  largeCase.evidence.push({evidence_id: `evidence-${suffix}`, text: `evidence-${suffix}:` + "y".repeat(19800), source_ref: "operator-source-001", limitations: ["Human review required."]});
+  largeCase.relationships.push({type: "SUPPORTS_ATTRIBUTION", from_ref: `evidence-${suffix}`, to_ref: `claim-${suffix}`});
+}
+largeCase.revision_sha256 = api.computeCaseRevision(largeCase, {hashText});
+const candidate = build({case_record: largeCase});
+const binding = api.evaluateFreshness(candidate, largeCase, {hashText, now: "2026-08-01T12:01:00.000Z"});
+binding.reason = "r".repeat(20000);
+const entry = {candidate, binding};
+const candidateBytes = new TextEncoder().encode(api.stableStringify(candidate)).byteLength;
+const entryBytes = new TextEncoder().encode(api.stableStringify(entry)).byteLength;
+if (candidateBytes > api.limits.maxEntryBytes || entryBytes <= api.limits.maxEntryBytes) {
+  throw new Error(`fixture did not straddle entry cap: candidate=${candidateBytes}, entry=${entryBytes}`);
+}
+const preloaded = {store_version: api.storeVersion, entries: [entry]};
+if (api.validateStore(preloaded, {hashText})) throw new Error("oversized preloaded entry passed store validation");
+try {
+  api.insertEntry(api.createStore(), entry, {hashText});
+  throw new Error("oversized new entry passed insertion");
+} catch (error) {
+  if (!`${error.message}`.includes("size limit")) throw error;
+}
+"""
+    )
+
+
+def test_learning_candidate_record_limit_is_enforced_before_storage_or_export():
+    run_model_smoke(
+        r"""
+const largeCase = JSON.parse(JSON.stringify(caseRecord));
+largeCase.claims = [];
+largeCase.evidence = [];
+largeCase.relationships = [];
+for (let index = 0; index < 8; index += 1) {
+  const suffix = String(index + 1).padStart(3, "0");
+  largeCase.claims.push({claim_id: `claim-${suffix}`, text: `claim-${suffix}:` + "x".repeat(19900), source_ref: "operator-source-001"});
+  largeCase.evidence.push({evidence_id: `evidence-${suffix}`, text: `evidence-${suffix}:` + "y".repeat(19900), source_ref: "operator-source-001", limitations: ["Human review required."]});
+  largeCase.relationships.push({type: "SUPPORTS_ATTRIBUTION", from_ref: `evidence-${suffix}`, to_ref: `claim-${suffix}`});
+}
+largeCase.revision_sha256 = api.computeCaseRevision(largeCase, {hashText});
+try {
+  build({case_record: largeCase});
+  throw new Error("oversized candidate was accepted");
+} catch (error) {
+  if (!`${error.message}`.includes("256 KiB")) throw error;
+}
+"""
+    )
+
+
+def test_learning_model_has_no_network_dom_or_automatic_training_path():
+    source = MODULE.read_text(encoding="utf-8")
+
+    for forbidden in (
+        "fetch(",
+        "XMLHttpRequest",
+        "WebSocket",
+        "sendBeacon",
+        "innerHTML",
+        "outerHTML",
+        "insertAdjacentHTML",
+    ):
+        assert forbidden not in source
+
+    assert "local-non-canonical" in source
+    assert "system-suggested" in source
+    assert "system-suggested relations are forbidden in v1" in source
+    assert "Only a current candidate can be accepted locally" in source
+
+
+def test_learning_rfc_marks_model_only_status_and_future_indexeddb_gate():
+    text = RFC.read_text(encoding="utf-8")
+    prose = " ".join(text.split())
+
+    assert "Model-only prototype contract; not integrated into Operator" in prose
+    assert "current Operator UI does not load this module" in prose
+    assert "does not persist candidates" in prose
+    assert "model-layer adapter uses IndexedDB database" in prose
+    assert "additional hard ceiling of 16 MiB" in prose
+    assert "Stored bytes are treated as untrusted" in prose
+    assert "append-only per candidate ID" in prose
+    assert "does not yet expose an edit-in-place API" in prose

--- a/tests/test_operator_learning_store.py
+++ b/tests/test_operator_learning_store.py
@@ -1,0 +1,1044 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL = ROOT / "site" / "operator" / "learning-candidate.v1.js"
+ADAPTER = ROOT / "site" / "operator" / "learning-store.v1.js"
+RFC = ROOT / "docs" / "rfc" / "operator_local_learning_candidate.md"
+OPERATOR = ROOT / "site" / "operator" / "index.html"
+SERVICE_WORKER = ROOT / "site" / "operator" / "sw.js"
+NODE = shutil.which("node")
+
+
+HARNESS = r"""
+const fs = require("fs");
+const vm = require("vm");
+const crypto = require("crypto");
+vm.runInThisContext(fs.readFileSync(process.env.LEARNING_MODEL, "utf8"));
+vm.runInThisContext(fs.readFileSync(process.env.LEARNING_STORE, "utf8"));
+const model = globalThis.HUB_OPTIMUS_LEARNING_CANDIDATE_V1;
+const storage = globalThis.HUB_OPTIMUS_LEARNING_STORE_V1;
+const hashText = (value) => crypto.createHash("sha256").update(value, "utf8").digest("hex");
+
+function clone(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function namedError(name, message) {
+  const error = new Error(message || name);
+  error.name = name;
+  return error;
+}
+
+class FakeRequest {
+  constructor() {
+    this.result = undefined;
+    this.error = null;
+    this.onsuccess = null;
+    this.onerror = null;
+    this.onblocked = null;
+    this.onupgradeneeded = null;
+    this.transaction = null;
+  }
+}
+
+class FakeTransaction {
+  constructor(factory, mode) {
+    this.factory = factory;
+    this.mode = mode;
+    this.error = null;
+    this.oncomplete = null;
+    this.onabort = null;
+    this.onerror = null;
+    this.pending = 0;
+    this.completed = false;
+    this.aborted = false;
+    this.completeTimer = null;
+    this.operations = [];
+    this.started = false;
+    this.waitingRequests = [];
+    this.working = null;
+    factory.enqueueTransaction(this);
+  }
+
+  start() {
+    if (this.started || this.aborted) return;
+    const source = this.factory.state.stores.get("learning_store");
+    this.working = new Map([...source.entries()].map(([key, value]) => [key, clone(value)]));
+    this.started = true;
+    const waiting = this.waitingRequests.splice(0);
+    waiting.forEach((execute) => execute());
+  }
+
+  objectStore(name) {
+    if (name !== "learning_store") throw namedError("NotFoundError");
+    return new FakeObjectStore(this);
+  }
+
+  request(operation, callback) {
+    const request = new FakeRequest();
+    this.operations.push(operation);
+    this.pending += 1;
+    clearTimeout(this.completeTimer);
+    const execute = () => setTimeout(() => {
+      if (this.aborted) return;
+      try {
+        request.result = clone(callback());
+        if (request.onsuccess) request.onsuccess({target: request});
+        this.pending -= 1;
+        this.scheduleComplete();
+      } catch (error) {
+        request.error = error;
+        this.error = error;
+        if (request.onerror) request.onerror({target: request});
+        this.abortInternal(error);
+      }
+    }, 0);
+    if (this.started) execute();
+    else this.waitingRequests.push(execute);
+    return request;
+  }
+
+  scheduleComplete() {
+    clearTimeout(this.completeTimer);
+    this.completeTimer = setTimeout(() => {
+      if (this.pending || this.aborted || this.completed) return;
+      if (this.mode === "readwrite") {
+        this.factory.state.stores.set(
+          "learning_store",
+          new Map([...this.working.entries()].map(([key, value]) => [key, clone(value)]))
+        );
+        this.factory.commitCount += 1;
+      }
+      this.completed = true;
+      this.factory.releaseTransaction(this);
+      if (this.oncomplete) this.oncomplete();
+    }, 0);
+  }
+
+  abortInternal(error) {
+    if (this.aborted || this.completed) return;
+    clearTimeout(this.completeTimer);
+    this.aborted = true;
+    this.error = error || this.error;
+    this.factory.abortCount += 1;
+    this.factory.releaseTransaction(this);
+    setTimeout(() => {
+      if (this.onerror) this.onerror();
+      if (this.onabort) this.onabort();
+    }, 0);
+  }
+
+  abort() {
+    if (this.completed) throw namedError("InvalidStateError");
+    this.abortInternal(this.error);
+  }
+}
+
+class FakeObjectStore {
+  constructor(transaction) {
+    this.transaction = transaction;
+    this.keyPath = transaction.factory.storeKeyPath;
+    this.autoIncrement = transaction.factory.storeAutoIncrement;
+    this.indexNames = [...transaction.factory.storeIndexNames];
+  }
+
+  count() {
+    return this.transaction.request("count", () => this.transaction.working.size);
+  }
+
+  get(key) {
+    return this.transaction.request("get", () => this.transaction.working.get(key));
+  }
+
+  put(value, key) {
+    return this.transaction.request("put", () => {
+      if (this.transaction.mode !== "readwrite") throw namedError("ReadOnlyError");
+      if (this.transaction.factory.quotaOnPut) throw namedError("QuotaExceededError");
+      this.transaction.working.set(key, clone(value));
+      return key;
+    });
+  }
+}
+
+class FakeDatabase {
+  constructor(factory) {
+    this.factory = factory;
+    this.closed = false;
+    this.onversionchange = null;
+    factory.connections.push(this);
+  }
+
+  get objectStoreNames() {
+    return [...this.factory.state.stores.keys()];
+  }
+
+  createObjectStore(name, options = {}) {
+    if (this.factory.state.stores.has(name)) throw namedError("ConstraintError");
+    this.factory.storeKeyPath = Object.prototype.hasOwnProperty.call(options, "keyPath")
+      ? options.keyPath
+      : null;
+    this.factory.storeAutoIncrement = options.autoIncrement === true;
+    this.factory.storeIndexNames = [];
+    const data = new Map();
+    this.factory.state.stores.set(name, data);
+    return {
+      put: (value, key) => {
+        data.set(key, clone(value));
+        const request = new FakeRequest();
+        request.result = key;
+        setTimeout(() => request.onsuccess && request.onsuccess({target: request}), 0);
+        return request;
+      }
+    };
+  }
+
+  transaction(name, mode) {
+    if (this.closed) throw namedError("InvalidStateError");
+    if (!this.factory.state.stores.has(name)) throw namedError("NotFoundError");
+    const transaction = new FakeTransaction(this.factory, mode);
+    this.factory.transactions.push(transaction);
+    return transaction;
+  }
+
+  close() {
+    if (!this.closed) this.factory.closeCount += 1;
+    this.closed = true;
+  }
+}
+
+class FakeIndexedDB {
+  constructor() {
+    this.state = {version: 0, stores: new Map()};
+    this.blocked = false;
+    this.continueAfterBlocked = false;
+    this.failOpen = null;
+    this.quotaOnPut = false;
+    this.commitCount = 0;
+    this.abortCount = 0;
+    this.closeCount = 0;
+    this.transactions = [];
+    this.connections = [];
+    this.lastOpen = null;
+    this.storeKeyPath = null;
+    this.storeAutoIncrement = false;
+    this.storeIndexNames = [];
+    this.activeTransaction = null;
+    this.transactionQueue = [];
+  }
+
+  enqueueTransaction(transaction) {
+    if (!this.activeTransaction) {
+      this.activeTransaction = transaction;
+      transaction.start();
+      return;
+    }
+    this.transactionQueue.push(transaction);
+  }
+
+  releaseTransaction(transaction) {
+    if (this.activeTransaction !== transaction) {
+      this.transactionQueue = this.transactionQueue.filter((item) => item !== transaction);
+      return;
+    }
+    this.activeTransaction = null;
+    const next = this.transactionQueue.shift();
+    if (next) {
+      this.activeTransaction = next;
+      next.start();
+    }
+  }
+
+  open(name, version) {
+    const request = new FakeRequest();
+    this.lastOpen = {name, version};
+    setTimeout(() => {
+      if (this.blocked) {
+        if (request.onblocked) request.onblocked({target: request});
+        if (!this.continueAfterBlocked) return;
+      }
+      if (this.failOpen) {
+        request.error = namedError(this.failOpen);
+        if (request.onerror) request.onerror({target: request});
+        return;
+      }
+      if (this.state.version > version) {
+        request.error = namedError("VersionError");
+        if (request.onerror) request.onerror({target: request});
+        return;
+      }
+      const database = new FakeDatabase(this);
+      request.result = database;
+      if (this.state.version < version) {
+        let upgradeAborted = false;
+        request.transaction = {abort() { upgradeAborted = true; }};
+        if (request.onupgradeneeded) {
+          request.onupgradeneeded({oldVersion: this.state.version, newVersion: version, target: request});
+        }
+        if (upgradeAborted) {
+          request.error = namedError("AbortError");
+          if (request.onerror) request.onerror({target: request});
+          return;
+        }
+        this.state.version = version;
+      }
+      setTimeout(() => request.onsuccess && request.onsuccess({target: request}), 0);
+    }, 0);
+    return request;
+  }
+
+  rawRecord() {
+    return clone(this.state.stores.get("learning_store")?.get("operator_learning_store.v1"));
+  }
+
+  setRawRecord(value) {
+    this.state.stores.get("learning_store").set("operator_learning_store.v1", clone(value));
+  }
+
+  addExtraRecord() {
+    this.state.stores.get("learning_store").set("unexpected", {bad: true});
+  }
+}
+
+const caseRecord = {
+  case_id: "operator-case-001",
+  core_version_ref: "v1",
+  revision_sha256: "",
+  claims: [{claim_id: "claim-001", text: "The source states that review is delayed.", source_ref: "operator-source-001"}],
+  evidence: [{evidence_id: "evidence-001", text: "The extracted source contains the submitted delay statement.", source_ref: "operator-source-001", limitations: ["Attribution only; not independent corroboration."]}],
+  relationships: [{type: "SUPPORTS_ATTRIBUTION", from_ref: "evidence-001", to_ref: "claim-001"}]
+};
+caseRecord.revision_sha256 = model.computeCaseRevision(caseRecord, {hashText});
+
+function buildCandidate(candidateId = "learning-00000000-0000-4000-8000-000000000001") {
+  return model.buildCandidate({
+    candidate_id: candidateId,
+    case_record: caseRecord,
+    outcome: "A source-bound local draft was prepared; the reported delay remains unverified.",
+    signals: [
+      {text: "The submitted text describes a delay.", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]},
+      {text: "The source does not identify an independent verifier.", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]},
+      {text: "The escalation step is not defined.", claim_refs: ["claim-001"], evidence_refs: ["evidence-001"]}
+    ],
+    diagnosis: {text: "The draft exposes a verification gap.", categories: ["weak_verification"], evidence_refs: ["evidence-001"]},
+    gap: "No accountable verifier is recorded.",
+    action: {change: "Add a verification owner.", reason: "Make follow-up inspectable.", verification_criterion: "A reviewer can identify the owner."},
+    metrics: [{name: "clarity", value: 3}, {name: "verifiability", value: 1}, {name: "open_points", value: 2}],
+    iteration_decision: "repeat_same_scenario",
+    next_experiment: "Prepare the same case with a named verifier.",
+    closure_check: {final_text: true, verification_owner: true, scope_and_deadlines: true, open_points: true, minimum_patch: true},
+    creation_note: "Recorded manually after reviewing the draft."
+  }, {hashText, now: "2026-08-01T12:00:00.000Z"});
+}
+
+function binding(candidate) {
+  return model.evaluateFreshness(candidate, caseRecord, {hashText, now: "2026-08-01T12:01:00.000Z"});
+}
+
+function expectCode(error, code) {
+  if (!error || error.code !== code) throw new Error(`expected ${code}, got ${error?.code}: ${error?.message}`);
+}
+
+function absentExpectations() {
+  return {
+    expectedCandidateSha256: null,
+    expectedCaseRevisionSha256: null,
+    expectedEntrySha256: null
+  };
+}
+
+function expectations(presented) {
+  return {
+    expectedCandidateSha256: presented.candidate_sha256,
+    expectedCaseRevisionSha256: presented.case_revision_sha256,
+    expectedEntrySha256: presented.entry_sha256
+  };
+}
+"""
+
+
+def run_store_script(body: str):
+    assert NODE, "Node.js is required for Operator learning-store tests"
+    script = HARNESS + "\n(async () => {\n" + body + "\n})().catch((error) => { console.error(error); process.exit(1); });\n"
+    completed = subprocess.run(
+        [NODE, "-e", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "LEARNING_MODEL": str(MODEL),
+            "LEARNING_STORE": str(ADAPTER),
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout
+
+
+def test_learning_store_contract_is_model_only_and_has_no_ambient_side_channels():
+    source = ADAPTER.read_text(encoding="utf-8")
+    rfc = " ".join(RFC.read_text(encoding="utf-8").split())
+
+    assert '"hub_optimus_operator_learning_v1"' in source
+    assert "const DB_VERSION = 1" in source
+    assert '"operator_learning_store.v1"' in source
+    assert "16 * 1024 * 1024" in source
+    assert "expectedCandidateSha256" in source
+    assert "expectedCaseRevisionSha256" in source
+    assert "expectedEntrySha256" in source
+    assert "onblocked" in source
+    assert "onversionchange" in source
+    assert "QuotaExceededError" in source
+
+    for forbidden in (
+        "fetch(",
+        "XMLHttpRequest",
+        "WebSocket",
+        "sendBeacon",
+        "localStorage",
+    ):
+        assert forbidden not in source
+
+    assert "learning-store.v1.js" not in OPERATOR.read_text(encoding="utf-8")
+    assert "learning-store.v1.js" not in SERVICE_WORKER.read_text(encoding="utf-8")
+    assert "current Operator HTML and service worker do not load or cache it" in rfc
+    assert "additional hard ceiling of 16 MiB" in rfc
+
+
+def test_learning_store_upgrade_crud_import_export_and_atomic_transactions():
+    run_store_script(
+        r"""
+const factory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: factory, model, hashText, now: () => "2026-08-01T12:10:00.000Z"});
+if (JSON.stringify(storage.errorCodes) !== JSON.stringify(["unavailable", "blocked", "corrupt", "quota", "conflict"])) throw new Error("error taxonomy drifted");
+for (const method of ["list", "get", "upsert", "delete", "deleteCase", "clearExplicit", "import", "export"]) {
+  if (typeof adapter[method] !== "function") throw new Error(`missing adapter API: ${method}`);
+}
+const initial = await adapter.list();
+if (initial.entries.length !== 0) throw new Error("new store was not empty");
+if (factory.lastOpen.name !== storage.dbName || factory.lastOpen.version !== 1) throw new Error("wrong database identity");
+if (factory.state.stores.size !== 1 || factory.rawRecord().store_version !== model.storeVersion) throw new Error("upgrade did not create one versioned record");
+
+const candidate = buildCandidate();
+const entry = {candidate, binding: binding(candidate)};
+const beforeTransactions = factory.transactions.length;
+const inserted = await adapter.upsert(entry, absentExpectations());
+if (factory.transactions.length !== beforeTransactions + 1) throw new Error("upsert used more than one transaction");
+const insertTransaction = factory.transactions.at(-1);
+if (insertTransaction.mode !== "readwrite" || insertTransaction.operations.join(",") !== "count,get,put") throw new Error("upsert was not one atomic read-latest transaction");
+
+const fetched = await adapter.get(candidate.candidate_id);
+if (!fetched || fetched.candidate_sha256 !== inserted.entry.candidate_sha256) throw new Error("get did not return inserted candidate");
+const listed = await adapter.list();
+if (listed.entries.length !== 1 || listed.store_sha256 !== inserted.store_sha256) throw new Error("list drifted from stored state");
+
+const replacement = model.transitionCandidate(
+  candidate,
+  "accepted",
+  "Accepted through a pure reviewed-state transition.",
+  {hashText, liveCase: caseRecord, now: "2026-08-01T12:09:00.000Z"}
+);
+const replaced = await adapter.upsert(
+  {candidate: replacement, binding: binding(replacement)},
+  expectations(fetched)
+);
+if (replaced.entry.candidate_sha256 === fetched.candidate_sha256) throw new Error("replacement did not change candidate digest");
+
+try {
+  await adapter.exportCandidate(candidate.candidate_id);
+  throw new Error("export without expected tokens succeeded");
+} catch (error) { expectCode(error, "conflict"); }
+try {
+  await adapter.exportCandidate(candidate.candidate_id, {
+    expectations: expectations(fetched)
+  });
+  throw new Error("export with stale expected tokens succeeded");
+} catch (error) { expectCode(error, "conflict"); }
+const exported = await adapter.exportCandidate(candidate.candidate_id, {
+  expectations: expectations(replaced.entry),
+  now: "2026-08-01T12:11:00.000Z"
+});
+if (exported.export_version !== model.exportVersion) throw new Error("export contract drifted");
+
+await adapter.delete(candidate.candidate_id, {
+  ...expectations(replaced.entry)
+});
+if ((await adapter.list()).entries.length !== 0) throw new Error("explicit candidate delete failed");
+
+const imported = await adapter.importCandidate(
+  JSON.stringify(exported),
+  binding(replacement),
+  absentExpectations()
+);
+if (imported.entry.candidate_sha256 !== replaced.entry.candidate_sha256) throw new Error("import/export round trip drifted");
+const statefulImport = {calls: 0, toString() { this.calls += 1; return JSON.stringify(exported); }};
+try {
+  await adapter.importCandidate(
+    statefulImport,
+    binding(replacement),
+    expectations(imported.entry)
+  );
+  throw new Error("non-string adapter import succeeded");
+} catch (error) { expectCode(error, "corrupt"); }
+if (statefulImport.calls !== 0) throw new Error("adapter coerced non-string import input");
+"""
+    )
+
+
+def test_learning_store_conflicts_and_quota_abort_without_lost_updates():
+    run_store_script(
+        r"""
+const factory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: factory, model, hashText});
+await adapter.list();
+const candidate = buildCandidate();
+const inserted = await adapter.upsert(
+  {candidate, binding: binding(candidate)},
+  absentExpectations()
+);
+const committed = JSON.stringify(factory.rawRecord());
+const commitCount = factory.commitCount;
+
+try {
+  await adapter.upsert(
+    {candidate, binding: binding(candidate)},
+    {...expectations(inserted.entry), expectedCandidateSha256: "0".repeat(64)}
+  );
+  throw new Error("stale replacement succeeded");
+} catch (error) { expectCode(error, "conflict"); }
+if (JSON.stringify(factory.rawRecord()) !== committed || factory.commitCount !== commitCount) throw new Error("conflict changed committed bytes");
+if (factory.transactions.at(-1).operations.join(",") !== "count,get") throw new Error("conflict wrote before expected-state check");
+
+try {
+  await adapter.delete(candidate.candidate_id, {
+    ...expectations(inserted.entry),
+    expectedCaseRevisionSha256: "f".repeat(64)
+  });
+  throw new Error("stale case revision deleted candidate");
+} catch (error) { expectCode(error, "conflict"); }
+if (JSON.stringify(factory.rawRecord()) !== committed || factory.commitCount !== commitCount) throw new Error("revision conflict changed committed bytes");
+
+factory.quotaOnPut = true;
+try {
+  await adapter.delete(candidate.candidate_id, {
+    ...expectations(inserted.entry)
+  });
+  throw new Error("quota failure committed deletion");
+} catch (error) { expectCode(error, "quota"); }
+if (JSON.stringify(factory.rawRecord()) !== committed || factory.commitCount !== commitCount) throw new Error("quota failure was not atomic");
+
+const smallFactory = new FakeIndexedDB();
+const smallAdapter = storage.createAdapter({indexedDB: smallFactory, model, hashText, maxAggregateBytes: 1024});
+await smallAdapter.list();
+try {
+  await smallAdapter.upsert(
+    {candidate, binding: binding(candidate)},
+    absentExpectations()
+  );
+  throw new Error("aggregate cap accepted oversized store");
+} catch (error) { expectCode(error, "quota"); }
+if (smallFactory.rawRecord().entries.length !== 0) throw new Error("aggregate cap changed local state");
+
+const fullFactory = new FakeIndexedDB();
+const fullAdapter = storage.createAdapter({indexedDB: fullFactory, model, hashText});
+await fullAdapter.list();
+let fullStore = model.createStore();
+for (let index = 0; index < 50; index += 1) {
+  const fullCandidate = buildCandidate(`learning-full-${String(index).padStart(3, "0")}`);
+  fullStore = model.insertEntry(fullStore, {candidate: fullCandidate, binding: binding(fullCandidate)}, {hashText});
+}
+fullFactory.setRawRecord(fullStore);
+const overflowCandidate = buildCandidate("learning-full-050");
+try {
+  await fullAdapter.upsert(
+    {candidate: overflowCandidate, binding: binding(overflowCandidate)},
+    absentExpectations()
+  );
+  throw new Error("51st candidate was inserted");
+} catch (error) { expectCode(error, "quota"); }
+if (fullFactory.rawRecord().entries.length !== 50) throw new Error("full-store failure evicted a candidate");
+"""
+    )
+
+
+def test_learning_store_rejects_getters_and_proxies_before_serialization():
+    run_store_script(
+        r"""
+const factory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: factory, model, hashText});
+await adapter.list();
+const candidate = buildCandidate("learning-unsafe-entry");
+const freshness = binding(candidate);
+let getterCalls = 0;
+const getterEntry = {binding: freshness};
+Object.defineProperty(getterEntry, "candidate", {
+  enumerable: true,
+  get() {
+    getterCalls += 1;
+    return candidate;
+  }
+});
+try {
+  await adapter.upsert(getterEntry, absentExpectations());
+  throw new Error("getter entry was accepted");
+} catch (error) { expectCode(error, "corrupt"); }
+if (getterCalls !== 0) throw new Error("adapter invoked an untrusted entry getter");
+if (factory.rawRecord().entries.length !== 0) throw new Error("getter rejection changed storage");
+
+const proxyEntry = new Proxy({candidate, binding: freshness}, {});
+try {
+  await adapter.upsert(proxyEntry, absentExpectations());
+  throw new Error("Proxy entry was accepted");
+} catch (error) { expectCode(error, "corrupt"); }
+if (factory.rawRecord().entries.length !== 0) throw new Error("Proxy rejection changed storage");
+
+let expectationGetterCalls = 0;
+const getterExpectations = {
+  expectedCandidateSha256: null,
+  expectedCaseRevisionSha256: null
+};
+Object.defineProperty(getterExpectations, "expectedEntrySha256", {
+  enumerable: true,
+  get() {
+    expectationGetterCalls += 1;
+    return null;
+  }
+});
+try {
+  await adapter.upsert({candidate, binding: freshness}, getterExpectations);
+  throw new Error("getter expectations were accepted");
+} catch (error) { expectCode(error, "conflict"); }
+if (expectationGetterCalls !== 0) throw new Error("adapter invoked an expectation getter");
+
+const inserted = await adapter.upsert({candidate, binding: freshness}, absentExpectations());
+let exportGetterCalls = 0;
+const getterExportOptions = {};
+Object.defineProperty(getterExportOptions, "expectations", {
+  enumerable: true,
+  get() {
+    exportGetterCalls += 1;
+    return expectations(inserted.entry);
+  }
+});
+try {
+  await adapter.exportCandidate(candidate.candidate_id, getterExportOptions);
+  throw new Error("getter export options were accepted");
+} catch (error) { expectCode(error, "conflict"); }
+if (exportGetterCalls !== 0) throw new Error("adapter invoked an export-options getter");
+"""
+    )
+
+
+def test_learning_store_load_is_fail_closed_for_corruption_blocking_and_unavailability():
+    run_store_script(
+        r"""
+const corruptFactory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: corruptFactory, model, hashText});
+await adapter.list();
+const commits = corruptFactory.commitCount;
+corruptFactory.setRawRecord({store_version: "operator_learning_store.v999", entries: []});
+try { await adapter.list(); throw new Error("corrupt record loaded"); }
+catch (error) { expectCode(error, "corrupt"); }
+if (corruptFactory.commitCount !== commits) throw new Error("corruption triggered an implicit reset");
+
+corruptFactory.setRawRecord(model.createStore());
+corruptFactory.addExtraRecord();
+try { await adapter.list(); throw new Error("extra record loaded"); }
+catch (error) { expectCode(error, "corrupt"); }
+
+const blockedFactory = new FakeIndexedDB();
+blockedFactory.blocked = true;
+const blockedAdapter = storage.createAdapter({indexedDB: blockedFactory, model, hashText});
+try { await blockedAdapter.list(); throw new Error("blocked open succeeded"); }
+catch (error) { expectCode(error, "blocked"); }
+
+const blockedRaceFactory = new FakeIndexedDB();
+blockedRaceFactory.blocked = true;
+blockedRaceFactory.continueAfterBlocked = true;
+const blockedRaceAdapter = storage.createAdapter({indexedDB: blockedRaceFactory, model, hashText});
+try { await blockedRaceAdapter.list(); throw new Error("blocked race open succeeded"); }
+catch (error) { expectCode(error, "blocked"); }
+if (blockedRaceFactory.state.version !== 0 || blockedRaceFactory.state.stores.size !== 0) {
+  throw new Error("blocked request mutated the database after rejection");
+}
+
+try {
+  storage.createAdapter({indexedDB: null, model, hashText});
+  throw new Error("missing IndexedDB created an adapter");
+} catch (error) { expectCode(error, "unavailable"); }
+try {
+  storage.createAdapter({indexedDB: new FakeIndexedDB(), model, hashText: () => "0".repeat(64)});
+  throw new Error("non-SHA-256 dependency created an adapter");
+} catch (error) { expectCode(error, "unavailable"); }
+
+for (const [label, mutateSchema] of [
+  ["keyPath", (factory) => { factory.storeKeyPath = "store_version"; }],
+  ["autoIncrement", (factory) => { factory.storeAutoIncrement = true; }],
+  ["index", (factory) => { factory.storeIndexNames = ["candidate_id"]; }]
+]) {
+  const schemaFactory = new FakeIndexedDB();
+  const schemaAdapter = storage.createAdapter({indexedDB: schemaFactory, model, hashText});
+  await schemaAdapter.list();
+  mutateSchema(schemaFactory);
+  try { await schemaAdapter.list(); throw new Error(`${label} schema opened`); }
+  catch (error) { expectCode(error, "corrupt"); }
+}
+
+const versionFactory = new FakeIndexedDB();
+versionFactory.state.version = 2;
+versionFactory.state.stores.set("learning_store", new Map([["operator_learning_store.v1", model.createStore()]]));
+const versionAdapter = storage.createAdapter({indexedDB: versionFactory, model, hashText});
+try { await versionAdapter.list(); throw new Error("newer database version opened"); }
+catch (error) { expectCode(error, "unavailable"); }
+"""
+    )
+
+
+def test_learning_store_seals_reviewed_candidate_bytes_and_allows_pure_transitions():
+    run_store_script(
+        r"""
+function expectations(presented) {
+  return {
+    expectedCandidateSha256: presented.candidate_sha256,
+    expectedCaseRevisionSha256: presented.case_revision_sha256,
+    expectedEntrySha256: presented.entry_sha256
+  };
+}
+async function expectConflict(callback, label) {
+  try { await callback(); throw new Error(`${label} succeeded`); }
+  catch (error) { expectCode(error, "conflict"); }
+}
+
+const factory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: factory, model, hashText});
+await adapter.list();
+
+const originalDraft = buildCandidate("learning-reviewed-a");
+const accepted = model.transitionCandidate(
+  originalDraft,
+  "accepted",
+  "Accepted after explicit review.",
+  {hashText, liveCase: caseRecord, now: "2026-08-01T12:02:00.000Z"}
+);
+const insertedAccepted = await adapter.upsert(
+  {candidate: accepted, binding: binding(accepted)},
+  absentExpectations()
+);
+
+const mutatedAccepted = clone(accepted);
+mutatedAccepted.next_experiment = "Changed after acceptance without returning to draft.";
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: mutatedAccepted, binding: binding(mutatedAccepted)},
+    expectations(insertedAccepted.entry)
+  ),
+  "same-state accepted edit"
+);
+const rewrittenAcceptedHistory = clone(accepted);
+rewrittenAcceptedHistory.history[0].note = "Rewritten creation history.";
+if (!model.validateCandidate(rewrittenAcceptedHistory, {hashText}).valid) {
+  throw new Error("history rewrite fixture was not model-valid");
+}
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: rewrittenAcceptedHistory, binding: binding(rewrittenAcceptedHistory)},
+    expectations(insertedAccepted.entry)
+  ),
+  "same-state accepted history rewrite"
+);
+
+const invalidBinding = {
+  freshness: "invalid",
+  checked_case_sha256: null,
+  reason: "The live case is not available in this view.",
+  checked_at_utc: "2026-08-01T12:03:00.000Z"
+};
+const bindingOnly = await adapter.upsert(
+  {candidate: accepted, binding: invalidBinding},
+  expectations(insertedAccepted.entry)
+);
+if (bindingOnly.entry.candidate_sha256 !== insertedAccepted.entry.candidate_sha256
+  || bindingOnly.entry.entry.binding.freshness !== "invalid") {
+  throw new Error("binding-only reviewed update failed");
+}
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: accepted, binding: binding(accepted)},
+    expectations(insertedAccepted.entry)
+  ),
+  "stale binding-only update"
+);
+
+const returnedDraft = model.transitionCandidate(
+  accepted,
+  "draft",
+  "Returned to draft before editing.",
+  {hashText, now: "2026-08-01T12:04:00.000Z"}
+);
+const returned = await adapter.upsert(
+  {candidate: returnedDraft, binding: binding(returnedDraft)},
+  expectations(bindingOnly.entry)
+);
+const resetHistoryDraft = buildCandidate("learning-reviewed-a");
+if (!model.validateCandidate(resetHistoryDraft, {hashText}).valid) {
+  throw new Error("history reset fixture was not model-valid");
+}
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: resetHistoryDraft, binding: binding(resetHistoryDraft)},
+    expectations(returned.entry)
+  ),
+  "reviewed history truncation after return to draft"
+);
+const editedDraft = clone(returnedDraft);
+editedDraft.next_experiment = "Attempted edit under the same append-only candidate ID.";
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: editedDraft, binding: binding(editedDraft)},
+    expectations(returned.entry)
+  ),
+  "draft content replacement"
+);
+const revisedDraft = buildCandidate("learning-reviewed-a-revision-002");
+revisedDraft.next_experiment = "Edited content receives a new append-only candidate ID.";
+const revisedSaved = await adapter.upsert(
+  {candidate: revisedDraft, binding: binding(revisedDraft)},
+  absentExpectations()
+);
+if (revisedSaved.entry.candidate_id === returned.entry.candidate_id) {
+  throw new Error("edited draft reused an append-only candidate ID");
+}
+
+const sourceDraft = buildCandidate("learning-reviewed-b");
+const sourceSaved = await adapter.upsert(
+  {candidate: sourceDraft, binding: binding(sourceDraft)},
+  absentExpectations()
+);
+const rebasedDraft = clone(sourceDraft);
+const rebasedCase = rebasedDraft.nodes.find((node) => node.node_type === "case");
+const rebasedClaim = rebasedDraft.nodes.find((node) => node.node_type === "claim");
+rebasedCase.revision_sha256 = hashText("different live-case revision");
+rebasedClaim.text = "Different source claim embedded under the same candidate ID.";
+rebasedClaim.text_sha256 = hashText(rebasedClaim.text);
+const rebasedBinding = {
+  freshness: "current",
+  checked_case_sha256: rebasedCase.revision_sha256,
+  reason: "Forged current binding for the rebased snapshot fixture.",
+  checked_at_utc: "2026-08-01T12:04:30.000Z"
+};
+if (!model.validateCandidate(rebasedDraft, {hashText}).valid) {
+  throw new Error("provenance rebase fixture was not model-valid");
+}
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: rebasedDraft, binding: rebasedBinding},
+    expectations(sourceSaved.entry)
+  ),
+  "draft provenance rebase"
+);
+const pureAccepted = model.transitionCandidate(
+  sourceDraft,
+  "accepted",
+  "Accepted without bundled edits.",
+  {hashText, liveCase: caseRecord, now: "2026-08-01T12:05:00.000Z"}
+);
+const acceptedSaved = await adapter.upsert(
+  {candidate: pureAccepted, binding: binding(pureAccepted)},
+  expectations(sourceSaved.entry)
+);
+if (acceptedSaved.entry.entry.candidate.state !== "accepted") {
+  throw new Error("pure draft-to-accepted transition failed");
+}
+
+const bundledAcceptance = model.transitionCandidate(
+  buildCandidate("learning-reviewed-c"),
+  "accepted",
+  "Transition fixture.",
+  {hashText, liveCase: caseRecord, now: "2026-08-01T12:05:00.000Z"}
+);
+const bundledDraft = buildCandidate("learning-reviewed-c");
+const bundledDraftSaved = await adapter.upsert(
+  {candidate: bundledDraft, binding: binding(bundledDraft)},
+  absentExpectations()
+);
+bundledAcceptance.next_experiment = "Bundled content edit.";
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: bundledAcceptance, binding: binding(bundledAcceptance)},
+    expectations(bundledDraftSaved.entry)
+  ),
+  "bundled draft-to-accepted edit"
+);
+
+const bundledReturn = model.transitionCandidate(
+  pureAccepted,
+  "draft",
+  "Return fixture.",
+  {hashText, now: "2026-08-01T12:06:00.000Z"}
+);
+bundledReturn.next_experiment = "Bundled return edit.";
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: bundledReturn, binding: binding(bundledReturn)},
+    expectations(acceptedSaved.entry)
+  ),
+  "bundled accepted-to-draft edit"
+);
+const rewrittenReturn = model.transitionCandidate(
+  pureAccepted,
+  "draft",
+  "Return fixture.",
+  {hashText, now: "2026-08-01T12:06:00.000Z"}
+);
+rewrittenReturn.history[0].note = "Rewritten history prefix.";
+if (!model.validateCandidate(rewrittenReturn, {hashText}).valid) {
+  throw new Error("prefix rewrite fixture was not model-valid");
+}
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: rewrittenReturn, binding: binding(rewrittenReturn)},
+    expectations(acceptedSaved.entry)
+  ),
+  "rewritten reviewed-to-draft history prefix"
+);
+
+const rejectedDraft = buildCandidate("learning-reviewed-d");
+const rejectedDraftSaved = await adapter.upsert(
+  {candidate: rejectedDraft, binding: binding(rejectedDraft)},
+  absentExpectations()
+);
+const rejected = model.transitionCandidate(
+  rejectedDraft,
+  "rejected",
+  "Rejected after review.",
+  {hashText, now: "2026-08-01T12:07:00.000Z"}
+);
+const rejectedSaved = await adapter.upsert(
+  {candidate: rejected, binding: binding(rejected)},
+  expectations(rejectedDraftSaved.entry)
+);
+const mutatedRejected = clone(rejected);
+mutatedRejected.next_experiment = "Changed after rejection.";
+await expectConflict(
+  () => adapter.upsert(
+    {candidate: mutatedRejected, binding: binding(mutatedRejected)},
+    expectations(rejectedSaved.entry)
+  ),
+  "same-state rejected edit"
+);
+"""
+    )
+
+
+def test_learning_store_serializes_concurrent_readwrite_transactions():
+    run_store_script(
+        r"""
+const factory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: factory, model, hashText});
+await adapter.list();
+const left = buildCandidate("learning-concurrent-left");
+const right = buildCandidate("learning-concurrent-right");
+const results = await Promise.all([
+  adapter.upsert(
+    {candidate: left, binding: binding(left)},
+    absentExpectations()
+  ),
+  adapter.upsert(
+    {candidate: right, binding: binding(right)},
+    absentExpectations()
+  )
+]);
+if (results.length !== 2 || (await adapter.list()).entries.length !== 2) {
+  throw new Error("serialized concurrent inserts lost an entry");
+}
+
+const sameFactory = new FakeIndexedDB();
+const sameAdapter = storage.createAdapter({indexedDB: sameFactory, model, hashText});
+await sameAdapter.list();
+const sameA = buildCandidate("learning-concurrent-same");
+const sameB = clone(sameA);
+sameB.next_experiment = "A competing draft under the same candidate ID.";
+const settled = await Promise.allSettled([
+  sameAdapter.upsert(
+    {candidate: sameA, binding: binding(sameA)},
+    absentExpectations()
+  ),
+  sameAdapter.upsert(
+    {candidate: sameB, binding: binding(sameB)},
+    absentExpectations()
+  )
+]);
+if (settled.filter((item) => item.status === "fulfilled").length !== 1
+  || settled.filter((item) => item.status === "rejected" && item.reason?.code === "conflict").length !== 1
+  || (await sameAdapter.list()).entries.length !== 1) {
+  throw new Error(`same-ID concurrency was not serialized: ${JSON.stringify(settled)}`);
+}
+
+const orderedFactory = new FakeIndexedDB();
+const orderedAdapter = storage.createAdapter({indexedDB: orderedFactory, model, hashText});
+await orderedAdapter.list();
+const orderedCandidate = buildCandidate("learning-concurrent-ordered");
+const pendingWrite = orderedAdapter.upsert(
+  {candidate: orderedCandidate, binding: binding(orderedCandidate)},
+  absentExpectations()
+);
+const pendingRead = orderedAdapter.list();
+const [, orderedRead] = await Promise.all([pendingWrite, pendingRead]);
+if (orderedRead.entries.length !== 1
+  || orderedRead.entries[0].candidate_id !== orderedCandidate.candidate_id) {
+  throw new Error("readonly transaction overtook an earlier readwrite transaction");
+}
+"""
+    )
+
+
+def test_learning_store_case_delete_and_clear_require_exact_explicit_snapshots():
+    run_store_script(
+        r"""
+const factory = new FakeIndexedDB();
+const adapter = storage.createAdapter({indexedDB: factory, model, hashText});
+await adapter.list();
+for (const id of ["learning-case-a", "learning-case-b"]) {
+  const candidate = buildCandidate(id);
+  await adapter.upsert(
+    {candidate, binding: binding(candidate)},
+    absentExpectations()
+  );
+}
+const before = await adapter.list();
+try {
+  await adapter.deleteCase("operator-case-001", [before.entries[0]]);
+  throw new Error("partial case expectation deleted records");
+} catch (error) { expectCode(error, "conflict"); }
+if ((await adapter.list()).entries.length !== 2) throw new Error("case conflict changed records");
+
+const expected = before.entries.map((item) => ({
+  candidate_id: item.candidate_id,
+  candidate_sha256: item.candidate_sha256,
+  case_revision_sha256: item.case_revision_sha256,
+  entry_sha256: item.entry_sha256
+}));
+const deleted = await adapter.deleteCase("operator-case-001", expected);
+if (deleted.removed !== 2 || (await adapter.list()).entries.length !== 0) throw new Error("atomic case delete failed");
+
+const candidate = buildCandidate("learning-clear-a");
+await adapter.upsert(
+  {candidate, binding: binding(candidate)},
+  absentExpectations()
+);
+const populated = await adapter.list();
+try {
+  await adapter.clearExplicit("yes", populated.store_sha256);
+  throw new Error("weak confirmation cleared store");
+} catch (error) { expectCode(error, "conflict"); }
+try {
+  await adapter.clearExplicit(storage.clearConfirmation, "0".repeat(64));
+  throw new Error("stale store digest cleared store");
+} catch (error) { expectCode(error, "conflict"); }
+const cleared = await adapter.clearExplicit(storage.clearConfirmation, populated.store_sha256);
+if (cleared.removed !== 1 || (await adapter.list()).entries.length !== 0) throw new Error("explicit clear failed");
+"""
+    )

--- a/tests/test_rfc_registry.py
+++ b/tests/test_rfc_registry.py
@@ -106,7 +106,7 @@ def test_current_lifecycle_snapshot_is_explicitly_unratified() -> None:
         entry for entry in entries if entry["id"] == "operator-controlled-url-intake"
     )
 
-    assert counts["Draft"] == 14
+    assert counts["Draft"] == 15
     assert counts["Partially Implemented"] == 1
     assert counts["Accepted"] == 0
     assert counts["Implemented"] == 0


### PR DESCRIPTION
Refs #1836

## Scope
- adds the versioned local-learning candidate schema, validator and RFC
- adds atomic IndexedDB persistence, concurrency fingerprints, import/export and explicit deletion
- seals reviewed candidates against content/provenance/history rewrites
- keeps all candidates local, human-reviewed and outside Core/analysis/share outputs

## Verification
- stage suite: 592 passed, 12 skipped (PowerShell-only)
- schema/store adversarial suite included
- tree SHA: `22889426d11599c40fbb543f474580120e63134f`

The visible multilingual review UI is intentionally completed in the next #1834 PR so this layer remains independent of the i18n catalog.