### PR TITLE
fix(site): keep WebGL focus inside narrow viewports

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -1373,6 +1373,8 @@ canvas {
   }
 
   .globe-stage {
+    width: 100%;
+    aspect-ratio: auto;
     min-height: clamp(18rem, 80vw, 23rem);
   }
 

--- a/tests/test_public_portfolio.py
+++ b/tests/test_public_portfolio.py
@@ -1818,6 +1818,8 @@ def test_mobile_hero_keeps_brand_visible_and_prioritizes_operator():
     assert re.search(r"\.language-switcher button\s*\{[^}]*min-width:\s*2\.75rem;", compact_rule, re.DOTALL)
     assert re.search(r"\.hero-actions\s*\{[^}]*flex-direction:\s*column;", compact_rule, re.DOTALL)
     assert re.search(r"\.hero-actions \.button\s*\{[^}]*width:\s*100%;", compact_rule, re.DOTALL)
+    assert re.search(r"\.globe-stage\s*\{[^}]*width:\s*100%;", mobile_rule, re.DOTALL)
+    assert re.search(r"\.globe-stage\s*\{[^}]*aspect-ratio:\s*auto;", mobile_rule, re.DOTALL)
     assert "min-height: clamp(18rem, 80vw, 23rem);" in css
     zoom_reflow_rule = css.split("@media (max-width: 360px)", 1)[1]
     assert re.search(r"\.truth-strip\s*\{[^}]*grid-template-columns:\s*1fr;", zoom_reflow_rule, re.DOTALL)

--- a/tests/test_public_site_static_interaction_qa.py
+++ b/tests/test_public_site_static_interaction_qa.py
@@ -565,6 +565,7 @@ def test_focus_motion_rtl_and_responsive_css_contracts_remain_versioned():
     assert ".boundary-row { grid-template-columns: 1fr;" in mobile
     assert ".site-footer { justify-items: start;" in mobile
     assert ".hero h1 { font-size: clamp(1.75rem, 18vw, 5.8rem);" in mobile
+    assert ".globe-stage { width: 100%; aspect-ratio: auto;" in mobile
 
     narrow = compact_css(css_block(portfolio, "@media (max-width: 540px)"))
     assert ".site-header { position: static; grid-template-columns: 1fr;" in narrow


### PR DESCRIPTION
## Summary

- constrain the mobile globe stage to the card width
- disable the desktop aspect-ratio transfer below 760 px so `min-height` cannot widen the canvas
- add regression assertions for the responsive focus contract

## Verification

- `650 passed, 12 skipped`
- exact-width browser QA: 320, 360, 390, 430, 682, 768, 1024, 1363 px
- keyboard focus at 320 px stays within the viewport
- Hebrew RTL, reduced motion, WebGL interaction/context-loss, and static fallback pass

Found during pre-deployment Sites QA; deployment remains paused until this hotfix is merged.