### PR TITLE
docs(site): pin public routes to merged evidence SHA

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -504,7 +504,7 @@ points: the portfolio, the branded 404 page, and Operator.
 - Same-origin links, assets, routes, and fragments are resolved against the
   checked-out `site/` artifact; repository evidence links resolve against
   local paths and are pinned to commit
-  `f99bfed196dbcb76c8a29a4bab31559fdb567ee5` rather than mutable `main`.
+  `8426b08e5f88b650c4d79e41d3ce3afd7d42746b` rather than mutable `main`.
 - Live navigation to the repository, its issue tracker, and the separate Labs
   repository is allowlisted structurally. Pytest performs no external network
   request and therefore does not attest current remote availability.

--- a/site/i18n/document-routes.v1.js
+++ b/site/i18n/document-routes.v1.js
@@ -1,7 +1,7 @@
 (() => {
   "use strict";
 
-  const EVIDENCE_SHA = "f99bfed196dbcb76c8a29a4bab31559fdb567ee5";
+  const EVIDENCE_SHA = "8426b08e5f88b650c4d79e41d3ce3afd7d42746b";
   const repository = "https://github.com/Voxterrae/HUB_Optimus";
   const blob = (path) => `${repository}/blob/${EVIDENCE_SHA}/${path}`;
   const tree = (path) => `${repository}/tree/${EVIDENCE_SHA}/${path}`;

--- a/site/index.html
+++ b/site/index.html
@@ -210,9 +210,9 @@
             Spanish is authoritative for v1; English is the parity target.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/v1_core/languages/es" data-document-route="core.canonical" hreflang="es"><span data-i18n="viewCanonical">Canonical core</span><small class="document-language-badge">ES · fallback · canonical</small></a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/v1_core/workflow/05_meta_learning.md" data-document-route="core.meta-learning" hreflang="es"><span data-i18n="metaLearningGuide">Meta-learning workflow</span><small class="document-language-badge">ES · fallback</small></a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/context/STATUS.md" data-document-route="status.policy" hreflang="en"><span data-i18n="viewStatus">Status policy</span><small class="document-language-badge">EN · source</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/v1_core/languages/es" data-document-route="core.canonical" hreflang="es"><span data-i18n="viewCanonical">Canonical core</span><small class="document-language-badge">ES · fallback · canonical</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/v1_core/workflow/05_meta_learning.md" data-document-route="core.meta-learning" hreflang="es"><span data-i18n="metaLearningGuide">Meta-learning workflow</span><small class="document-language-badge">ES · fallback</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/context/STATUS.md" data-document-route="status.policy" hreflang="en"><span data-i18n="viewStatus">Status policy</span><small class="document-language-badge">EN · source</small></a>
           </div>
         </article>
 
@@ -227,8 +227,8 @@
             output, frozen benchmarks, and structural drift diagnostics.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/SIMULATION_README.md" data-document-route="simulator.guide" hreflang="es"><span data-i18n="runScenario">Run a scenario</span><small class="document-language-badge">ES · fallback</small></a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/runtime_contract.md" data-document-route="runtime.contract" hreflang="en"><span data-i18n="runtimeContract">Runtime contract</span><small class="document-language-badge">EN · source</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/SIMULATION_README.md" data-document-route="simulator.guide" hreflang="es"><span data-i18n="runScenario">Run a scenario</span><small class="document-language-badge">ES · fallback</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/architecture/runtime_contract.md" data-document-route="runtime.contract" hreflang="en"><span data-i18n="runtimeContract">Runtime contract</span><small class="document-language-badge">EN · source</small></a>
           </div>
         </article>
 
@@ -244,8 +244,8 @@
             evaluate or score claims.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/semantic_engine" data-i18n="inspectEngine">Inspect the engine</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/semantic_engine_cli.md" data-document-route="semantic.cli" hreflang="en"><span data-i18n="cliContract">CLI contract</span><small class="document-language-badge">EN · source</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/semantic_engine" data-i18n="inspectEngine">Inspect the engine</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/architecture/semantic_engine_cli.md" data-document-route="semantic.cli" hreflang="en"><span data-i18n="cliContract">CLI contract</span><small class="document-language-badge">EN · source</small></a>
           </div>
         </article>
 
@@ -269,7 +269,7 @@
           </p>
           <div class="card-links">
             <a href="./operator/?lang=en#product_intake" hreflang="en" data-operator-route data-i18n="openOperator">Open Operator</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/site/operator" data-i18n="inspectSource">Inspect source</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/site/operator" data-i18n="inspectSource">Inspect source</a>
           </div>
         </article>
 
@@ -285,9 +285,9 @@
             not verified evidence.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/operator_controlled_url_intake.md" data-document-route="operator.intake.rfc" hreflang="en"><span data-i18n="intakeContract">How URL intake works</span><small class="document-language-badge">EN · source</small></a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/ops/ec2/hub-api.sh" data-i18n="inspectIntake">Inspect intake source</a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/tests/test_hub_api_controlled_url_intake.py" data-i18n="intakeTests">Inspect tests</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/rfc/operator_controlled_url_intake.md" data-document-route="operator.intake.rfc" hreflang="en"><span data-i18n="intakeContract">How URL intake works</span><small class="document-language-badge">EN · source</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/ops/ec2/hub-api.sh" data-i18n="inspectIntake">Inspect intake source</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/tests/test_hub_api_controlled_url_intake.py" data-i18n="intakeTests">Inspect tests</a>
           </div>
         </article>
 
@@ -302,8 +302,8 @@
             narrative consistency checks, and source-labelled research datasets.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/lab_state.md" data-document-route="lab.state" hreflang="en"><span data-i18n="labState">Lab state</span><small class="document-language-badge">EN · source</small></a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/tools" data-i18n="researchTools">Research tools</a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/lab_state.md" data-document-route="lab.state" hreflang="en"><span data-i18n="labState">Lab state</span><small class="document-language-badge">EN · source</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/tools" data-i18n="researchTools">Research tools</a>
           </div>
         </article>
 
@@ -318,8 +318,8 @@
             narrative amplification, and operational relevance under human accountability.
           </p>
           <div class="card-links">
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/governance/GOVERNANCE_INTELLIGENCE.md" data-document-route="governance.protocol" hreflang="en"><span data-i18n="readProtocol">Read protocol</span><small class="document-language-badge">EN · source · canonical</small></a>
-            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/governance/SYSTEM_PROTECTION_MATRIX.md" data-document-route="governance.protection" hreflang="en"><span data-i18n="protectionMatrix">Protection matrix</span><small class="document-language-badge">EN · source · canonical</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/governance/GOVERNANCE_INTELLIGENCE.md" data-document-route="governance.protocol" hreflang="en"><span data-i18n="readProtocol">Read protocol</span><small class="document-language-badge">EN · source · canonical</small></a>
+            <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/governance/SYSTEM_PROTECTION_MATRIX.md" data-document-route="governance.protection" hreflang="en"><span data-i18n="protectionMatrix">Protection matrix</span><small class="document-language-badge">EN · source · canonical</small></a>
           </div>
         </article>
       </div>
@@ -445,7 +445,7 @@
             execution remains local or controlled and provider-independent. A hosting or
             model provider does not gain project or semantic authority.
           </p>
-          <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/platform_compatibility.md" data-document-route="platform.policy" hreflang="en"><span data-i18n="platformPolicy">Platform compatibility policy</span><small class="document-language-badge">EN · source</small></a>
+          <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/architecture/platform_compatibility.md" data-document-route="platform.policy" hreflang="en"><span data-i18n="platformPolicy">Platform compatibility policy</span><small class="document-language-badge">EN · source</small></a>
         </aside>
       </div>
     </section>
@@ -461,19 +461,19 @@
       </div>
 
       <div class="future-grid">
-        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/hermes_pwa_interface_boundary.md" data-status="rfc-not-implemented" data-document-route="future.hermes" hreflang="en">
+        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/rfc/hermes_pwa_interface_boundary.md" data-status="rfc-not-implemented" data-document-route="future.hermes" hreflang="en">
           <span data-i18n="futureHermesLabel">RFC / UI</span>
           <h3>HERMES</h3>
           <p data-i18n="hermesCopy">Future PWA interface boundary. Not implemented.</p>
           <small class="document-language-badge">EN · source</small>
         </a>
-        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/enterprise_boundary.md" data-status="rfc-not-implemented" data-document-route="future.enterprise" hreflang="en">
+        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/rfc/enterprise_boundary.md" data-status="rfc-not-implemented" data-document-route="future.enterprise" hreflang="en">
           <span data-i18n="futureEnterpriseLabel">RFC / OPERATING MODEL</span>
           <h3>Enterprise</h3>
           <p data-i18n="enterpriseCopy">Proposed private operating boundary. No enterprise product or public service exists.</p>
           <small class="document-language-badge">EN · source</small>
         </a>
-        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/rfc/post_quantum_control_plane.md" data-status="rfc-not-implemented" data-document-route="future.postquantum" hreflang="en">
+        <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/rfc/post_quantum_control_plane.md" data-status="rfc-not-implemented" data-document-route="future.postquantum" hreflang="en">
           <span data-i18n="futurePostQuantumLabel">RFC / SECURITY</span>
           <h3 data-i18n="postQuantumTitle">Post-quantum control plane</h3>
           <p data-i18n="postQuantumCopy">RFC planning around standardized cryptographic primitives. No cryptographic implementation.</p>
@@ -498,7 +498,7 @@
       </div>
       <div class="evidence-links">
         <a class="button button-primary" href="https://github.com/Voxterrae/HUB_Optimus" data-i18n="openRepository">Open repository</a>
-        <a class="button button-secondary" href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/docs/architecture/capability_status.md" data-document-route="capability.status" hreflang="en"><span data-i18n="capabilityStatus">Capability status</span><small class="document-language-badge">EN · source</small></a>
+        <a class="button button-secondary" href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/architecture/capability_status.md" data-document-route="capability.status" hreflang="en"><span data-i18n="capabilityStatus">Capability status</span><small class="document-language-badge">EN · source</small></a>
       </div>
     </section>
   </main>
@@ -512,8 +512,8 @@
       No embedded client-side analytics or advertising tracking. No hidden scoring. Hosting providers may retain operational logs. GitHub remains authoritative.
     </p>
     <nav aria-label="Legal and project links" data-i18n-aria="footerNavAria">
-      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/IP_NOTICE.md" data-document-route="legal.ip" hreflang="en"><span>IP</span><small class="document-language-badge">EN · source</small></a>
-      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/f99bfed196dbcb76c8a29a4bab31559fdb567ee5/SECURITY.md" data-document-route="security.policy" hreflang="en"><span data-i18n="security">Security</span><small class="document-language-badge">EN · source</small></a>
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/IP_NOTICE.md" data-document-route="legal.ip" hreflang="en"><span>IP</span><small class="document-language-badge">EN · source</small></a>
+      <a href="https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/SECURITY.md" data-document-route="security.policy" hreflang="en"><span data-i18n="security">Security</span><small class="document-language-badge">EN · source</small></a>
       <a href="https://github.com/Voxterrae/HUB_Optimus/issues" data-i18n="issues">Issues</a>
     </nav>
   </footer>

--- a/tests/test_public_portfolio.py
+++ b/tests/test_public_portfolio.py
@@ -1417,7 +1417,7 @@ def test_document_route_resolver_has_complete_explicit_locale_matrix():
     }
     assert set(probe["routeIds"]) == expected_route_ids
     assert probe["unknown"] is None
-    assert probe["evidenceSha"] == "f99bfed196dbcb76c8a29a4bab31559fdb567ee5"
+    assert probe["evidenceSha"] == "8426b08e5f88b650c4d79e41d3ce3afd7d42746b"
 
     resolved = probe["resolved"]
     assert all(

--- a/tests/test_public_site_links_and_contrast.py
+++ b/tests/test_public_site_links_and_contrast.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote, urljoin, urlsplit
 ROOT = Path(__file__).resolve().parents[1]
 SITE = ROOT / "site"
 PUBLIC_ORIGIN = "https://huboptimus.dev"
-EVIDENCE_REF = "f99bfed196dbcb76c8a29a4bab31559fdb567ee5"
+EVIDENCE_REF = "8426b08e5f88b650c4d79e41d3ce3afd7d42746b"
 PUBLIC_ROUTES = {
     "/": SITE / "index.html",
     "/404.html": SITE / "404.html",


### PR DESCRIPTION
## Purpose
Pin every public GitHub document/source route to the immutable merged stack commit `8426b08e5f88b650c4d79e41d3ce3afd7d42746b`.

## Scope
- 22 static links in `site/index.html`
- `EVIDENCE_SHA` in the locale-aware document resolver
- both route-integrity test expectations
- the AI handoff record

## Verification
- focused route suite: 35 passed
- full suite: 650 passed, 12 skipped (PowerShell-only)
- no route points at mutable `main`

After this PR is merged, its resulting `main` SHA becomes the deterministic GitHub → Sites source SHA.