### PR TITLE
fix(site): make the mobile landing task-first and responsive (#1833)

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -7,7 +7,7 @@
   const translations = {
     en: {
       title: "HUB_Optimus — Versioned public portfolio",
-      description: "The evidence-backed public portfolio of HUB_Optimus: Core, deterministic simulator, Semantic Engine contracts and CLI, Operator, research, governance, and Labs.",
+      description: "Turn a URL or source text into a structured, source-bound draft for human review, then inspect the versioned evidence, method, governance, and limits behind HUB_Optimus.",
       skip: "Skip to portfolio",
       homeAria: "HUB_Optimus home",
       brandDescriptor: "Versioned public portfolio",
@@ -18,12 +18,14 @@
       navBoundaries: "Boundaries",
       languageAria: "Language",
       openGithub: "Open GitHub",
-      heroEyebrow: "Public, versioned, evidence-backed",
+      heroEyebrow: "From source to reviewable draft",
       sequence: "Reality → Evidence → Inference → Narrative → Operational Signal",
-      heroLead: "An integrity-first diplomatic simulation workflow for structured evaluation, preventive mediation, and systemic learning.",
+      heroLead: "Turn a URL or source text into a structured, source-bound draft for human review—without presenting it as verified truth.",
       heroBoundary: "It supports better judgment. It is not an authority, a prediction engine, or a replacement for diplomacy.",
       explorePortfolio: "Explore the portfolio",
       openOperator: "Open Operator",
+      tryOperator: "Try Operator",
+      howItWorks: "How it works",
       truthSource: "Source of truth",
       truthCore: "Canonical v1 language",
       truthCoreValue: "Spanish",
@@ -38,6 +40,7 @@
       globeFallbackAlt: "HUB_Optimus approved geographic brand artwork",
       globeAria: "Interactive globe projected from real coastline coordinates. Routes are illustrative and are not live telemetry.",
       globeControls: "Drag, swipe, or use the arrow keys to rotate.",
+      globeFallbackNotice: "Static illustration · interactive controls unavailable",
       globeData: "Geographic data",
       principleAria: "Operating principle",
       principle: "Observe → detect → decide → act.",
@@ -171,7 +174,7 @@
     },
     es: {
       title: "HUB_Optimus — Portfolio público versionado",
-      description: "El portfolio público de HUB_Optimus respaldado por evidencia: Core, simulador determinista, contratos y CLI del Semantic Engine, Operator, investigación, gobernanza y Labs.",
+      description: "Convierte una URL o texto fuente en un borrador estructurado y vinculado a la fuente para revisión humana; después consulta la evidencia versionada, el método, la gobernanza y los límites de HUB_Optimus.",
       skip: "Ir al portfolio",
       homeAria: "Inicio de HUB_Optimus",
       brandDescriptor: "Portfolio público versionado",
@@ -182,12 +185,14 @@
       navBoundaries: "Límites",
       languageAria: "Idioma",
       openGithub: "Abrir GitHub",
-      heroEyebrow: "Público, versionado y respaldado por evidencia",
+      heroEyebrow: "De la fuente al borrador revisable",
       sequence: "Realidad → Evidencia → Inferencia → Narrativa → Señal operativa",
-      heroLead: "Un flujo de simulación diplomática que prioriza la integridad para la evaluación estructurada, la mediación preventiva y el aprendizaje sistémico.",
+      heroLead: "Convierte una URL o un texto fuente en un borrador estructurado y vinculado a la fuente para revisión humana, sin presentarlo como verdad verificada.",
       heroBoundary: "Ayuda a mejorar el criterio. No es una autoridad, un motor de predicción ni un sustituto de la diplomacia.",
       explorePortfolio: "Explorar el portfolio",
       openOperator: "Abrir Operator",
+      tryOperator: "Probar Operator",
+      howItWorks: "Cómo funciona",
       truthSource: "Fuente de verdad",
       truthCore: "Idioma canónico de v1",
       truthCoreValue: "Español",
@@ -202,6 +207,7 @@
       globeFallbackAlt: "Gráfico geográfico aprobado de la marca HUB_Optimus",
       globeAria: "Globo interactivo proyectado a partir de coordenadas costeras reales. Las rutas son ilustrativas y no representan telemetría en directo.",
       globeControls: "Arrastra, desliza o utiliza las flechas del teclado para girar.",
+      globeFallbackNotice: "Ilustración estática · controles interactivos no disponibles",
       globeData: "Datos geográficos",
       principleAria: "Principio operativo",
       principle: "Observar → detectar → decidir → actuar.",
@@ -335,7 +341,7 @@
     },
     de: {
       title: "HUB_Optimus — Versioniertes öffentliches Portfolio",
-      description: "Das evidenzgestützte öffentliche Portfolio von HUB_Optimus: Core, deterministischer Simulator, Verträge und CLI der Semantic Engine, Operator, Forschung, Governance und Labs.",
+      description: "Verwandle eine URL oder einen Quelltext in einen strukturierten, quellengebundenen Entwurf zur menschlichen Prüfung und prüfe anschließend die versionierten Nachweise, Methoden, Governance und Grenzen von HUB_Optimus.",
       skip: "Zum Portfolio springen",
       homeAria: "HUB_Optimus Startseite",
       brandDescriptor: "Versioniertes öffentliches Portfolio",
@@ -346,12 +352,14 @@
       navBoundaries: "Grenzen",
       languageAria: "Sprache",
       openGithub: "GitHub öffnen",
-      heroEyebrow: "Öffentlich, versioniert und evidenzgestützt",
+      heroEyebrow: "Von der Quelle zum prüfbaren Entwurf",
       sequence: "Realität → Evidenz → Schlussfolgerung → Narrativ → Operatives Signal",
-      heroLead: "Ein integritätsorientierter Workflow für diplomatische Simulation, strukturierte Bewertung, präventive Vermittlung und systemisches Lernen.",
+      heroLead: "Verwandle eine URL oder einen Quelltext in einen strukturierten, quellengebundenen Entwurf zur menschlichen Prüfung – ohne ihn als verifizierte Wahrheit darzustellen.",
       heroBoundary: "Das System unterstützt bessere Urteile. Es ist weder Autorität noch Prognosemaschine noch Ersatz für Diplomatie.",
       explorePortfolio: "Portfolio erkunden",
       openOperator: "Operator öffnen",
+      tryOperator: "Operator testen",
+      howItWorks: "So funktioniert es",
       truthSource: "Maßgebliche Quelle",
       truthCore: "Kanonische Sprache von v1",
       truthCoreValue: "Spanisch",
@@ -366,6 +374,7 @@
       globeFallbackAlt: "Freigegebene geografische Markengrafik von HUB_Optimus",
       globeAria: "Interaktiver Globus, projiziert aus realen Küstenkoordinaten. Die Routen sind illustrativ und stellen keine Live-Telemetrie dar.",
       globeControls: "Mit Ziehen, Wischen oder den Pfeiltasten drehen.",
+      globeFallbackNotice: "Statische Illustration · interaktive Steuerung nicht verfügbar",
       globeData: "Geografische Daten",
       principleAria: "Arbeitsprinzip",
       principle: "Beobachten → erkennen → entscheiden → handeln.",
@@ -499,7 +508,7 @@
     },
     ru: {
       title: "HUB_Optimus — Версионируемый публичный портфель",
-      description: "Публичный портфель HUB_Optimus, подкреплённый доказательствами: Core, детерминированный симулятор, контракты и CLI Semantic Engine, Operator, исследования, управление и Labs.",
+      description: "Преобразуйте URL или исходный текст в структурированный, привязанный к источнику черновик для проверки человеком, а затем изучите версионируемые доказательства, метод, управление и ограничения HUB_Optimus.",
       skip: "Перейти к портфелю",
       homeAria: "Главная страница HUB_Optimus",
       brandDescriptor: "Версионируемый публичный портфель",
@@ -510,12 +519,14 @@
       navBoundaries: "Границы",
       languageAria: "Язык",
       openGithub: "Открыть GitHub",
-      heroEyebrow: "Публично, версионируемо, с опорой на доказательства",
+      heroEyebrow: "От источника к проверяемому черновику",
       sequence: "Реальность → Доказательства → Вывод → Нарратив → Операционный сигнал",
-      heroLead: "Рабочий процесс дипломатического моделирования с приоритетом целостности для структурированной оценки, превентивного посредничества и системного обучения.",
+      heroLead: "Преобразуйте URL или исходный текст в структурированный черновик, привязанный к источнику, для проверки человеком — без представления его как подтверждённой истины.",
       heroBoundary: "Он помогает улучшить суждение. Это не орган власти, не механизм прогнозирования и не замена дипломатии.",
       explorePortfolio: "Изучить портфель",
       openOperator: "Открыть Operator",
+      tryOperator: "Попробовать Operator",
+      howItWorks: "Как это работает",
       truthSource: "Источник истины",
       truthCore: "Канонический язык v1",
       truthCoreValue: "Испанский",
@@ -530,6 +541,7 @@
       globeFallbackAlt: "Утверждённое географическое изображение бренда HUB_Optimus",
       globeAria: "Интерактивный глобус, построенный по реальным координатам береговой линии. Маршруты носят иллюстративный характер и не являются телеметрией в реальном времени.",
       globeControls: "Перетаскивайте, проводите пальцем или используйте клавиши со стрелками для вращения.",
+      globeFallbackNotice: "Статическая иллюстрация · интерактивное управление недоступно",
       globeData: "Географические данные",
       principleAria: "Операционный принцип",
       principle: "Наблюдать → обнаруживать → решать → действовать.",
@@ -663,7 +675,7 @@
     },
     he: {
       title: "HUB_Optimus — פורטפוליו ציבורי מנוהל בגרסאות",
-      description: "הפורטפוליו הציבורי של HUB_Optimus, המבוסס על ראיות: Core, סימולטור דטרמיניסטי, החוזים וממשק שורת הפקודה של Semantic Engine, ‏Operator, מחקר, ממשל ו-Labs.",
+      description: "הפכו כתובת URL או טקסט מקור לטיוטה מובנית המקושרת למקור לצורך בדיקה אנושית, ולאחר מכן עיינו בראיות, בשיטה, בממשל ובמגבלות של HUB_Optimus המתועדים בגרסאות.",
       skip: "דילוג לפורטפוליו",
       homeAria: "דף הבית של HUB_Optimus",
       brandDescriptor: "פורטפוליו ציבורי מנוהל בגרסאות",
@@ -674,12 +686,14 @@
       navBoundaries: "גבולות",
       languageAria: "שפה",
       openGithub: "פתיחת GitHub",
-      heroEyebrow: "ציבורי, מנוהל בגרסאות ומבוסס על ראיות",
+      heroEyebrow: "מהמקור לטיוטה הניתנת לבדיקה",
       sequence: "מציאות ← ראיות ← הסקה ← נרטיב ← אות תפעולי",
-      heroLead: "תהליך עבודה לסימולציה דיפלומטית, המעמיד יושרה בראש סדר העדיפויות, לצורך הערכה מובנית, תיווך מונע ולמידה מערכתית.",
+      heroLead: "הפכו כתובת URL או טקסט מקור לטיוטה מובנית המקושרת למקור לצורך בדיקה אנושית — בלי להציג אותה כאמת מאומתת.",
       heroBoundary: "הוא מסייע לשיקול דעת טוב יותר. הוא אינו סמכות, מנוע חיזוי או תחליף לדיפלומטיה.",
       explorePortfolio: "עיון בפורטפוליו",
       openOperator: "פתיחת Operator",
+      tryOperator: "ניסיון ב-Operator",
+      howItWorks: "איך זה עובד",
       truthSource: "מקור האמת",
       truthCore: "השפה הקנונית של v1",
       truthCoreValue: "ספרדית",
@@ -694,6 +708,7 @@
       globeFallbackAlt: "יצירת המותג הגאוגרפית המאושרת של HUB_Optimus",
       globeAria: "גלובוס אינטראקטיבי המוקרן מקואורדינטות אמיתיות של קווי חוף. המסלולים מיועדים להמחשה ואינם טלמטריה בזמן אמת.",
       globeControls: "גררו, החליקו או השתמשו במקשי החצים כדי לסובב.",
+      globeFallbackNotice: "איור סטטי · הפקדים האינטראקטיביים אינם זמינים",
       globeData: "נתונים גאוגרפיים",
       principleAria: "עיקרון תפעולי",
       principle: "להתבונן ← לזהות ← להחליט ← לפעול.",
@@ -827,7 +842,7 @@
     },
     "zh-Hans": {
       title: "HUB_Optimus — 版本化公开项目组合",
-      description: "以证据为依据的 HUB_Optimus 公开项目组合：Core、确定性模拟器、Semantic Engine 合约与 CLI、Operator、研究、治理和 Labs。",
+      description: "将 URL 或来源文本转换为结构化、与来源绑定的草稿，供人工审阅；随后查看 HUB_Optimus 的版本化证据、方法、治理与边界。",
       skip: "跳至项目组合",
       homeAria: "HUB_Optimus 首页",
       brandDescriptor: "版本化公开项目组合",
@@ -838,12 +853,14 @@
       navBoundaries: "边界",
       languageAria: "语言",
       openGithub: "打开 GitHub",
-      heroEyebrow: "公开、版本化、以证据为依据",
+      heroEyebrow: "从来源到可审阅草稿",
       sequence: "现实 → 证据 → 推断 → 叙事 → 运营信号",
-      heroLead: "以完整性为先的外交模拟工作流，用于结构化评估、预防性调解和系统性学习。",
+      heroLead: "将 URL 或来源文本转换为结构化、与来源绑定的草稿，供人工审阅，而不把它当作已核实的事实。",
       heroBoundary: "它帮助改善判断。它不是权威机构、预测引擎，也不能替代外交。",
       explorePortfolio: "浏览项目组合",
       openOperator: "打开 Operator",
+      tryOperator: "试用 Operator",
+      howItWorks: "工作原理",
       truthSource: "事实依据来源",
       truthCore: "v1 规范语言",
       truthCoreValue: "西班牙语",
@@ -858,6 +875,7 @@
       globeFallbackAlt: "经仓库认可的 HUB_Optimus 地理品牌图像",
       globeAria: "依据真实海岸线坐标投影的交互式地球仪。路线仅作说明，并非实时遥测。",
       globeControls: "拖动、滑动或使用方向键旋转。",
+      globeFallbackNotice: "静态插图 · 交互控件不可用",
       globeData: "地理数据",
       principleAria: "运营原则",
       principle: "观察 → 发现 → 决策 → 行动。",
@@ -1203,6 +1221,8 @@
   updateMotionButton();
 
   const fallback = canvas.parentElement.querySelector(".globe-fallback");
+  const interactiveNote = document.querySelector("[data-globe-interactive-note]");
+  const fallbackNote = document.querySelector("[data-globe-fallback-note]");
   let renderer = null;
   const state = {
     rotation: -8,
@@ -1225,6 +1245,8 @@
     if (document.activeElement === canvas) canvas.blur();
     motionButton.hidden = true;
     if (fallback) fallback.removeAttribute("aria-hidden");
+    if (interactiveNote) interactiveNote.hidden = true;
+    if (fallbackNote) fallbackNote.hidden = false;
   }
 
   function showInteractiveGlobe() {
@@ -1236,6 +1258,8 @@
     canvas.classList.add("is-ready");
     motionButton.hidden = false;
     if (fallback) fallback.setAttribute("aria-hidden", "true");
+    if (interactiveNote) interactiveNote.hidden = false;
+    if (fallbackNote) fallbackNote.hidden = true;
   }
 
   function drawGlobe() {

--- a/site/i18n/locale-metadata.v1.json
+++ b/site/i18n/locale-metadata.v1.json
@@ -13,7 +13,7 @@
     "supported_locales": ["en", "es", "de", "ru", "he", "zh-Hans"],
     "review_status": "AI/machine-assisted; qualified human linguistic review required"
   },
-  "portfolio_translation_key_count": 162,
+  "portfolio_translation_key_count": 165,
   "field_status": {
     "document_title_and_description": {
       "en": "AI-assisted terminology and register audit; named qualified human review required",

--- a/site/index.html
+++ b/site/index.html
@@ -6,9 +6,9 @@
   <meta name="theme-color" content="#0B0F14">
   <meta name="color-scheme" content="dark light">
   <title>HUB_Optimus — Versioned public portfolio</title>
-  <meta name="description" content="The evidence-backed public portfolio of HUB_Optimus: Core, deterministic simulator, Semantic Engine contracts and CLI, Operator, research, governance, and Labs.">
+  <meta name="description" content="Turn a URL or source text into a structured, source-bound draft for human review, then inspect the versioned evidence, method, governance, and limits behind HUB_Optimus.">
   <meta property="og:title" content="HUB_Optimus — Versioned public portfolio">
-  <meta property="og:description" content="Reality → Evidence → Inference → Narrative → Operational Signal.">
+  <meta property="og:description" content="Source-bound drafts for human review, with provenance, uncertainty, and limits kept visible.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://huboptimus.dev/">
   <meta property="og:image" content="https://huboptimus.dev/assets/brand/hub-optimus-hero.jpg">
@@ -58,15 +58,15 @@
         <div class="hero-copy">
           <p class="eyebrow">
             <span class="status-dot"></span>
-            <span data-i18n="heroEyebrow">Public, versioned, evidence-backed</span>
+            <span data-i18n="heroEyebrow">From source to reviewable draft</span>
           </p>
-          <h1 id="hero-title">HUB<span>_</span>Optimus</h1>
+          <h1 id="hero-title">HUB<span>_</span><wbr>Optimus</h1>
           <p class="signal-sequence" data-i18n="sequence">
             Reality → Evidence → Inference → Narrative → Operational Signal
           </p>
           <p class="hero-lead" data-i18n="heroLead">
-            An integrity-first diplomatic simulation workflow for structured evaluation,
-            preventive mediation, and systemic learning.
+            Turn a URL or source text into a structured, source-bound draft for human
+            review—without presenting it as verified truth.
           </p>
           <p class="hero-boundary" data-i18n="heroBoundary">
             It supports better judgment. It is not an authority, a prediction engine,
@@ -74,8 +74,8 @@
           </p>
 
           <div class="hero-actions">
-            <a class="button button-primary" href="#portfolio" data-i18n="explorePortfolio">Explore the portfolio</a>
-            <a class="button button-secondary" href="./operator/?lang=en#product_intake" hreflang="en" data-operator-route data-i18n="openOperator">Open Operator</a>
+            <a class="button button-primary" href="./operator/?lang=en#product_intake" hreflang="en" data-operator-route data-i18n="tryOperator">Try Operator</a>
+            <a class="button button-secondary" href="#method" data-i18n="howItWorks">How it works</a>
           </div>
 
           <dl class="truth-strip">
@@ -127,7 +127,8 @@
             </div>
           </div>
           <figcaption>
-            <span data-i18n="globeControls">Drag, swipe, or use the arrow keys to rotate.</span>
+            <span data-globe-interactive-note data-i18n="globeControls" hidden>Drag, swipe, or use the arrow keys to rotate.</span>
+            <span data-globe-fallback-note data-i18n="globeFallbackNotice">Static illustration · interactive controls unavailable</span>
             <a href="./assets/geo/README.md" data-document-route="geo.data" hreflang="en"><span data-i18n="globeData">Geographic data</span><small class="document-language-badge">EN · source</small></a>
           </figcaption>
           <noscript>

--- a/site/styles.css
+++ b/site/styles.css
@@ -42,6 +42,7 @@ body {
   font-family: var(--font-sans);
   font-size: 16px;
   line-height: 1.6;
+  overflow-wrap: anywhere;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
 }
@@ -214,7 +215,8 @@ canvas {
 }
 
 .language-switcher button {
-  min-width: 2.25rem;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
   padding: 0.35rem 0.55rem;
   border: 0;
   border-radius: 999px;
@@ -302,6 +304,10 @@ canvas {
   padding: clamp(4rem, 9vh, 8rem) 0;
 }
 
+.hero-copy {
+  min-width: 0;
+}
+
 .eyebrow,
 .section-kicker {
   margin: 0 0 1.25rem;
@@ -328,7 +334,7 @@ canvas {
 }
 
 .hero h1 {
-  max-width: 9ch;
+  max-width: 100%;
   margin: 0;
   font-size: clamp(3.8rem, 8vw, 8rem);
   font-weight: 720;
@@ -509,6 +515,7 @@ canvas {
 }
 
 .globe-toolbar button {
+  min-height: 2.75rem;
   padding: 0.45rem 0.72rem;
   border: 1px solid rgba(214, 164, 79, 0.48);
   border-radius: 999px;
@@ -551,8 +558,12 @@ canvas {
   z-index: 1;
   cursor: grab;
   opacity: 0;
-  touch-action: none;
+  touch-action: pan-y pinch-zoom;
   transition: opacity 300ms ease;
+}
+
+#world-globe:focus-visible {
+  outline-offset: -4px;
 }
 
 #world-globe.is-ready {
@@ -582,7 +593,7 @@ canvas {
   position: absolute;
   z-index: 2;
   top: 50%;
-  inset-inline-start: 50%;
+  left: 50%;
   display: flex;
   align-items: baseline;
   gap: 0.12rem;
@@ -1260,6 +1271,7 @@ canvas {
 
 .site-footer nav {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.2rem;
 }
 
@@ -1349,7 +1361,7 @@ canvas {
   }
 
   .hero h1 {
-    font-size: clamp(3.5rem, 18vw, 5.8rem);
+    font-size: clamp(1.75rem, 18vw, 5.8rem);
   }
 
   .hero-lead {
@@ -1361,7 +1373,7 @@ canvas {
   }
 
   .globe-stage {
-    min-height: 23rem;
+    min-height: clamp(18rem, 80vw, 23rem);
   }
 
   .globe-toolbar,
@@ -1506,16 +1518,58 @@ canvas {
 
 @media (max-width: 540px) {
   .site-header {
+    position: static;
     grid-template-columns: 1fr;
     gap: 0.45rem;
     justify-items: center;
     padding-block: 0.55rem;
   }
 
+  .language-switcher {
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 100%;
+  }
+
   .language-switcher button {
-    min-height: 2.25rem;
-    min-width: 2rem;
+    min-height: 2.75rem;
+    min-width: 2.75rem;
     padding-inline: 0.42rem;
+  }
+
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .hero-actions .button {
+    width: 100%;
+    min-height: 3.25rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .truth-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .globe-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .globe-toolbar button {
+    width: 100%;
+  }
+
+  .globe-stage {
+    min-height: clamp(14rem, 100vw, 18rem);
+  }
+
+  .site-footer nav {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.75rem;
   }
 }
 

--- a/tests/test_public_portfolio.py
+++ b/tests/test_public_portfolio.py
@@ -593,7 +593,7 @@ def test_public_javascript_syntax_and_translation_key_parity():
     source = APP.read_text(encoding="utf-8")
     dictionaries = extract_translation_dictionaries(source)
     assert set(dictionaries) == PUBLIC_LOCALES
-    assert len(dictionaries["en"]) == 162
+    assert len(dictionaries["en"]) == 165
     assert all(set(dictionary) == set(dictionaries["en"]) for dictionary in dictionaries.values())
     assert all(
         value.strip()
@@ -989,7 +989,7 @@ def test_translation_review_metadata_and_termbase_are_versioned_and_linked():
     assert set(operator_localization["advanced_audit_console_locales"]) == PUBLIC_LOCALES
     assert set(operator_localization["supported_locales"]) == PUBLIC_LOCALES
     assert "human" in operator_localization["review_status"]
-    assert metadata["portfolio_translation_key_count"] == 162
+    assert metadata["portfolio_translation_key_count"] == 165
     assert set(metadata["locales"]) == PUBLIC_LOCALES
     assert len(metadata["field_status"]) >= 10
     for record in metadata["locales"].values():
@@ -1215,7 +1215,7 @@ def test_small_screen_header_preserves_home_and_language_controls():
     assert ".language-switcher button" in mobile_section
     assert ".site-header > .brand" not in mobile_section
     assert "display: none" not in mobile_section
-    assert "min-height: 2.25rem" in mobile_section
+    assert "min-height: 2.75rem" in mobile_section
 
 
 def test_not_found_page_has_six_locales_and_resolving_routes():
@@ -1250,7 +1250,7 @@ def test_public_identity_uses_approved_repository_brand():
     )
 
     assert re.search(
-        r'<h1 id="hero-title">\s*HUB<span>_</span>Optimus\s*</h1>',
+        r'<h1 id="hero-title">\s*HUB<span>_</span><wbr>Optimus\s*</h1>',
         html,
     )
     assert "Reality → Evidence → Inference → Narrative → Operational Signal" in html
@@ -1752,6 +1752,10 @@ def test_globe_uses_real_geojson_with_attribution_and_accessible_controls():
     assert 'canvas.setAttribute("tabindex", "0")' in app
     assert 'canvas.removeAttribute("tabindex")' in app
     assert 'fallback.setAttribute("aria-hidden", "true")' in app
+    assert 'interactiveNote.hidden = true' in app
+    assert 'fallbackNote.hidden = false' in app
+    assert 'data-globe-interactive-note data-i18n="globeControls" hidden' in html
+    assert 'data-globe-fallback-note data-i18n="globeFallbackNotice">' in html
     assert "showStaticFallback" in app
     assert "webglcontextlost" in app
     assert "webglcontextrestored" in app
@@ -1771,7 +1775,12 @@ def test_globe_uses_real_geojson_with_attribution_and_accessible_controls():
     assert "three.js" not in globe.lower()
     assert "https://" not in globe
     assert "@media (prefers-reduced-motion: reduce)" in css
-    assert "touch-action: none" in css
+    assert "touch-action: pan-y pinch-zoom" in css
+    globe_core_rule = re.search(r"\.globe-core\s*\{(?P<body>.*?)\}", css, re.DOTALL)
+    assert globe_core_rule
+    assert "left: 50%" in globe_core_rule.group("body")
+    assert "inset-inline-start" not in globe_core_rule.group("body")
+    assert "touch-action: none" not in css
     assert ".no-js #world-globe" in css
     assert "function showStaticFallback()" in app
     assert 'canvas.removeAttribute("tabindex")' in app
@@ -1779,6 +1788,41 @@ def test_globe_uses_real_geojson_with_attribution_and_accessible_controls():
     assert "canvas.hidden = false" in app
     assert "canvas.blur()" in app
     assert app.count("showStaticFallback();") == 3
+
+
+def test_mobile_hero_keeps_brand_visible_and_prioritizes_operator():
+    html = INDEX.read_text(encoding="utf-8")
+    css = STYLES.read_text(encoding="utf-8")
+
+    operator_cta = (
+        '<a class="button button-primary" href="./operator/?lang=en#product_intake" hreflang="en" '
+        'data-operator-route data-i18n="tryOperator">Try Operator</a>'
+    )
+    method_cta = (
+        '<a class="button button-secondary" href="#method" '
+        'data-i18n="howItWorks">How it works</a>'
+    )
+
+    assert operator_cta in html
+    assert method_cta in html
+    assert html.index(operator_cta) < html.index(method_cta)
+    assert re.search(r"\.hero-copy\s*\{[^}]*min-width:\s*0;", css, re.DOTALL)
+    assert re.search(r"\.hero h1\s*\{[^}]*max-width:\s*100%;", css, re.DOTALL)
+    assert re.search(r"body\s*\{[^}]*overflow-wrap:\s*anywhere;", css, re.DOTALL)
+    mobile_rule = css.split("@media (max-width: 760px)", 1)[1]
+    assert "font-size: clamp(1.75rem, 18vw, 5.8rem);" in mobile_rule
+    compact_rule = css.split("@media (max-width: 540px)", 1)[1]
+    assert re.search(r"\.site-header\s*\{[^}]*position:\s*static;", compact_rule, re.DOTALL)
+    assert re.search(r"\.language-switcher\s*\{[^}]*flex-wrap:\s*wrap;", compact_rule, re.DOTALL)
+    assert re.search(r"\.language-switcher button\s*\{[^}]*min-height:\s*2\.75rem;", compact_rule, re.DOTALL)
+    assert re.search(r"\.language-switcher button\s*\{[^}]*min-width:\s*2\.75rem;", compact_rule, re.DOTALL)
+    assert re.search(r"\.hero-actions\s*\{[^}]*flex-direction:\s*column;", compact_rule, re.DOTALL)
+    assert re.search(r"\.hero-actions \.button\s*\{[^}]*width:\s*100%;", compact_rule, re.DOTALL)
+    assert "min-height: clamp(18rem, 80vw, 23rem);" in css
+    zoom_reflow_rule = css.split("@media (max-width: 360px)", 1)[1]
+    assert re.search(r"\.truth-strip\s*\{[^}]*grid-template-columns:\s*1fr;", zoom_reflow_rule, re.DOTALL)
+    assert re.search(r"\.globe-toolbar\s*\{[^}]*flex-direction:\s*column;", zoom_reflow_rule, re.DOTALL)
+    assert "min-height: clamp(14rem, 100vw, 18rem);" in zoom_reflow_rule
 
 
 def test_webgl_globe_geometry_is_spherical_depth_ready_and_reproducible():

--- a/tests/test_public_site_static_interaction_qa.py
+++ b/tests/test_public_site_static_interaction_qa.py
@@ -147,6 +147,9 @@ canvas.parentElement = {
 };
 const motionButton = new Element({"data-i18n": "pauseGlobe"});
 motionButton.hidden = true;
+const interactiveNote = new Element({"data-i18n": "globeControls"});
+interactiveNote.hidden = true;
+const fallbackNote = new Element({"data-i18n": "globeFallbackNotice"});
 
 const document = {
   activeElement: null,
@@ -154,10 +157,14 @@ const document = {
   documentElement: {lang: "en", dir: "ltr"},
   hidden: false,
   title: "",
-  querySelector() { return null; },
+  querySelector(selector) {
+    if (selector === "[data-globe-interactive-note]") return interactiveNote;
+    if (selector === "[data-globe-fallback-note]") return fallbackNote;
+    return null;
+  },
   querySelectorAll(selector) {
     if (selector === "[data-language]") return [];
-    if (selector === "[data-i18n]") return [motionButton];
+    if (selector === "[data-i18n]") return [motionButton, interactiveNote, fallbackNote];
     if (selector === "[data-i18n-aria]") return [];
     if (selector === "[data-i18n-alt]") return [];
     return [];
@@ -225,6 +232,16 @@ function snapshot() {
       ariaPressed: motionButton.getAttribute("aria-pressed"),
       hidden: motionButton.hidden,
       text: motionButton.textContent
+    },
+    notes: {
+      fallback: {
+        hidden: fallbackNote.hidden,
+        text: fallbackNote.textContent
+      },
+      interactive: {
+        hidden: interactiveNote.hidden,
+        text: interactiveNote.textContent
+      }
     }
   };
 }
@@ -258,6 +275,30 @@ function keyEvent(key) {
 
   const initial = snapshot();
   const initialDrawCount = drawCalls.length;
+  let pointer = null;
+  if (!canvas.hidden) {
+    const pointerDown = {
+      pointerId: 7,
+      clientX: 20,
+      clientY: 20,
+      prevented: false,
+      preventDefault() { this.prevented = true; }
+    };
+    dispatch(canvas, "pointerdown", pointerDown);
+    const captureAfterDown = canvas.hasPointerCapture(7);
+    const pointerCancel = {
+      pointerId: 7,
+      prevented: false,
+      preventDefault() { this.prevented = true; }
+    };
+    dispatch(canvas, "pointercancel", pointerCancel);
+    pointer = {
+      cancelPrevented: pointerCancel.prevented,
+      captureAfterCancel: canvas.hasPointerCapture(7),
+      captureAfterDown,
+      downPrevented: pointerDown.prevented
+    };
+  }
   frames.shift()(1000);
   frames.shift()(1040);
   const reducedMotionDrawCount = drawCalls.length;
@@ -306,6 +347,7 @@ function keyEvent(key) {
     keyboardDrawCount,
     loadCount,
     manualToggleDrawCount,
+    pointer,
     reducedMotionDrawCount,
     resizeCount
   }));
@@ -350,6 +392,22 @@ def test_globe_keyboard_reduced_motion_and_focus_fallback_execute_deterministica
             "hidden": False,
             "text": "Resume",
         },
+        "notes": {
+            "fallback": {
+                "hidden": True,
+                "text": "Static illustration · interactive controls unavailable",
+            },
+            "interactive": {
+                "hidden": False,
+                "text": "Drag, swipe, or use the arrow keys to rotate.",
+            },
+        },
+    }
+    assert probe["pointer"] == {
+        "cancelPrevented": False,
+        "captureAfterCancel": False,
+        "captureAfterDown": True,
+        "downPrevented": False,
     }
     assert probe["loadCount"] == 1
     assert probe["resizeCount"] == 1
@@ -385,6 +443,16 @@ def test_globe_keyboard_reduced_motion_and_focus_fallback_execute_deterministica
             "hidden": True,
             "text": "Pause",
         },
+        "notes": {
+            "fallback": {
+                "hidden": False,
+                "text": "Static illustration · interactive controls unavailable",
+            },
+            "interactive": {
+                "hidden": True,
+                "text": "Drag, swipe, or use the arrow keys to rotate.",
+            },
+        },
         "activeElementCleared": True,
         "blurCount": 1,
         "prevented": True,
@@ -414,6 +482,12 @@ def test_globe_reacts_to_a_new_reduced_motion_preference():
         "text": "Pause",
     }
     assert probe["manualToggleDrawCount"] == probe["keyboardDrawCount"] + 1
+    assert probe["pointer"] == {
+        "cancelPrevented": False,
+        "captureAfterCancel": False,
+        "captureAfterDown": True,
+        "downPrevented": False,
+    }
 
 
 def test_globe_without_a_renderer_stays_static_and_out_of_the_tab_order():
@@ -435,7 +509,18 @@ def test_globe_without_a_renderer_stays_static_and_out_of_the_tab_order():
             "hidden": True,
             "text": "Pause",
         },
+        "notes": {
+            "fallback": {
+                "hidden": False,
+                "text": "Static illustration · interactive controls unavailable",
+            },
+            "interactive": {
+                "hidden": True,
+                "text": "Drag, swipe, or use the arrow keys to rotate.",
+            },
+        },
     }
+    assert probe["pointer"] is None
     assert probe["loadCount"] == 0
     assert probe["resizeCount"] == 0
     assert probe["initialDrawCount"] == 0
@@ -479,10 +564,25 @@ def test_focus_motion_rtl_and_responsive_css_contracts_remain_versioned():
     )
     assert ".boundary-row { grid-template-columns: 1fr;" in mobile
     assert ".site-footer { justify-items: start;" in mobile
+    assert ".hero h1 { font-size: clamp(1.75rem, 18vw, 5.8rem);" in mobile
 
     narrow = compact_css(css_block(portfolio, "@media (max-width: 540px)"))
-    assert ".site-header { grid-template-columns: 1fr;" in narrow
-    assert ".language-switcher button { min-height: 2.25rem;" in narrow
+    assert ".site-header { position: static; grid-template-columns: 1fr;" in narrow
+    assert ".language-switcher { flex-wrap: wrap;" in narrow
+    assert ".language-switcher button { min-height: 2.75rem; min-width: 2.75rem;" in narrow
+    zoom_reflow = compact_css(css_block(portfolio, "@media (max-width: 360px)"))
+    assert ".truth-strip { grid-template-columns: 1fr;" in zoom_reflow
+    assert ".globe-toolbar { align-items: stretch; flex-direction: column;" in zoom_reflow
+    assert ".globe-stage { min-height: clamp(14rem, 100vw, 18rem);" in zoom_reflow
+    assert ".site-footer nav { align-items: flex-start; flex-direction: column;" in zoom_reflow
+    assert "overflow-wrap: anywhere" in css_block(portfolio, "body")
+    language_target = css_block(portfolio, ".language-switcher button")
+    assert "min-height: 2.75rem" in language_target
+    assert "min-width: 2.75rem" in language_target
+    assert "min-height: 2.75rem" in css_block(portfolio, ".globe-toolbar button")
+    assert "outline-offset: -4px" in css_block(portfolio, "#world-globe:focus-visible")
+    globe_blocks = re.findall(r"#world-globe\s*\{(?P<body>.*?)\}", portfolio, re.DOTALL)
+    assert any("touch-action: pan-y pinch-zoom" in block for block in globe_blocks)
     assert "inset-inline-start" in portfolio
     assert "inset-inline-end" in portfolio
     assert "padding-inline" in portfolio


### PR DESCRIPTION
Refs #1833

## Scope
- makes the landing task-first with a direct Operator intake CTA
- fixes narrow-screen title, wrapping, touch targets, focus visibility and 320–1363 px reflow
- adds reduced-motion and WebGL fallback behavior
- preserves explicit language continuity into Operator

## Verification
- local final suite: 650 passed, 12 skipped (PowerShell-only)
- inherited GitHub runner suite: 661 passed
- final tree SHA: `2d49eb3971cc227a373c7e88a0e8ab12e85c11fe`

Real Safari/iOS device QA is performed after merge and deterministic GitHub → Sites synchronization, against the exact deployed SHA.