### PR TITLE
docs(wiki): add Operator and deployment guide

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,45 @@
+# Arquitectura
+
+> **Estado:** mapa orientativo; no acredita un despliegue.  
+> **Última revisión:** 2026-08-02.  
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+
+## Superficies principales
+
+- **Core:** metodología v1; la versión canónica está en español.
+- **Simulator:** prototipo determinista basado en escenarios.
+- **Semantic Engine CLI:** valida contratos y prepara registros; no es un juez
+  autónomo.
+- **Operator:** interfaz de navegador para intake y borradores revisables.
+- **GitHub Pages:** alojamiento de la web pública.
+- **EC2:** entorno operativo privado/local, sin exposición pública acreditada.
+- **Governance:** reglas humanas de revisión, cambios y responsabilidad.
+
+## Flujo público actual
+
+`GitHub main → Pages workflow → huboptimus.dev → Operator manual/local`
+
+El navegador puede preparar borradores con texto pegado. No existe una API
+pública de análisis certificada.
+
+## Topología privada propuesta
+
+`NGINX :443 → oauth2-proxy/Entra → gateway limitado → hub-api localhost`
+
+Redis, oauth2-proxy, gateway y `hub-api` deben permanecer en loopback. Esta
+topología pertenece a la [PR #1844](https://github.com/Voxterrae/HUB_Optimus/pull/1844)
+y todavía no está acreditada como live.
+
+## Límites
+
+- Un documento no demuestra que un servicio esté desplegado.
+- Una prueba acredita únicamente el comportamiento que verifica.
+- Un borrador de Operator no es evidencia verificada.
+- Un RFC no se aprueba a sí mismo.
+- La Wiki nunca prevalece sobre `main` o los registros vivos de GitHub.
+
+## Fuentes
+
+- [Mapa completo de arquitectura](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/system_architecture_map.md)
+- [Contrato de runtime](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/runtime_contract.md)
+- [Jerarquía de fuentes](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/context/SOURCE_OF_TRUTH.md)

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -2,7 +2,7 @@
 
 > **Estado:** mapa orientativo; no acredita un despliegue.
 > **Última revisión:** 2026-08-02.
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+> **Base auditada:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).
 
 ## Superficies principales
 
@@ -19,8 +19,9 @@
 
 `GitHub main → Pages workflow → huboptimus.dev → Operator manual/local`
 
-El navegador puede preparar borradores con texto pegado. No existe una API
-pública de análisis certificada.
+El navegador puede preparar borradores con el texto completo pegado. Una URL
+opcional permanece como atribución local no verificada y no provoca una
+petición de red. No existe una API pública de análisis certificada.
 
 ## Topología privada propuesta
 
@@ -40,6 +41,6 @@ y todavía no está acreditada como live.
 
 ## Fuentes
 
-- [Mapa completo de arquitectura](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/system_architecture_map.md)
-- [Contrato de runtime](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/runtime_contract.md)
-- [Jerarquía de fuentes](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/context/SOURCE_OF_TRUTH.md)
+- [Mapa completo de arquitectura](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/architecture/system_architecture_map.md)
+- [Contrato de runtime](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/architecture/runtime_contract.md)
+- [Jerarquía de fuentes](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/context/SOURCE_OF_TRUTH.md)

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,7 +1,7 @@
 # Arquitectura
 
-> **Estado:** mapa orientativo; no acredita un despliegue.  
-> **Última revisión:** 2026-08-02.  
+> **Estado:** mapa orientativo; no acredita un despliegue.
+> **Última revisión:** 2026-08-02.
 > **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
 
 ## Superficies principales

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,7 +1,7 @@
 # HUB_Optimus
 
-> **Estado:** Wiki de navegación; no sustituye la documentación versionada.  
-> **Última revisión:** 2026-08-02.  
+> **Estado:** Wiki de navegación; no sustituye la documentación versionada.
+> **Última revisión:** 2026-08-02.
 > **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
 
 HUB_Optimus organiza información en una cadena revisable:

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,42 @@
+# HUB_Optimus
+
+> **Estado:** Wiki de navegación; no sustituye la documentación versionada.  
+> **Última revisión:** 2026-08-02.  
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+
+HUB_Optimus organiza información en una cadena revisable:
+
+**Realidad → Evidencia → Inferencia → Narrativa → Señal operativa**
+
+No es un oráculo, no determina automáticamente qué es verdad y no sustituye la
+responsabilidad humana.
+
+## Accesos rápidos
+
+- [Web pública](https://huboptimus.dev/)
+- [Operator público](https://huboptimus.dev/operator/?lang=es#product_intake)
+- [[Guía de Operator|Operator-User-Guide]]
+- [[Resolución de problemas|Operator-Troubleshooting]]
+- [[Arquitectura|Architecture]]
+- [[Hosting y despliegue|Hosting-and-Deployment]]
+- [[Roadmap y estado|Roadmap-and-Live-Status]]
+- [Empezar en español](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/es/00_start_here.md)
+
+## Estado resumido
+
+- La web pública se despliega mediante GitHub Pages.
+- El Operator público puede preparar borradores a partir de texto pegado.
+- La importación automática de una URL no está operativa públicamente.
+- El backend EC2 documentado permanece limitado a `localhost`.
+- La frontera privada con Microsoft Entra/OIDC está propuesta en la
+  [PR #1844](https://github.com/Voxterrae/HUB_Optimus/pull/1844), todavía en
+  borrador.
+
+## Fuente de verdad
+
+Para cualquier conflicto, prevalecen `main`, los objetos vivos de GitHub y los
+contratos aplicables del repositorio.
+
+- [Jerarquía de fuentes](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/context/SOURCE_OF_TRUTH.md)
+- [README principal](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/README.md)
+- [Estado de capacidades](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/capability_status.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,7 +2,7 @@
 
 > **Estado:** Wiki de navegación; no sustituye la documentación versionada.
 > **Última revisión:** 2026-08-02.
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+> **Base auditada:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).
 
 HUB_Optimus organiza información en una cadena revisable:
 
@@ -20,14 +20,17 @@ responsabilidad humana.
 - [[Arquitectura|Architecture]]
 - [[Hosting y despliegue|Hosting-and-Deployment]]
 - [[Roadmap y estado|Roadmap-and-Live-Status]]
-- [Empezar en español](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/es/00_start_here.md)
+- [Empezar en español](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/es/00_start_here.md)
 
 ## Estado resumido
 
 - La web pública se despliega mediante GitHub Pages.
-- El Operator público puede preparar borradores a partir de texto pegado.
-- La importación automática de una URL no está operativa públicamente.
-- El backend EC2 documentado permanece limitado a `localhost`.
+- El Operator público puede preparar borradores a partir del texto completo
+  pegado y conservar una URL exacta como atribución local no verificada.
+- El Operator público no recupera URLs: una URL sola termina de inmediato y
+  remite al futuro Operator privado autenticado.
+- La última auditoría conocida encontró el backend EC2 limitado a `localhost`
+  pero obsoleto; su estado actual todavía no se ha reatestado.
 - La frontera privada con Microsoft Entra/OIDC está propuesta en la
   [PR #1844](https://github.com/Voxterrae/HUB_Optimus/pull/1844), todavía en
   borrador.
@@ -37,6 +40,6 @@ responsabilidad humana.
 Para cualquier conflicto, prevalecen `main`, los objetos vivos de GitHub y los
 contratos aplicables del repositorio.
 
-- [Jerarquía de fuentes](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/context/SOURCE_OF_TRUTH.md)
-- [README principal](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/README.md)
-- [Estado de capacidades](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/capability_status.md)
+- [Jerarquía de fuentes](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/context/SOURCE_OF_TRUTH.md)
+- [README principal](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/README.md)
+- [Estado de capacidades](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/architecture/capability_status.md)

--- a/docs/wiki/Hosting-and-Deployment.md
+++ b/docs/wiki/Hosting-and-Deployment.md
@@ -2,11 +2,11 @@
 
 > **Estado:** GitHub Pages público; backend privado pendiente.
 > **Última revisión:** 2026-08-02.
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+> **Base auditada:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).
 
 | Superficie | Alojamiento | Estado |
 | --- | --- | --- |
-| Web y Operator público | GitHub Pages | Disponible; Operator es un prototipo. |
+| Web y Operator público | GitHub Pages | Disponible; intake manual/local desplegado en `c399c94`. |
 | Preview de revisión | ChatGPT Sites, cuando se utilice | No es fuente de verdad ni producción canónica. |
 | `hub-api` | EC2, `127.0.0.1:8080` | Última auditoría conocida, 2026-07-29: host existente y servicio local, pero despliegue obsoleto; estado actual no reatestado. |
 | Operator privado | `api.huboptimus.dev` | No operativo; candidato en PR #1844. |
@@ -16,8 +16,8 @@
 El workflow publica `site/` cuando los cambios correspondientes llegan a
 `main`.
 
-- [Workflow Pages](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/.github/workflows/pages.yml)
-- [Última ejecución auditada](https://github.com/Voxterrae/HUB_Optimus/actions/runs/30755670306)
+- [Workflow Pages](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/.github/workflows/pages.yml)
+- [Última ejecución auditada](https://github.com/Voxterrae/HUB_Optimus/actions/runs/30765273410)
 - [Web pública](https://huboptimus.dev/)
 
 No hace falta modificar el DNS de `huboptimus.dev` para trabajar con GitHub
@@ -51,5 +51,5 @@ del host.
 Esta Wiki no debe contener secretos, direcciones internas sensibles, cookies,
 tokens, tenant secrets, credenciales ni valores reales de configuración.
 
-- [Guía AWS de desarrollo](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/aws_dev_runtime.md)
-- [Operaciones EC2](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/ops/ec2/README.md)
+- [Guía AWS de desarrollo](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/architecture/aws_dev_runtime.md)
+- [Operaciones EC2](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/ops/ec2/README.md)

--- a/docs/wiki/Hosting-and-Deployment.md
+++ b/docs/wiki/Hosting-and-Deployment.md
@@ -1,0 +1,47 @@
+# Hosting y despliegue
+
+> **Estado:** GitHub Pages público; backend privado pendiente.  
+> **Última revisión:** 2026-08-02.  
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+
+| Superficie | Alojamiento | Estado |
+| --- | --- | --- |
+| Web y Operator público | GitHub Pages | Disponible; Operator es un prototipo. |
+| Preview de revisión | ChatGPT Sites, cuando se utilice | No es fuente de verdad ni producción canónica. |
+| `hub-api` | EC2, `127.0.0.1:8080` | Scripts versionados; host live no acreditado. |
+| Operator privado | `api.huboptimus.dev` | No operativo; candidato en PR #1844. |
+
+## GitHub Pages
+
+El workflow publica `site/` cuando los cambios correspondientes llegan a
+`main`.
+
+- [Workflow Pages](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/.github/workflows/pages.yml)
+- [Última ejecución auditada](https://github.com/Voxterrae/HUB_Optimus/actions/runs/30755670306)
+- [Web pública](https://huboptimus.dev/)
+
+No hace falta modificar el DNS de `huboptimus.dev` para trabajar con GitHub
+Pages si ya está correctamente configurado.
+
+## Orden para activar el backend
+
+1. Fusionar y validar la seguridad de despliegue de
+   [#1832](https://github.com/Voxterrae/HUB_Optimus/issues/1832).
+2. Desplegar y acreditar el SHA exacto mediante
+   [#1831](https://github.com/Voxterrae/HUB_Optimus/issues/1831).
+3. Preparar Redis, NGINX, TLS, firewall y Microsoft Entra.
+4. Validar propietario, equipo y cuenta sin rol.
+5. Ejecutar QA real y rollback.
+6. Solo entonces fusionar y desplegar la
+   [PR #1844](https://github.com/Voxterrae/HUB_Optimus/pull/1844).
+
+No debe crearse el DNS de `api.huboptimus.dev` hasta disponer de destino
+estable, TLS válido y servicios preparados.
+
+## Seguridad documental
+
+Esta Wiki no debe contener secretos, direcciones internas sensibles, cookies,
+tokens, tenant secrets, credenciales ni valores reales de configuración.
+
+- [Guía AWS de desarrollo](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/aws_dev_runtime.md)
+- [Operaciones EC2](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/ops/ec2/README.md)

--- a/docs/wiki/Hosting-and-Deployment.md
+++ b/docs/wiki/Hosting-and-Deployment.md
@@ -1,14 +1,14 @@
 # Hosting y despliegue
 
-> **Estado:** GitHub Pages público; backend privado pendiente.  
-> **Última revisión:** 2026-08-02.  
+> **Estado:** GitHub Pages público; backend privado pendiente.
+> **Última revisión:** 2026-08-02.
 > **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
 
 | Superficie | Alojamiento | Estado |
 | --- | --- | --- |
 | Web y Operator público | GitHub Pages | Disponible; Operator es un prototipo. |
 | Preview de revisión | ChatGPT Sites, cuando se utilice | No es fuente de verdad ni producción canónica. |
-| `hub-api` | EC2, `127.0.0.1:8080` | Scripts versionados; host live no acreditado. |
+| `hub-api` | EC2, `127.0.0.1:8080` | Última auditoría conocida, 2026-07-29: host existente y servicio local, pero despliegue obsoleto; estado actual no reatestado. |
 | Operator privado | `api.huboptimus.dev` | No operativo; candidato en PR #1844. |
 
 ## GitHub Pages
@@ -35,8 +35,16 @@ Pages si ya está correctamente configurado.
 6. Solo entonces fusionar y desplegar la
    [PR #1844](https://github.com/Voxterrae/HUB_Optimus/pull/1844).
 
-No debe crearse el DNS de `api.huboptimus.dev` hasta disponer de destino
-estable, TLS válido y servicios preparados.
+No debe enviarse tráfico de producción a `api.huboptimus.dev` hasta disponer de
+destino estable, servicios preparados y una vía de emisión TLS definida. Con
+ACME DNS-01 puede emitirse el certificado antes de publicar el registro de
+servicio; con HTTP-01 debe utilizarse una ventana DNS controlada y validar TLS
+antes de admitir tráfico de usuarios.
+
+La auditoría de 2026-07-29 observó un checkout antiguo, NGINX solo en HTTP y sin
+DNS resolviendo para la API. Es evidencia histórica, no prueba del estado live
+actual. No se publican en la Wiki direcciones, identificadores ni credenciales
+del host.
 
 ## Seguridad documental
 

--- a/docs/wiki/Operator-Troubleshooting.md
+++ b/docs/wiki/Operator-Troubleshooting.md
@@ -1,25 +1,25 @@
 # Resolución de problemas de Operator
 
 > **Estado:** diagnóstico del Operator público auditado el 2026-08-02.
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+> **Base auditada:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).
 
 | Síntoma | Causa probable | Acción |
 | --- | --- | --- |
-| Se queda en `6 %` | Está esperando el intake remoto de URL, que no está operativo públicamente. | Borra completamente la URL y usa texto pegado. |
-| “URL no disponible” | El backend público no responde o la fuente rechaza la extracción. | Usa el flujo manual; no reintentes indefinidamente. |
-| Sigue pidiendo texto | La URL no produjo una fuente utilizable. | Pega el texto completo con el campo URL vacío. |
+| Se queda en `6 %` | El navegador todavía ejecuta el worker antiguo `v0-26`. | Recarga dos veces o abre una pestaña privada; confirma después que aparece el flujo manual/local. |
+| Una URL sola pide texto | Es el límite intencional del Operator público `v0-27`; no se envió ninguna petición. | Pega el texto completo o espera al Operator privado autenticado. |
+| URL + texto no avanza | Falta revisar o confirmar los pasajes propuestos. | Revisa la selección, marca la confirmación y pulsa de nuevo. |
 | Aparece “1.200 caracteres” | Es el contexto opcional, no el máximo de la fuente. | Introduce la fuente en el campo de texto principal. |
 | Hay pasajes seleccionados pero no borrador | Falta la confirmación humana. | Revisa, marca la confirmación y pulsa de nuevo. |
 | Aparece `401` o `403` | La futura consola privada exige sesión y rol autorizados. | El propietario o IT debe revisar Entra y los roles `HUB.Owner`/`HUB.Operator`. |
 | Aparece `429` | Límite temporal de solicitudes. | Espera antes de reintentar. |
 | Aparece `502` o un error `5xx` | Servicio privado no desplegado o no saludable. | Utiliza texto manual y revisa el estado de despliegue. |
-| Se muestra una versión antigua | Puede quedar una caché del PWA. | Recarga primero. Antes de borrar datos del sitio, exporta los borradores locales. |
+| Se muestra una versión antigua | Puede quedar una caché del PWA. | Recarga dos veces. Antes de borrar datos del sitio, exporta los borradores locales. |
 
 No compartas contraseñas, tokens, cookies, secretos, identificadores internos
 ni capturas que los contengan.
 
 ## Evidencia relacionada
 
-- [Operaciones EC2](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/ops/ec2/README.md)
+- [Operaciones EC2](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/ops/ec2/README.md)
 - [Issue #1835: frontera autenticada](https://github.com/Voxterrae/HUB_Optimus/issues/1835)
 - [PR #1844: implementación OIDC en borrador](https://github.com/Voxterrae/HUB_Optimus/pull/1844)

--- a/docs/wiki/Operator-Troubleshooting.md
+++ b/docs/wiki/Operator-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Resolución de problemas de Operator
 
-> **Estado:** diagnóstico del Operator público auditado el 2026-08-02.  
+> **Estado:** diagnóstico del Operator público auditado el 2026-08-02.
 > **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
 
 | Síntoma | Causa probable | Acción |

--- a/docs/wiki/Operator-Troubleshooting.md
+++ b/docs/wiki/Operator-Troubleshooting.md
@@ -1,0 +1,25 @@
+# Resolución de problemas de Operator
+
+> **Estado:** diagnóstico del Operator público auditado el 2026-08-02.  
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+
+| Síntoma | Causa probable | Acción |
+| --- | --- | --- |
+| Se queda en `6 %` | Está esperando el intake remoto de URL, que no está operativo públicamente. | Borra completamente la URL y usa texto pegado. |
+| “URL no disponible” | El backend público no responde o la fuente rechaza la extracción. | Usa el flujo manual; no reintentes indefinidamente. |
+| Sigue pidiendo texto | La URL no produjo una fuente utilizable. | Pega el texto completo con el campo URL vacío. |
+| Aparece “1.200 caracteres” | Es el contexto opcional, no el máximo de la fuente. | Introduce la fuente en el campo de texto principal. |
+| Hay pasajes seleccionados pero no borrador | Falta la confirmación humana. | Revisa, marca la confirmación y pulsa de nuevo. |
+| Aparece `401` o `403` | La futura consola privada exige sesión y rol autorizados. | El propietario o IT debe revisar Entra y los roles `HUB.Owner`/`HUB.Operator`. |
+| Aparece `429` | Límite temporal de solicitudes. | Espera antes de reintentar. |
+| Aparece `502` o un error `5xx` | Servicio privado no desplegado o no saludable. | Utiliza texto manual y revisa el estado de despliegue. |
+| Se muestra una versión antigua | Puede quedar una caché del PWA. | Recarga primero. Antes de borrar datos del sitio, exporta los borradores locales. |
+
+No compartas contraseñas, tokens, cookies, secretos, identificadores internos
+ni capturas que los contengan.
+
+## Evidencia relacionada
+
+- [Operaciones EC2](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/ops/ec2/README.md)
+- [Issue #1835: frontera autenticada](https://github.com/Voxterrae/HUB_Optimus/issues/1835)
+- [PR #1844: implementación OIDC en borrador](https://github.com/Voxterrae/HUB_Optimus/pull/1844)

--- a/docs/wiki/Operator-User-Guide.md
+++ b/docs/wiki/Operator-User-Guide.md
@@ -2,14 +2,15 @@
 
 > **Estado:** prototipo público con revisión humana obligatoria.
 > **Última revisión:** 2026-08-02.
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+> **Base auditada:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).
 
 [Abre Operator en español](https://huboptimus.dev/operator/?lang=es#product_intake).
 
 ## Flujo que funciona actualmente
 
-1. Deja completamente vacío el campo de URL.
-2. Pega el texto de la fuente.
+1. Pega el texto completo de la fuente.
+2. Si quieres conservar la procedencia, añade su URL pública; es opcional y no
+   se recuperará ni verificará automáticamente.
 3. Pulsa **Preparar borrador**.
 4. Revisa los pasajes exactos propuestos.
 5. Confirma que has revisado la selección.
@@ -22,12 +23,15 @@ fuente.
 
 ## Importación mediante URL
 
-La importación automática de URLs no está operativa en el Operator público.
-Hasta que exista la frontera privada autenticada:
+La importación automática de URLs no está operativa en el Operator público. El
+comportamiento desplegado es deliberadamente inmediato y local:
 
-- borra la URL;
-- pega el texto completo;
-- conserva externamente la URL como referencia;
+- una URL sin texto no inicia ninguna petición y muestra el acceso previsto al
+  Operator privado;
+- una URL con texto conserva la URL exacta como atribución local no verificada;
+- no introduzcas enlaces privados o firmados, tokens, contraseñas de un solo
+  uso ni datos personales, porque una acción explícita de compartir puede
+  incluir la URL;
 - no presentes el contenido como verificado automáticamente.
 
 ## Qué produce
@@ -40,6 +44,6 @@ noticia y no convierte una fuente en evidencia confirmada.
 
 ## Fuentes
 
-- [Código del Operator](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/site/operator/index.html)
-- [Límite de idiomas e interfaz](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/site/i18n/README.md)
-- [RFC de intake controlado](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/rfc/operator_controlled_url_intake.md)
+- [Código del Operator](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/site/operator/index.html)
+- [Límite de idiomas e interfaz](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/site/i18n/README.md)
+- [RFC de intake controlado](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/rfc/operator_controlled_url_intake.md)

--- a/docs/wiki/Operator-User-Guide.md
+++ b/docs/wiki/Operator-User-Guide.md
@@ -1,7 +1,7 @@
 # Guía de uso de Operator
 
-> **Estado:** prototipo público con revisión humana obligatoria.  
-> **Última revisión:** 2026-08-02.  
+> **Estado:** prototipo público con revisión humana obligatoria.
+> **Última revisión:** 2026-08-02.
 > **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
 
 [Abre Operator en español](https://huboptimus.dev/operator/?lang=es#product_intake).

--- a/docs/wiki/Operator-User-Guide.md
+++ b/docs/wiki/Operator-User-Guide.md
@@ -1,0 +1,45 @@
+# Guía de uso de Operator
+
+> **Estado:** prototipo público con revisión humana obligatoria.  
+> **Última revisión:** 2026-08-02.  
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+
+[Abre Operator en español](https://huboptimus.dev/operator/?lang=es#product_intake).
+
+## Flujo que funciona actualmente
+
+1. Deja completamente vacío el campo de URL.
+2. Pega el texto de la fuente.
+3. Pulsa **Preparar borrador**.
+4. Revisa los pasajes exactos propuestos.
+5. Confirma que has revisado la selección.
+6. Pulsa **Preparar borrador vinculado a la fuente**.
+7. Revisa, corrige y guarda o exporta explícitamente el resultado.
+
+El texto de la fuente no está limitado a 1.200 caracteres. Esa cifra
+corresponde al contexto opcional del operador, no al contenido completo de la
+fuente.
+
+## Importación mediante URL
+
+La importación automática de URLs no está operativa en el Operator público.
+Hasta que exista la frontera privada autenticada:
+
+- borra la URL;
+- pega el texto completo;
+- conserva externamente la URL como referencia;
+- no presentes el contenido como verificado automáticamente.
+
+## Qué produce
+
+Operator prepara un borrador revisable con pasajes, afirmaciones, procedencia,
+incertidumbres y siguientes acciones.
+
+No ejecuta automáticamente el Semantic Engine, no verifica la verdad de una
+noticia y no convierte una fuente en evidencia confirmada.
+
+## Fuentes
+
+- [Código del Operator](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/site/operator/index.html)
+- [Límite de idiomas e interfaz](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/site/i18n/README.md)
+- [RFC de intake controlado](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/rfc/operator_controlled_url_intake.md)

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -6,6 +6,9 @@ is a navigation layer, not an independent source of truth.
 ## Publishing contract
 
 - Review changes here through the normal pull-request workflow.
+- Enable the repository Wiki only with **Restrict editing to collaborators only**
+  selected. Direct edits in the published Wiki are not an authoring path; make
+  every durable change here first and review it in a pull request.
 - Publish only the Markdown files in this directory to
   `Voxterrae/HUB_Optimus.wiki.git`.
 - Keep `_Sidebar.md` and `_Footer.md` synchronized with the published pages.
@@ -17,3 +20,42 @@ is a navigation layer, not an independent source of truth.
 
 If a Wiki statement conflicts with an applicable contract, `main`, or a live
 GitHub object, the narrower authoritative source wins.
+
+## One-way publication procedure
+
+Publish from a clean, reviewed `main` checkout. The following procedure mirrors
+only `docs/wiki/*.md` into a disposable clone of the Wiki repository; never run
+the removal step in the source repository or an unverified directory.
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+test -z "$(git -C "$repo_root" status --porcelain)"
+source_sha="$(git -C "$repo_root" rev-parse HEAD)"
+wiki_parent="$(mktemp -d)"
+wiki_checkout="$wiki_parent/HUB_Optimus.wiki"
+git clone git@github.com:Voxterrae/HUB_Optimus.wiki.git "$wiki_checkout"
+test "$(git -C "$wiki_checkout" remote get-url origin)" = \
+  "git@github.com:Voxterrae/HUB_Optimus.wiki.git"
+git -C "$wiki_checkout" rm -f --ignore-unmatch -- '*.md'
+cp "$repo_root"/docs/wiki/*.md "$wiki_checkout"/
+git -C "$wiki_checkout" add -- '*.md'
+git -C "$wiki_checkout" diff --cached --check
+git -C "$wiki_checkout" diff --cached --name-status
+git -C "$wiki_checkout" commit -m "docs(wiki): sync from main $source_sha"
+git -C "$wiki_checkout" push origin HEAD
+```
+
+Before pushing, a reviewer must confirm that the staged paths are only the
+expected root-level Markdown pages. After pushing, fetch the Wiki again and
+compare the source and published file sets and hashes:
+
+```bash
+git -C "$wiki_checkout" fetch origin
+git -C "$wiki_checkout" reset --hard '@{upstream}'
+(cd "$repo_root/docs/wiki" && sha256sum -- *.md | sort) > "$wiki_parent/source.sha256"
+(cd "$wiki_checkout" && sha256sum -- *.md | sort) > "$wiki_parent/published.sha256"
+diff -u "$wiki_parent/source.sha256" "$wiki_parent/published.sha256"
+```
+
+The final `diff` must be empty. If it is not, stop publication and reconcile the
+drift through a new source pull request; do not repair the Wiki directly.

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,19 @@
+# GitHub Wiki source
+
+This directory is the reviewed source for the HUB_Optimus GitHub Wiki. The Wiki
+is a navigation layer, not an independent source of truth.
+
+## Publishing contract
+
+- Review changes here through the normal pull-request workflow.
+- Publish only the Markdown files in this directory to
+  `Voxterrae/HUB_Optimus.wiki.git`.
+- Keep `_Sidebar.md` and `_Footer.md` synchronized with the published pages.
+- Every status page must name its observation date and audited repository SHA.
+- Immutable specifications should link to a commit-pinned path. Mutable PR,
+  Issue, Actions, and deployment state should link to the live GitHub object.
+- Never add credentials, tokens, cookies, tenant/client secrets, private keys,
+  internal capabilities, or live secret values.
+
+If a Wiki statement conflicts with an applicable contract, `main`, or a live
+GitHub object, the narrower authoritative source wins.

--- a/docs/wiki/Roadmap-and-Live-Status.md
+++ b/docs/wiki/Roadmap-and-Live-Status.md
@@ -1,0 +1,34 @@
+# Roadmap y estado live
+
+> **Corte de estado:** 2026-08-02.  
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).  
+> Los Issues, PRs, Checks y Actions vivos prevalecen sobre esta página.
+
+| Área | Estado observado | Siguiente decisión |
+| --- | --- | --- |
+| Web pública | Desplegada en GitHub Pages. | Mantener sincronización desde `main`. |
+| Operator con texto | Utilizable como prototipo revisable. | Mejorar mensajes y QA. |
+| Importación automática de URL | No operativa públicamente. | Completar backend privado autenticado. |
+| Backend EC2 local | Código y scripts versionados. | Acreditar host y SHA mediante #1831/#1832. |
+| OIDC propietario/equipo | PR #1844 en borrador. | Configurar Entra, Redis, TLS y pruebas E2E. |
+| QA iOS/Safari | Gate pendiente para el Operator privado. | Probar 320–1363 px, 200 %, RTL, movimiento reducido y WebGL. |
+| Historial persistente | No verificado como implementado. | Diseñar después del Operator privado. |
+| GitHub App Observe | Futuro. | Mantener inicialmente solo lectura. |
+| Señales y grafo | Futuro. | Definir contratos y procedencia primero. |
+| Consola espacial | Futuro. | Abordar después de persistencia y grafo. |
+
+## Secuencia recomendada
+
+1. [#1832: despliegue recuperable](https://github.com/Voxterrae/HUB_Optimus/issues/1832).
+2. [#1831: desplegar y acreditar SHA](https://github.com/Voxterrae/HUB_Optimus/issues/1831).
+3. [#1835: frontera pública segura](https://github.com/Voxterrae/HUB_Optimus/issues/1835).
+4. [PR #1844: OIDC propietario/equipo](https://github.com/Voxterrae/HUB_Optimus/pull/1844).
+5. QA real, evidencia y rollback.
+6. Historial persistente → Observe → señales/grafo → consola espacial.
+
+## Estado vivo
+
+- [Issues](https://github.com/Voxterrae/HUB_Optimus/issues)
+- [Pull requests](https://github.com/Voxterrae/HUB_Optimus/pulls)
+- [Actions](https://github.com/Voxterrae/HUB_Optimus/actions)
+- [Estado de capacidades versionado](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/capability_status.md)

--- a/docs/wiki/Roadmap-and-Live-Status.md
+++ b/docs/wiki/Roadmap-and-Live-Status.md
@@ -1,7 +1,7 @@
 # Roadmap y estado live
 
-> **Corte de estado:** 2026-08-02.  
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).  
+> **Corte de estado:** 2026-08-02.
+> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
 > Los Issues, PRs, Checks y Actions vivos prevalecen sobre esta página.
 
 | Área | Estado observado | Siguiente decisión |

--- a/docs/wiki/Roadmap-and-Live-Status.md
+++ b/docs/wiki/Roadmap-and-Live-Status.md
@@ -1,15 +1,15 @@
 # Roadmap y estado live
 
 > **Corte de estado:** 2026-08-02.
-> **Base auditada:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+> **Base auditada:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).
 > Los Issues, PRs, Checks y Actions vivos prevalecen sobre esta página.
 
 | Área | Estado observado | Siguiente decisión |
 | --- | --- | --- |
 | Web pública | Desplegada en GitHub Pages. | Mantener sincronización desde `main`. |
-| Operator con texto | Utilizable como prototipo revisable. | Mejorar mensajes y QA. |
+| Operator con texto | `c399c94` desplegado: texto completo local y URL opcional no verificada. | Completar QA real de caché y dispositivos. |
 | Importación automática de URL | No operativa públicamente. | Completar backend privado autenticado. |
-| Backend EC2 local | Código y scripts versionados. | Acreditar host y SHA mediante #1831/#1832. |
+| Backend EC2 local | Última auditoría: host local-only pero obsoleto; estado actual no reatestado. | Adoptar el estado legado con #1832 y después acreditar SHA mediante #1831. |
 | OIDC propietario/equipo | PR #1844 en borrador. | Configurar Entra, Redis, TLS y pruebas E2E. |
 | QA iOS/Safari | Gate pendiente para el Operator privado. | Probar 320–1363 px, 200 %, RTL, movimiento reducido y WebGL. |
 | Historial persistente | No verificado como implementado. | Diseñar después del Operator privado. |
@@ -31,4 +31,4 @@
 - [Issues](https://github.com/Voxterrae/HUB_Optimus/issues)
 - [Pull requests](https://github.com/Voxterrae/HUB_Optimus/pulls)
 - [Actions](https://github.com/Voxterrae/HUB_Optimus/actions)
-- [Estado de capacidades versionado](https://github.com/Voxterrae/HUB_Optimus/blob/4400b0d778dc64779f9db9bd4cdb398a7d46a69b/docs/architecture/capability_status.md)
+- [Estado de capacidades versionado](https://github.com/Voxterrae/HUB_Optimus/blob/c399c94e098058a723482001811c7d8491ebbd5e/docs/architecture/capability_status.md)

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,4 @@
+HUB_Optimus · Wiki de navegación · Revisada el 2026-08-02 · Base
+[`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b)
+· [`main`](https://github.com/Voxterrae/HUB_Optimus) y los registros vivos de
+GitHub son la fuente de verdad.

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,4 +1,4 @@
 HUB_Optimus · Wiki de navegación · Revisada el 2026-08-02 · Base
-[`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b)
+[`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e)
 · [`main`](https://github.com/Voxterrae/HUB_Optimus) y los registros vivos de
 GitHub son la fuente de verdad.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -19,4 +19,4 @@
 ---
 
 **Estado:** navegación documental.
-**Base:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).
+**Base:** [`c399c94`](https://github.com/Voxterrae/HUB_Optimus/commit/c399c94e098058a723482001811c7d8491ebbd5e).

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,22 @@
+## HUB_Optimus
+
+- [[Inicio|Home]]
+- [[Guía de Operator|Operator-User-Guide]]
+- [[Problemas de Operator|Operator-Troubleshooting]]
+- [[Arquitectura|Architecture]]
+- [[Hosting y despliegue|Hosting-and-Deployment]]
+- [[Roadmap y estado|Roadmap-and-Live-Status]]
+
+---
+
+- [Web](https://huboptimus.dev/)
+- [Operator](https://huboptimus.dev/operator/?lang=es#product_intake)
+- [Repositorio](https://github.com/Voxterrae/HUB_Optimus)
+- [Issues](https://github.com/Voxterrae/HUB_Optimus/issues)
+- [PRs](https://github.com/Voxterrae/HUB_Optimus/pulls)
+- [Actions](https://github.com/Voxterrae/HUB_Optimus/actions)
+
+---
+
+**Estado:** navegación documental.  
+**Base:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -18,5 +18,5 @@
 
 ---
 
-**Estado:** navegación documental.  
+**Estado:** navegación documental.
 **Base:** [`4400b0d`](https://github.com/Voxterrae/HUB_Optimus/commit/4400b0d778dc64779f9db9bd4cdb398a7d46a69b).

--- a/tests/test_wiki_source.py
+++ b/tests/test_wiki_source.py
@@ -27,14 +27,22 @@ def test_reviewed_wiki_source_has_the_required_navigation_pages():
 def test_wiki_declares_its_audited_boundary_and_live_state_authorities():
     home = (WIKI / "Home.md").read_text(encoding="utf-8")
     roadmap = (WIKI / "Roadmap-and-Live-Status.md").read_text(encoding="utf-8")
+    operator = (WIKI / "Operator-User-Guide.md").read_text(encoding="utf-8")
+    troubleshooting = (WIKI / "Operator-Troubleshooting.md").read_text(
+        encoding="utf-8"
+    )
     publishing = (WIKI / "README.md").read_text(encoding="utf-8")
 
-    assert "4400b0d778dc64779f9db9bd4cdb398a7d46a69b" in home
+    assert "c399c94e098058a723482001811c7d8491ebbd5e" in home
     assert "main" in publishing
     assert "independent source of truth" in publishing
     assert "https://github.com/Voxterrae/HUB_Optimus/issues" in roadmap
     assert "https://github.com/Voxterrae/HUB_Optimus/pulls" in roadmap
     assert "https://github.com/Voxterrae/HUB_Optimus/actions" in roadmap
+    assert "una URL sin texto no inicia ninguna petición" in operator
+    assert "una URL con texto conserva la URL exacta" in operator
+    assert "worker antiguo `v0-26`" in troubleshooting
+    assert "Operator público `v0-27`" in troubleshooting
 
 
 def test_wiki_publication_is_restricted_one_way_and_verified_for_drift():

--- a/tests/test_wiki_source.py
+++ b/tests/test_wiki_source.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WIKI = REPO_ROOT / "docs" / "wiki"
+
+
+def test_reviewed_wiki_source_has_the_required_navigation_pages():
+    expected = {
+        "README.md",
+        "Home.md",
+        "Operator-User-Guide.md",
+        "Operator-Troubleshooting.md",
+        "Architecture.md",
+        "Hosting-and-Deployment.md",
+        "Roadmap-and-Live-Status.md",
+        "_Sidebar.md",
+        "_Footer.md",
+    }
+    assert {path.name for path in WIKI.glob("*.md")} == expected
+
+    sidebar = (WIKI / "_Sidebar.md").read_text(encoding="utf-8")
+    for page in expected - {"README.md", "_Sidebar.md", "_Footer.md"}:
+        assert page.removesuffix(".md") in sidebar
+
+
+def test_wiki_declares_its_audited_boundary_and_live_state_authorities():
+    home = (WIKI / "Home.md").read_text(encoding="utf-8")
+    roadmap = (WIKI / "Roadmap-and-Live-Status.md").read_text(encoding="utf-8")
+    publishing = (WIKI / "README.md").read_text(encoding="utf-8")
+
+    assert "4400b0d778dc64779f9db9bd4cdb398a7d46a69b" in home
+    assert "main" in publishing
+    assert "independent source of truth" in publishing
+    assert "https://github.com/Voxterrae/HUB_Optimus/issues" in roadmap
+    assert "https://github.com/Voxterrae/HUB_Optimus/pulls" in roadmap
+    assert "https://github.com/Voxterrae/HUB_Optimus/actions" in roadmap
+
+
+def test_wiki_contains_no_secret_material_or_live_secret_placeholders():
+    text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(WIKI.glob("*.md"))
+    ).lower()
+    forbidden = (
+        "-----begin private key-----",
+        "aws_access_key_id=",
+        "aws_secret_access_key=",
+        "client_secret=",
+        "cookie_secret=",
+        "hub_operator_intake_capability=",
+    )
+    for marker in forbidden:
+        assert marker not in text

--- a/tests/test_wiki_source.py
+++ b/tests/test_wiki_source.py
@@ -37,6 +37,22 @@ def test_wiki_declares_its_audited_boundary_and_live_state_authorities():
     assert "https://github.com/Voxterrae/HUB_Optimus/actions" in roadmap
 
 
+def test_wiki_publication_is_restricted_one_way_and_verified_for_drift():
+    publishing = (WIKI / "README.md").read_text(encoding="utf-8")
+    hosting = (WIKI / "Hosting-and-Deployment.md").read_text(encoding="utf-8")
+
+    assert "Restrict editing to collaborators only" in publishing
+    assert "Direct edits in the published Wiki are not an authoring path" in publishing
+    assert "docs/wiki/*.md" in publishing
+    assert "HUB_Optimus.wiki.git" in publishing
+    assert "diff --cached --check" in publishing
+    assert "sha256sum -- *.md" in publishing
+    assert "The final `diff` must be empty" in publishing
+    assert "estado actual no reatestado" in hosting
+    assert "ACME DNS-01" in hosting
+    assert "HTTP-01" in hosting
+
+
 def test_wiki_contains_no_secret_material_or_live_secret_placeholders():
     text = "\n".join(
         path.read_text(encoding="utf-8") for path in sorted(WIKI.glob("*.md"))


### PR DESCRIPTION
## What changed

- add a reviewed `docs/wiki/` source package for the GitHub Wiki;
- document the deployed public Operator behavior at `c399c94`: URL + full pasted text stays local; URL-only stops immediately; automatic retrieval remains private;
- separate GitHub Pages from the proposed AWS/OIDC boundary;
- add architecture, deployment, roadmap, sidebar and footer pages;
- require collaborator-only Wiki editing and a one-way, hash-verified sync from `main`;
- record the last-known legacy EC2 audit without exposing host identifiers or secrets;
- add regression checks for the page set, source-of-truth boundary, publication controls and absence of secret material.

## Validation

- Wiki source tests: `4 passed`
- mojibake: 9/9 Markdown files clean
- `git diff --check`: clean
- CI, Link Check, Kernel Guard and both PR Safety runs: passed on `c6e4f90`
- independent final review: **PUBLISH**, no blocking findings
- remote/local blobs verified identical
- deployed Operator commit `c399c94` and Pages run `30765273410` verified

## Publication gate

The repository reports `has_wiki=true`, but `Voxterrae/HUB_Optimus.wiki` is not initialized yet (404). After merge:

1. Confirm **Settings → General → Features → Wikis → Restrict editing to collaborators only**.
2. Open the Wiki and initialize the first page as `Home`.
3. Synchronize only `docs/wiki/*.md` using `docs/wiki/README.md`.
4. Verify the published file set and SHA-256 manifest are identical.

Direct Wiki edits are not an authoring path; durable changes return through `docs/wiki/` and pull-request review.