### PR TITLE
fix(ec2): make current deployment recoverable

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -118,6 +118,52 @@ These scripts remain a manually installed EC2 backend layer. Repository tests
 exercise their isolated contracts; only a reviewed deployment and runtime
 inspection can attest the state of a real EC2 host.
 
+Issue #1832 hardens that boundary before the blocked host operation in #1831:
+
+- the confirmed legacy current release has a separate, explicit adoption
+  command bound to its real full commit; it validates repository/release/
+  symlink/launcher identity, preserves the original six-field state
+  byte-for-byte as mode-`0400` evidence, records its hash without re-attesting
+  the legacy test-count claim, postvalidates exact shared/per-release state,
+  and recovers transactionally at every mutation failpoint;
+- candidate validation still completes before operational mutation; a failed
+  candidate and validation log remain inspectable without changing `current`;
+- before mutation, deploy validates the managed rollback target's directory,
+  full commit, release/path state, launcher presence, and launcher SHA-256;
+- replacement launcher, release state, current marker, and rollback pointer are
+  staged, while exact pre-deploy artifacts are snapshotted inside the persistent
+  candidate release;
+- any later deploy failure restores the previous symlink and shared artifacts,
+  records recovery, and retains the failed candidate without depending on a
+  disposable reviewed-tools checkout; unavailable recovery logging never
+  suppresses restoration or produces a success result;
+- rollback validates unique state identity keys and uses its own persistent
+  snapshot, staged artifacts, exit recovery, and injected-failure coverage for
+  the complete multi-file transition;
+- the API captures its full running commit and launcher SHA-256 at process
+  start; `/status` exposes those immutable running values separately from the
+  mutable configured-current symlink and commit;
+- the #1831 host preflight is read-only and fail-closed on exact shared/current
+  launcher and release-state parity, rollback identity, complete operation-tool
+  inventory, `sudo -n`, egress, disk, inode, available-memory, and load floors;
+  an older unattested previous pointer is inventory only, while the adopted
+  current release becomes the next deploy's attested rollback target;
+- the host runbook requires both complete disk-state and process-bound
+  attestation after deploy and after any explicit rollback before either may
+  be called complete; disk attestation rejects malformed, duplicate, partial,
+  or divergent shared/per-release state and derives launcher identity from
+  both versioned and shared files, while process attestation binds both running
+  and configured release paths to the exact selected release;
+- localhost URL-intake evidence is reconstructed from an explicit allowlist;
+  fetched text and unknown/debug/body fields are never printed, and a passing
+  smoke requires curl success, HTTP 200, and exact running-launcher parity with
+  the reviewed release state.
+
+This repository state does not attest deployment on EC2 and does not authorize
+DNS, TLS, nginx, Security Group, public API, provider, reboot, schema,
+simulator, benchmark, or governance changes. Issue #1831 must be repinned to the
+reviewed merged commit and receive a fresh human-approved execution decision.
+
 ## Python Packaging Boundary
 
 Issue #1763 records drift between the documented Python minimum, executable

--- a/ops/ec2/ISSUE_1831_RUNBOOK.md
+++ b/ops/ec2/ISSUE_1831_RUNBOOK.md
@@ -1,0 +1,693 @@
+# Issue #1831 localhost intake runbook boundary
+
+This document defines the reviewed shape of the replacement host runbook after
+issue #1832. It is not an authorization to deploy its current repository
+checkout. Issue #1831 must first be repinned to the exact merged `main` commit,
+and the operator must replace `<fresh-reviewed-main-sha>` below with that full
+lowercase 40-character SHA.
+
+The operation remains local to the existing EC2 release layout. It does not
+change DNS, TLS, nginx, a Security Group, public routing, providers, or the
+host's reboot state.
+
+## 1. Retain the reviewed tools checkout
+
+The reviewed checkout must live under the managed shared directory until the
+operation and any explicit rollback are complete. Do not put it behind an
+`EXIT` trap that deletes it.
+
+```bash
+set -euo pipefail
+
+TARGET_SHA='<fresh-reviewed-main-sha>'
+LEGACY_CURRENT_SHA='9d6771994095e4fc04e8fdbf2caa644ccb002ab1'
+REPO_URL='https://github.com/Voxterrae/HUB_Optimus.git'
+APP_ROOT='/opt/hub-optimus'
+REFERENCE_URL='https://amp.dw.com/es/los-grandes-capos-mexicanos-presos-en-estados-unidos/a-77973174'
+TOOLS_ROOT="$APP_ROOT/shared/reviewed-tools/$TARGET_SHA"
+
+[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+REQUIRED_COMMANDS=(
+  awk basename bash cat chmod cmp cp curl date df dirname flock free git grep
+  head install ln mkdir mktemp mv python3 readlink rm rmdir sed sha256sum stat
+  sudo systemctl tee timeout tr
+)
+for command_name in "${REQUIRED_COMMANDS[@]}"; do
+  command -v "$command_name" >/dev/null
+done
+sudo -n true
+install -d -m 0700 "$APP_ROOT/shared/reviewed-tools"
+test ! -e "$TOOLS_ROOT"
+git init --quiet "$TOOLS_ROOT"
+git -C "$TOOLS_ROOT" remote add origin "$REPO_URL"
+git -C "$TOOLS_ROOT" fetch --quiet --depth 1 origin "$TARGET_SHA"
+git -C "$TOOLS_ROOT" checkout --quiet --detach FETCH_HEAD
+test "$(git -C "$TOOLS_ROOT" rev-parse --verify HEAD)" = "$TARGET_SHA"
+
+bash -n "$TOOLS_ROOT"/ops/ec2/*.sh
+python3 -m py_compile "$TOOLS_ROOT/ops/ec2/intake-smoke-evidence.py"
+```
+
+Removal of this retained checkout is a separate post-operation cleanup choice;
+failure handling never depends on recreating deleted tools.
+
+## 2. Explicitly adopt the exact legacy current release
+
+The confirmed legacy host state predates per-release deployment provenance. It
+must be adopted before the strict preflight. Do not edit either release-state
+file, the launcher, or a symlink by hand. The command is deliberately bound to
+the known full current commit rather than the legacy state's short SHA:
+
+```bash
+HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
+HUB_OPTIMUS_REPO_URL="$REPO_URL" \
+  bash "$TOOLS_ROOT/ops/ec2/adopt-legacy-current.sh" \
+    "$LEGACY_CURRENT_SHA"
+
+ADOPTED_CURRENT="$(readlink -f "$APP_ROOT/current")"
+ADOPTED_STATE="$ADOPTED_CURRENT/.hub-deployment/RELEASE_STATE"
+LEGACY_EVIDENCE="$ADOPTED_CURRENT/.hub-deployment/LEGACY_RELEASE_STATE"
+
+test "$(git -C "$ADOPTED_CURRENT" rev-parse --verify HEAD)" \
+  = "$LEGACY_CURRENT_SHA"
+cmp -s "$ADOPTED_CURRENT/ops/ec2/hub-api.sh" \
+  "$APP_ROOT/shared/bin/hub-api"
+cmp -s "$ADOPTED_STATE" "$APP_ROOT/shared/RELEASE_STATE"
+test "$(stat -c '%a' "$LEGACY_EVIDENCE")" = '400'
+test "$(sha256sum -- "$LEGACY_EVIDENCE" | awk '{print $1}')" \
+  = "$(sed -n 's/^legacy_state_sha256=//p' "$ADOPTED_STATE")"
+```
+
+Adoption validates the managed symlink, exact repository origin, clean release
+checkout, full commit, marker, and byte-identical versioned/shared launcher. It
+does not re-assert the old `pytest 55 passed` claim. Instead it preserves the
+original legacy state byte-for-byte as mode-`0400` evidence, records its
+SHA-256 and short-commit prefix in a new full-SHA state, and postvalidates that
+the per-release and shared states are identical before committing success.
+
+The command is idempotent only when that complete evidence bundle remains
+exact. A failure after mutation begins restores the pre-adoption state and
+retains its snapshot and recovery log under `shared/legacy-adoption.*`. Stop
+and inspect that evidence; do not repair or retry by hand.
+
+## 3. Fail-closed host preflight
+
+Run the versioned preflight before deployment:
+
+```bash
+HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
+HUB_OPTIMUS_REPO_URL="$REPO_URL" \
+  bash "$TOOLS_ROOT/ops/ec2/preflight-deploy.sh" \
+    "$TARGET_SHA" \
+    "$REFERENCE_URL"
+```
+
+The preflight stops unless all of the following are true:
+
+- the target is one explicit full commit SHA;
+- required tooling and `sudo -n` are available;
+- `hub-api.service` is active;
+- `current` has exact shared/per-release state parity and a launcher bound to
+  its clean, managed repository checkout;
+- any historical `previous_release` with deployment state is fully attested;
+  an older pointer without per-release state is inventoried as
+  `legacy-unattested-not-deploy-rollback-target` and is never trusted as the
+  rollback target for this deploy (the adopted current release becomes that
+  target when deployment switches);
+- the current, historical previous, and shared launcher SHA-256 values and the
+  previous-state status are printed;
+- at least 3 GiB disk, 50,000 inodes, and 512 MiB available RAM remain;
+- one-minute load is no greater than 2.00;
+- GitHub and the HTTPS reference URL are reachable from the host.
+
+Do not override a failed threshold or identity check inside the same operation.
+
+## 4. Exact-SHA deploy and review
+
+```bash
+HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
+HUB_OPTIMUS_REPO_URL="$REPO_URL" \
+  bash "$TOOLS_ROOT/ops/ec2/deploy-current.sh" "$TARGET_SHA"
+
+DEPLOYED_RELEASE="$(readlink -f "$APP_ROOT/current")"
+test "$(git -C "$DEPLOYED_RELEASE" rev-parse --verify HEAD)" = "$TARGET_SHA"
+DEPLOYED_RELEASE_STATE="$DEPLOYED_RELEASE/.hub-deployment/RELEASE_STATE"
+cmp -s "$DEPLOYED_RELEASE_STATE" "$APP_ROOT/shared/RELEASE_STATE"
+
+python3 - "$APP_ROOT" "$DEPLOYED_RELEASE" "$TARGET_SHA" <<'PY_DEPLOY_STATE'
+import hashlib
+import json
+import re
+import stat
+import sys
+from pathlib import Path
+
+app_root = Path(sys.argv[1]).resolve()
+deployed = Path(sys.argv[2]).resolve()
+target = sys.argv[3]
+required_keys = {
+    "release",
+    "requested_ref",
+    "requested_ref_kind",
+    "commit",
+    "path",
+    "validated_at_utc",
+    "validation_command",
+    "validation_exit_code",
+    "validation_result",
+    "validation_log",
+    "validation_log_exit_code",
+    "launcher_sha256",
+    "status",
+}
+
+def require_regular(path, *, executable=False, mode=None):
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"not one regular file: {path}")
+    actual_mode = stat.S_IMODE(path.stat().st_mode)
+    if executable and actual_mode & 0o111 == 0:
+        raise SystemExit(f"not executable: {path}")
+    if mode is not None and actual_mode != mode:
+        raise SystemExit(f"unexpected mode for {path}: {actual_mode:o}")
+
+def exact_state(path, raw):
+    try:
+        lines = raw.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"release state is not UTF-8: {path}") from exc
+    pairs = []
+    for line in lines:
+        if "=" not in line:
+            raise SystemExit(f"malformed release-state line in {path}")
+        key, value = line.split("=", 1)
+        if not key:
+            raise SystemExit(f"empty release-state key in {path}")
+        pairs.append((key, value))
+    keys = [key for key, _ in pairs]
+    if len(keys) != len(set(keys)):
+        raise SystemExit(f"duplicate release-state key in {path}")
+    if set(keys) != required_keys:
+        raise SystemExit(f"release state does not have the exact field set: {path}")
+    return dict(pairs)
+
+if deployed.parent != app_root / "releases":
+    raise SystemExit("deployed release is outside the managed release root")
+if not re.fullmatch(r"[0-9a-f]{40}", target):
+    raise SystemExit("target is not one full lowercase commit SHA")
+current = app_root / "current"
+if not current.is_symlink() or current.resolve() != deployed:
+    raise SystemExit("current does not resolve to the deployed release")
+
+release_state_path = deployed / ".hub-deployment" / "RELEASE_STATE"
+shared_state_path = app_root / "shared" / "RELEASE_STATE"
+require_regular(release_state_path, mode=0o600)
+require_regular(shared_state_path, mode=0o644)
+release_state_raw = release_state_path.read_bytes()
+shared_state_raw = shared_state_path.read_bytes()
+if release_state_raw != shared_state_raw:
+    raise SystemExit("shared and per-release RELEASE_STATE differ")
+state = exact_state(release_state_path, release_state_raw)
+
+if state["release"] != deployed.name:
+    raise SystemExit("release state has the wrong release name")
+if state["path"] != str(deployed):
+    raise SystemExit("release state has the wrong release path")
+if state["requested_ref"] != target or state["commit"] != target:
+    raise SystemExit("release state is not target-bound")
+if state["requested_ref_kind"] != "commit":
+    raise SystemExit("release state was not created from an exact commit")
+if not re.fullmatch(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",
+    state["validated_at_utc"],
+):
+    raise SystemExit("release-state validation timestamp is invalid")
+if state["validation_command"] != "python -m pytest -q":
+    raise SystemExit("release-state validation command differs")
+if state["validation_exit_code"] != "0" or state["validation_log_exit_code"] != "0":
+    raise SystemExit("candidate validation did not pass")
+if not state["validation_result"]:
+    raise SystemExit("release-state validation result is empty")
+expected_validation_log = deployed / ".hub-deployment" / "validation.log"
+if state["validation_log"] != str(expected_validation_log):
+    raise SystemExit("release-state validation log path differs")
+require_regular(expected_validation_log, mode=0o600)
+if not re.fullmatch(r"[0-9a-f]{64}", state["launcher_sha256"]):
+    raise SystemExit("launcher identity is missing")
+if state["status"] != "production-candidate-core":
+    raise SystemExit("release state is not a production candidate")
+
+versioned_launcher = deployed / "ops" / "ec2" / "hub-api.sh"
+shared_launcher = app_root / "shared" / "bin" / "hub-api"
+require_regular(versioned_launcher, executable=True)
+require_regular(shared_launcher, executable=True)
+versioned_launcher_raw = versioned_launcher.read_bytes()
+shared_launcher_raw = shared_launcher.read_bytes()
+versioned_hash = hashlib.sha256(versioned_launcher_raw).hexdigest()
+shared_hash = hashlib.sha256(shared_launcher_raw).hexdigest()
+if versioned_launcher_raw != shared_launcher_raw:
+    raise SystemExit("shared and versioned launchers differ")
+if state["launcher_sha256"] != versioned_hash or versioned_hash != shared_hash:
+    raise SystemExit("launcher hashes do not match RELEASE_STATE")
+
+current_marker = app_root / "shared" / "current_release"
+require_regular(current_marker)
+if current_marker.read_bytes() != f"{deployed.name}\n".encode():
+    raise SystemExit("current-release marker differs from deployed release")
+
+print(json.dumps({
+    "commit": state["commit"],
+    "launcher_sha256": state["launcher_sha256"],
+    "path": state["path"],
+    "release": state["release"],
+    "release_state_sha256": hashlib.sha256(release_state_raw).hexdigest(),
+    "validation_exit_code": state["validation_exit_code"],
+    "validation_log_exit_code": state["validation_log_exit_code"],
+}, indent=2, sort_keys=True))
+PY_DEPLOY_STATE
+
+EXPECTED_LAUNCHER_SHA256="$(
+  sha256sum -- "$DEPLOYED_RELEASE/ops/ec2/hub-api.sh" | awk '{print $1}'
+)"
+[[ "$EXPECTED_LAUNCHER_SHA256" =~ ^[0-9a-f]{64}$ ]]
+```
+
+An internal failure after deployment mutation begins automatically restores the
+exact pre-deploy `current` symlink, shared launcher, shared release state,
+current-release marker, and previous-release pointer. The failed candidate,
+validation log, snapshot, and recovery log remain under its release directory.
+Do not restart or invoke rollback after a deployment failure that reports a
+successful automatic restoration.
+
+## 5. Explicit restart and process-bound status
+
+Only after reviewing the release state:
+
+```bash
+sudo -n systemctl restart hub-api.service
+sudo -n systemctl is-active --quiet hub-api.service
+
+STATUS_RESPONSE="$(mktemp /tmp/hub-optimus-status.XXXXXX.json)"
+curl -fsS --connect-timeout 2 --max-time 5 \
+  -o "$STATUS_RESPONSE" \
+  http://127.0.0.1:8080/status
+
+python3 \
+  - "$STATUS_RESPONSE" "$DEPLOYED_RELEASE" "$TARGET_SHA" \
+  "$EXPECTED_LAUNCHER_SHA256" \
+  <<'PY_STATUS'
+import json
+import re
+import sys
+from pathlib import Path
+
+status = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected_release = str(Path(sys.argv[2]).resolve())
+target = sys.argv[3]
+expected_launcher_sha256 = sys.argv[4]
+if not isinstance(status, dict):
+    raise SystemExit("status response is not an object")
+if not re.fullmatch(r"[0-9a-f]{40}", target):
+    raise SystemExit("expected status commit is invalid")
+if not re.fullmatch(r"[0-9a-f]{64}", expected_launcher_sha256):
+    raise SystemExit("expected status launcher identity is invalid")
+evidence = {
+    "product": status.get("product"),
+    "running_release": status.get("running_release"),
+    "running_commit": status.get("running_commit"),
+    "running_launcher_sha256": status.get("running_launcher_sha256"),
+    "configured_current_release": status.get("configured_current_release"),
+    "configured_current_commit": status.get("configured_current_commit"),
+}
+print(json.dumps(evidence, indent=2, sort_keys=True))
+if evidence["running_release"] != expected_release:
+    raise SystemExit("running process is not bound to the deployed release")
+if evidence["configured_current_release"] != expected_release:
+    raise SystemExit("configured current release is not the deployed release")
+if evidence["running_commit"] != target:
+    raise SystemExit("running process is not bound to the target commit")
+if evidence["configured_current_commit"] != target:
+    raise SystemExit("configured current release is not the target commit")
+if evidence["running_launcher_sha256"] != expected_launcher_sha256:
+    raise SystemExit("running launcher does not match RELEASE_STATE")
+PY_STATUS
+```
+
+The status evidence deliberately omits `release_state` and every unknown field.
+Changing `current` without restarting changes only the configured identity; it
+cannot rewrite the process-bound running commit or launcher hash.
+
+## 6. Controlled URL intake and strict evidence allowlist
+
+Keep the raw response mode-private on the host. Only the allowlisted summary
+produced by `intake-smoke-evidence.py` may be posted to GitHub.
+
+```bash
+EVIDENCE_DIR="$(mktemp -d "$APP_ROOT/shared/intake-smoke.XXXXXX")"
+chmod 0700 "$EVIDENCE_DIR"
+RESPONSE="$EVIDENCE_DIR/response.json"
+install -m 0600 /dev/null "$RESPONSE"
+PAYLOAD="$(
+  python3 - "$REFERENCE_URL" <<'PY_REQUEST'
+import json
+import sys
+print(json.dumps({"url": sys.argv[1]}, ensure_ascii=False))
+PY_REQUEST
+)"
+
+set +e
+HTTP_CODE="$(
+  curl --silent --show-error \
+    --fail-with-body \
+    --connect-timeout 5 \
+    --max-time 15 \
+    --output "$RESPONSE" \
+    --write-out '%{http_code}' \
+    --request POST \
+    http://127.0.0.1:8080/intake/url \
+    --header 'Content-Type: application/json' \
+    --data-binary "$PAYLOAD"
+)"
+CURL_RC=$?
+set -e
+
+python3 "$DEPLOYED_RELEASE/ops/ec2/intake-smoke-evidence.py" \
+  "$RESPONSE" \
+  "$HTTP_CODE" \
+  "$CURL_RC" \
+  "$TARGET_SHA"
+```
+
+The evidence helper constructs a new object from an explicit allowlist. It
+never prints `text`, title, message, debug/body fields, redirects, extraction
+notes, or an unknown response field. It emits only target/transport status,
+stable application error code, source/final URL metadata, content metadata,
+verification status, and text presence/count/SHA-256.
+
+## 7. Failure after a successful deploy
+
+If the explicit restart, status attestation, or intake smoke fails after the
+deploy itself completed, retain the local response and use the rollback script
+from the persistent deployed release, not a temporary checkout:
+
+```bash
+HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
+  bash "$DEPLOYED_RELEASE/ops/ec2/rollback-current.sh"
+
+ROLLED_BACK_RELEASE="$(readlink -f "$APP_ROOT/current")"
+RESTORED_COMMIT="$(git -C "$ROLLED_BACK_RELEASE" rev-parse --verify HEAD)"
+test "$RESTORED_COMMIT" = "$LEGACY_CURRENT_SHA"
+RESTORED_RELEASE_STATE="$ROLLED_BACK_RELEASE/.hub-deployment/RELEASE_STATE"
+cmp -s "$RESTORED_RELEASE_STATE" "$APP_ROOT/shared/RELEASE_STATE"
+RESTORED_LAUNCHER_SHA256="$(
+  sha256sum -- "$ROLLED_BACK_RELEASE/ops/ec2/hub-api.sh" | awk '{print $1}'
+)"
+
+python3 \
+  - "$ROLLED_BACK_RELEASE" "$RESTORED_COMMIT" \
+  "$RESTORED_LAUNCHER_SHA256" "$APP_ROOT" "$DEPLOYED_RELEASE" \
+  "$TARGET_SHA" "$LEGACY_CURRENT_SHA" \
+  <<'PY_ROLLBACK_STATE'
+import hashlib
+import json
+import re
+import stat
+import sys
+from pathlib import Path
+
+restored = Path(sys.argv[1]).resolve()
+restored_commit = sys.argv[2]
+restored_launcher_sha256 = sys.argv[3]
+app_root = Path(sys.argv[4]).resolve()
+deployed = Path(sys.argv[5]).resolve()
+deployed_commit = sys.argv[6]
+legacy_commit = sys.argv[7]
+adopted_keys = {
+    "release",
+    "requested_ref",
+    "requested_ref_kind",
+    "commit",
+    "path",
+    "adopted_at_utc",
+    "validation_command",
+    "validation_exit_code",
+    "validation_result",
+    "validation_log",
+    "validation_log_exit_code",
+    "launcher_sha256",
+    "status",
+    "provenance",
+    "legacy_state_sha256",
+    "legacy_commit_prefix",
+}
+legacy_keys = {
+    "release",
+    "commit",
+    "path",
+    "validated_at_utc",
+    "validation",
+    "status",
+}
+rollback_keys = {
+    "rolled_back_at_utc",
+    "from_release",
+    "from_commit",
+    "to_release",
+    "to_commit",
+    "to_launcher_sha256",
+}
+
+if restored.parent != app_root / "releases":
+    raise SystemExit("rollback target is outside the managed release root")
+if deployed.parent != app_root / "releases":
+    raise SystemExit("rollback source is outside the managed release root")
+if not re.fullmatch(r"[0-9a-f]{40}", restored_commit):
+    raise SystemExit("restored commit is not one full SHA")
+if not re.fullmatch(r"[0-9a-f]{40}", deployed_commit):
+    raise SystemExit("deployed commit is not one full SHA")
+if legacy_commit != restored_commit:
+    raise SystemExit("rollback target is not the expected legacy commit")
+if not re.fullmatch(r"[0-9a-f]{64}", restored_launcher_sha256):
+    raise SystemExit("restored launcher identity is invalid")
+
+def require_regular(path, *, executable=False, mode=None):
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"not one regular file: {path}")
+    actual_mode = stat.S_IMODE(path.stat().st_mode)
+    if executable and actual_mode & 0o111 == 0:
+        raise SystemExit(f"not executable: {path}")
+    if mode is not None and actual_mode != mode:
+        raise SystemExit(f"unexpected mode for {path}: {actual_mode:o}")
+
+def exact_state(path, raw, required):
+    try:
+        lines = raw.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"state is not UTF-8: {path}") from exc
+    pairs = []
+    for line in lines:
+        if "=" not in line:
+            raise SystemExit(f"malformed state line in {path}")
+        key, value = line.split("=", 1)
+        if not key:
+            raise SystemExit(f"empty state key in {path}")
+        pairs.append((key, value))
+    keys = [key for key, _ in pairs]
+    if len(keys) != len(set(keys)):
+        raise SystemExit(f"duplicate state field in {path}")
+    if set(keys) != required:
+        raise SystemExit(f"state does not have the exact field set: {path}")
+    return dict(pairs)
+
+current = app_root / "current"
+if not current.is_symlink() or current.resolve() != restored:
+    raise SystemExit("current does not resolve to the rollback target")
+
+release_state_path = restored / ".hub-deployment" / "RELEASE_STATE"
+shared_state_path = app_root / "shared" / "RELEASE_STATE"
+require_regular(release_state_path, mode=0o600)
+require_regular(shared_state_path, mode=0o644)
+release_state_raw = release_state_path.read_bytes()
+shared_state_raw = shared_state_path.read_bytes()
+if release_state_raw != shared_state_raw:
+    raise SystemExit("shared and per-release rollback RELEASE_STATE differ")
+release_state = exact_state(
+    release_state_path,
+    release_state_raw,
+    adopted_keys,
+)
+
+if release_state["release"] != restored.name:
+    raise SystemExit("restored release state has the wrong release name")
+if release_state["path"] != str(restored):
+    raise SystemExit("restored release state has the wrong release path")
+if release_state["requested_ref"] != restored_commit:
+    raise SystemExit("restored release requested ref differs")
+if release_state["requested_ref_kind"] != "legacy-host-adoption":
+    raise SystemExit("restored release is not an explicit legacy adoption")
+if release_state["commit"] != restored_commit:
+    raise SystemExit("restored release commit differs")
+if not re.fullmatch(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",
+    release_state["adopted_at_utc"],
+):
+    raise SystemExit("restored adoption timestamp is invalid")
+if release_state["validation_command"] != "not-run-during-legacy-adoption":
+    raise SystemExit("restored adoption validation command differs")
+if release_state["validation_exit_code"] != "not-run":
+    raise SystemExit("restored adoption validation exit differs")
+if release_state["validation_result"] != (
+    "legacy validation claim not re-attested; original state retained by SHA-256"
+):
+    raise SystemExit("restored adoption validation result differs")
+if release_state["validation_log"] != "not-applicable":
+    raise SystemExit("restored adoption validation log differs")
+if release_state["validation_log_exit_code"] != "not-run":
+    raise SystemExit("restored adoption log exit differs")
+if release_state["status"] != "adopted-legacy-current":
+    raise SystemExit("restored adoption status differs")
+if release_state["provenance"] != "adopted-legacy-current-v1":
+    raise SystemExit("restored adoption provenance differs")
+if not re.fullmatch(r"[0-9a-f]{64}", release_state["legacy_state_sha256"]):
+    raise SystemExit("restored legacy-state identity is invalid")
+legacy_prefix = release_state["legacy_commit_prefix"]
+if not re.fullmatch(r"[0-9a-f]{7,39}", legacy_prefix):
+    raise SystemExit("restored legacy commit prefix is invalid")
+if not restored_commit.startswith(legacy_prefix):
+    raise SystemExit("restored legacy commit prefix differs")
+
+legacy_state_path = restored / ".hub-deployment" / "LEGACY_RELEASE_STATE"
+require_regular(legacy_state_path, mode=0o400)
+legacy_state_raw = legacy_state_path.read_bytes()
+if hashlib.sha256(legacy_state_raw).hexdigest() != release_state["legacy_state_sha256"]:
+    raise SystemExit("retained legacy state does not match its recorded hash")
+legacy_state = exact_state(legacy_state_path, legacy_state_raw, legacy_keys)
+if legacy_state["release"] != restored.name:
+    raise SystemExit("retained legacy state has the wrong release name")
+if legacy_state["path"] != str(restored):
+    raise SystemExit("retained legacy state has the wrong release path")
+if legacy_state["commit"] != legacy_prefix:
+    raise SystemExit("retained legacy state has the wrong commit prefix")
+if not re.fullmatch(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",
+    legacy_state["validated_at_utc"],
+):
+    raise SystemExit("retained legacy validation timestamp is invalid")
+if not legacy_state["validation"]:
+    raise SystemExit("retained legacy validation claim is empty")
+if legacy_state["status"] != "production-candidate-core":
+    raise SystemExit("retained legacy status differs")
+
+shared_launcher = app_root / "shared" / "bin" / "hub-api"
+versioned_launcher = restored / "ops" / "ec2" / "hub-api.sh"
+require_regular(shared_launcher, executable=True)
+require_regular(versioned_launcher, executable=True)
+shared_launcher_raw = shared_launcher.read_bytes()
+versioned_launcher_raw = versioned_launcher.read_bytes()
+shared_hash = hashlib.sha256(shared_launcher_raw).hexdigest()
+versioned_hash = hashlib.sha256(versioned_launcher_raw).hexdigest()
+if shared_launcher_raw != versioned_launcher_raw:
+    raise SystemExit("restored shared and versioned launchers differ")
+if release_state["launcher_sha256"] != versioned_hash:
+    raise SystemExit("restored launcher does not match RELEASE_STATE")
+if restored_launcher_sha256 != versioned_hash or versioned_hash != shared_hash:
+    raise SystemExit("restored shared/versioned launcher identity differs")
+
+current_marker = app_root / "shared" / "current_release"
+require_regular(current_marker)
+if current_marker.read_bytes() != f"{restored.name}\n".encode():
+    raise SystemExit("restored current-release marker differs")
+
+rollback_state_path = app_root / "shared" / "ROLLBACK_STATE"
+require_regular(rollback_state_path, mode=0o600)
+rollback_state = exact_state(
+    rollback_state_path,
+    rollback_state_path.read_bytes(),
+    rollback_keys,
+)
+if rollback_state["from_release"] != deployed.name:
+    raise SystemExit("rollback source release differs")
+if rollback_state["from_commit"] != deployed_commit:
+    raise SystemExit("rollback source commit differs")
+if rollback_state["to_release"] != restored.name:
+    raise SystemExit("rollback target release differs")
+if rollback_state["to_commit"] != restored_commit:
+    raise SystemExit("rollback target commit differs")
+if rollback_state["to_launcher_sha256"] != restored_launcher_sha256:
+    raise SystemExit("rollback target launcher differs")
+if not re.fullmatch(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",
+    rollback_state["rolled_back_at_utc"],
+):
+    raise SystemExit("rollback timestamp is invalid")
+last_rollback_from = app_root / "shared" / "last_rollback_from"
+require_regular(last_rollback_from)
+if last_rollback_from.read_bytes() != f"{deployed}\n".encode():
+    raise SystemExit("rollback source pointer differs")
+print(json.dumps({
+    "from_commit": deployed_commit,
+    "release_state_sha256": hashlib.sha256(release_state_raw).hexdigest(),
+    "to_commit": restored_commit,
+    "to_release": restored.name,
+    "to_launcher_sha256": restored_launcher_sha256,
+}, indent=2, sort_keys=True))
+PY_ROLLBACK_STATE
+
+sudo -n systemctl restart hub-api.service
+sudo -n systemctl is-active --quiet hub-api.service
+
+ROLLBACK_STATUS_RESPONSE="$(mktemp /tmp/hub-optimus-rollback-status.XXXXXX.json)"
+curl -fsS --connect-timeout 2 --max-time 5 \
+  -o "$ROLLBACK_STATUS_RESPONSE" \
+  http://127.0.0.1:8080/status
+
+python3 \
+  - "$ROLLBACK_STATUS_RESPONSE" "$ROLLED_BACK_RELEASE" \
+  "$RESTORED_COMMIT" "$RESTORED_LAUNCHER_SHA256" \
+  <<'PY_ROLLBACK_STATUS'
+import json
+import re
+import sys
+from pathlib import Path
+
+status = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected_release = str(Path(sys.argv[2]).resolve())
+expected_commit = sys.argv[3]
+expected_launcher_sha256 = sys.argv[4]
+if not isinstance(status, dict):
+    raise SystemExit("rollback status response is not an object")
+if not re.fullmatch(r"[0-9a-f]{40}", expected_commit):
+    raise SystemExit("expected rollback commit is invalid")
+if not re.fullmatch(r"[0-9a-f]{64}", expected_launcher_sha256):
+    raise SystemExit("expected rollback launcher identity is invalid")
+evidence = {
+    "product": status.get("product"),
+    "running_release": status.get("running_release"),
+    "running_commit": status.get("running_commit"),
+    "running_launcher_sha256": status.get("running_launcher_sha256"),
+    "configured_current_release": status.get("configured_current_release"),
+    "configured_current_commit": status.get("configured_current_commit"),
+}
+print(json.dumps(evidence, indent=2, sort_keys=True))
+if evidence["running_release"] != expected_release:
+    raise SystemExit("running rollback release differs")
+if evidence["configured_current_release"] != expected_release:
+    raise SystemExit("configured rollback release differs")
+if evidence["running_commit"] != expected_commit:
+    raise SystemExit("running rollback commit differs")
+if evidence["configured_current_commit"] != expected_commit:
+    raise SystemExit("configured rollback commit differs")
+if evidence["running_launcher_sha256"] != expected_launcher_sha256:
+    raise SystemExit("running rollback launcher differs")
+PY_ROLLBACK_STATUS
+```
+
+The rollback command stages its transition and snapshots every shared artifact
+before mutation. If rollback itself fails, its exit handler restores the exact
+pre-rollback state and retains the transaction snapshot and recovery log under
+`$APP_ROOT/shared/rollback-transaction.*`; do not hand-edit around that result.
+
+Only after the rollback command, complete disk-state attestation, explicit
+restart, and process-bound status attestation all pass is rollback complete.
+Record the allowlisted failure evidence and the versioned rollback transition.
+Do not hand-edit symlinks. Do not proceed to DNS, TLS, nginx, public routing, or
+a reboot in this operation.

--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -83,20 +83,73 @@ command, its exit code, its final output line, and its validation log. Failed
 validation leaves its candidate release and metadata for inspection but never
 switches `current`.
 
+The release state also records the SHA-256 of the selected `hub-api.sh`
+launcher. Before changing operational state, deployment validates that the
+current release is a managed, usable rollback target and stages all replacement
+artifacts. If any later step fails, an exit handler restores the exact previous
+`current` symlink, shared launcher, shared release state, current-release
+marker, previous-release pointer, and any transactionally completed legacy
+release state. The failed candidate retains its validation log,
+`pre-deploy-state` snapshot, and `recovery.log`; recovery does not depend on an
+external or temporary checkout. Restoration is attempted even when the
+recovery log cannot be opened or written; that condition is reported as a
+failed recovery outcome rather than a false success.
+
 The script fixes and records the selected source revision; it does not itself
 prove that a commit or tag was reviewed or signed. GitHub review records and the
 human deploy decision remain the authority for that claim.
 
 Before switching, deployment preserves provenance for the current release.
-`rollback-current` verifies that the recorded commit still matches the target,
-switches explicitly to `previous_release`, restores that release's API launcher
-and deployment state, and writes a separate `ROLLBACK_STATE` transition record.
-Deploy and rollback share a non-blocking host lock so they cannot mutate release
-state concurrently.
+`rollback-current` rejects duplicate target-state identity keys, verifies the
+recorded commit, path, release, and launcher hash, then snapshots and stages its
+own complete transition. Any injected or ordinary failure after rollback
+mutation begins restores the exact pre-rollback symlink, launcher, release
+state, rollback state, current marker, and prior transition marker. A successful
+rollback publishes a separate `ROLLBACK_STATE`. Deploy and rollback share a
+non-blocking host lock so they cannot mutate release state concurrently.
 
 Neither operation silently restarts the running API service. After a deploy or
 rollback, an operator must review the recorded state and explicitly restart the
 service when the process should load the restored launcher.
+
+At launcher start, the API captures the full commit of the resolved running
+release and the SHA-256 of the launcher that started it. `/status` reports those
+immutable process-bound values as `running_release`, `running_commit`, and
+`running_launcher_sha256`. It reports the mutable symlink separately as
+`configured_current_release` and `configured_current_commit`. Moving `current`
+without restarting therefore cannot make an old process claim the new running
+identity.
+
+## Issue #1831 host safeguards
+
+[`adopt-legacy-current.sh`](adopt-legacy-current.sh) is the one-time,
+idempotent migration boundary for the confirmed pre-#1832 current release. It
+requires the operator to supply that checkout's full commit SHA, then validates
+the managed symlink, exact repository origin, clean checkout, marker, and
+byte-identical versioned/shared launcher. It does not trust the legacy short
+commit or validation-count claim as authority. The original six-field state is
+retained byte-for-byte as mode-`0400` `LEGACY_RELEASE_STATE`; its SHA-256 and
+short prefix are linked from the new full-SHA state. The shared/per-release
+states are postvalidated before success. Any post-mutation failure restores the
+exact snapshot, and an exact completed adoption can be rerun without change.
+
+[`preflight-deploy.sh`](preflight-deploy.sh) is the read-only, fail-closed host
+gate for the exact-SHA localhost intake operation. It checks rollback release
+identity and launcher provenance, requires the shared launcher and shared
+release state to match the configured current release exactly, checks
+non-interactive sudo, required tooling, GitHub/reference-URL egress, and
+explicit t3.small resource floors before a deploy is attempted. A historical
+`previous_release` without per-release state is inventoried as unattested but
+is not trusted as the next deployment's rollback target; the fully adopted
+current release becomes that target when the deploy switches.
+
+[`intake-smoke-evidence.py`](intake-smoke-evidence.py) renders only the reviewed
+evidence allowlist from a retained localhost response. It never reproduces the
+fetched text or passes through unknown response fields, and success requires
+both curl transport success and HTTP 200. The complete repinning, attestation,
+and failure boundary is documented in
+[`ISSUE_1831_RUNBOOK.md`](ISSUE_1831_RUNBOOK.md). That template requires a new
+exact merged SHA before host execution and does not itself authorize a deploy.
 
 ## Controlled URL intake network boundary
 
@@ -177,5 +230,10 @@ curl -sS http://127.0.0.1:8080/health
 Repository regression coverage:
 
 ```bash
-python -m pytest -q tests/test_ec2_run_identity_and_provenance.py
+python -m pytest -q \
+  tests/test_ec2_run_identity_and_provenance.py \
+  tests/test_ec2_deploy_hub_api_sync.py \
+  tests/test_ec2_legacy_adoption.py \
+  tests/test_ec2_preflight_and_evidence.py \
+  tests/test_ec2_runbook_attestation.py
 ```

--- a/ops/ec2/adopt-legacy-current.sh
+++ b/ops/ec2/adopt-legacy-current.sh
@@ -1,0 +1,529 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
+REPO_URL="${HUB_OPTIMUS_REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
+EXPECTED_COMMIT="${1:-}"
+
+usage() {
+  cat <<USAGE
+HUB_Optimus explicit legacy-current adoption
+
+Usage:
+  adopt-legacy-current <expected-full-current-commit-sha>
+
+This command adopts only the already configured current release. It does not
+deploy, switch current, restart a service, or infer identity from a short SHA.
+USAGE
+}
+
+fail() {
+  echo "[legacy-adoption:error] $*" >&2
+  exit 1
+}
+
+sha256_file() {
+  local path="$1"
+  local digest
+
+  digest="$(sha256sum -- "$path" | awk '{print $1}')"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Could not calculate SHA-256 for $path"
+  printf '%s\n' "$digest"
+}
+
+state_value() {
+  local state_file="$1"
+  local key="$2"
+  sed -n "s/^${key}=//p" "$state_file" | head -n 1
+}
+
+required_state_value() {
+  local state_file="$1"
+  local key="$2"
+  local count
+
+  count="$(grep -c "^${key}=" "$state_file" 2>/dev/null || true)"
+  [ "$count" -eq 1 ] \
+    || fail "$state_file must contain exactly one $key field."
+  state_value "$state_file" "$key"
+}
+
+validate_exact_state_keys() {
+  local state_file="$1"
+  shift
+  local allowed=" $* "
+  local line
+  local key
+  local expected_count="$#"
+  local actual_count=0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    actual_count=$((actual_count + 1))
+    [[ "$line" == *=* ]] \
+      || fail "$state_file contains a malformed state line."
+    key="${line%%=*}"
+    case "$allowed" in
+      *" $key "*) ;;
+      *) fail "$state_file contains an unsupported field: $key" ;;
+    esac
+  done < "$state_file"
+
+  for key in "$@"; do
+    required_state_value "$state_file" "$key" >/dev/null
+  done
+  [ "$actual_count" -eq "$expected_count" ] \
+    || fail "$state_file does not contain the exact expected field set."
+}
+
+snapshot_item() {
+  local source="$1"
+  local name="$2"
+
+  if [ -e "$source" ] || [ -L "$source" ]; then
+    printf 'present\n' > "$RECOVERY_DIR/$name.presence"
+    cp -a -- "$source" "$RECOVERY_DIR/$name"
+  else
+    printf 'absent\n' > "$RECOVERY_DIR/$name.presence"
+  fi
+}
+
+restore_item() {
+  local target="$1"
+  local name="$2"
+  local presence
+
+  presence="$(cat "$RECOVERY_DIR/$name.presence")"
+  if [ -d "$target" ] && [ ! -L "$target" ]; then
+    echo "[legacy-adoption:recovery:error] Refusing to replace directory: $target" >&2
+    return 1
+  fi
+  rm -f -- "$target"
+
+  case "$presence" in
+    present)
+      cp -a -- "$RECOVERY_DIR/$name" "$target"
+      ;;
+    absent)
+      ;;
+    *)
+      echo "[legacy-adoption:recovery:error] Invalid snapshot marker for $target" >&2
+      return 1
+      ;;
+  esac
+}
+
+recovery_note() {
+  local message="$1"
+  local log_requirement="$2"
+
+  if [ "$RECOVERY_LOG_READY" -eq 1 ]; then
+    if ! printf '%s\n' "$message" >&8; then
+      RECOVERY_LOG_FAILED=1
+      RECOVERY_LOG_READY=0
+      [ "$log_requirement" != "require-log" ] || return 1
+    fi
+  elif [ "$log_requirement" = "require-log" ]; then
+    return 1
+  fi
+  printf '%s\n' "$message" >&2 || true
+}
+
+recover_legacy_adoption() {
+  local state_restore_failed=0
+  local recovery_succeeded=0
+
+  RECOVERY_LOG_READY=0
+  RECOVERY_LOG_FAILED=0
+  set +e
+
+  if [ -n "$RECOVERY_LOG" ] \
+    && { exec 8>> "$RECOVERY_LOG"; } 2>/dev/null; then
+    RECOVERY_LOG_READY=1
+    chmod 0600 "$RECOVERY_LOG" 2>/dev/null || RECOVERY_LOG_FAILED=1
+  else
+    RECOVERY_LOG_FAILED=1
+  fi
+
+  recovery_note \
+    "[legacy-adoption:recovery] Restoring exact pre-adoption state" \
+    allow-missing-log
+  restore_item "$APP_ROOT/shared/RELEASE_STATE" "shared-release-state" \
+    || state_restore_failed=1
+  restore_item "$CURRENT_DEPLOYMENT_STATE" "current-release-state" \
+    || state_restore_failed=1
+  restore_item "$CURRENT_LEGACY_STATE" "legacy-release-state" \
+    || state_restore_failed=1
+  restore_item "$CURRENT_GIT_EXCLUDE" "current-git-exclude" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/current_release" "current-release-marker" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/bin/hub-api" "shared-launcher" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/previous_release" "previous-release-pointer" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/current" "current-symlink" \
+    || state_restore_failed=1
+  rm -f -- "$CURRENT_DEPLOYMENT_STATE_NEW" || state_restore_failed=1
+  rm -f -- "$CURRENT_LEGACY_STATE_NEW" || state_restore_failed=1
+  if [ "$DEPLOYMENT_DIR_EXISTED" -eq 0 ] \
+    && [ -d "$CURRENT_DEPLOYMENT_DIR" ]; then
+    rmdir "$CURRENT_DEPLOYMENT_DIR" 2>/dev/null || state_restore_failed=1
+  fi
+
+  if [ "$state_restore_failed" -eq 0 ] \
+    && [ "$RECOVERY_LOG_FAILED" -eq 0 ] \
+    && recovery_note \
+      "[legacy-adoption:recovery] Pre-adoption state restored" \
+      require-log; then
+    recovery_succeeded=1
+  elif [ "$state_restore_failed" -eq 0 ]; then
+    recovery_note \
+      "[legacy-adoption:recovery:error] State restored, but recovery evidence could not be recorded; treating recovery as failed" \
+      allow-missing-log
+  else
+    recovery_note \
+      "[legacy-adoption:recovery:error] Recovery was incomplete; inspect the retained snapshot" \
+      allow-missing-log
+  fi
+
+  if [ "$RECOVERY_LOG_READY" -eq 1 ]; then
+    exec 8>&-
+  fi
+  set -e
+  [ "$recovery_succeeded" -eq 1 ]
+}
+
+on_exit() {
+  local exit_code="$?"
+
+  trap - EXIT
+  if [ "$exit_code" -ne 0 ] && [ "$MUTATION_STARTED" -eq 1 ]; then
+    recover_legacy_adoption || exit_code=1
+  fi
+  exit "$exit_code"
+}
+
+inject_test_failure() {
+  local stage="$1"
+
+  if [ "${HUB_OPTIMUS_TEST_LEGACY_ADOPTION_FAIL_AFTER_MUTATION:-}" = "$stage" ]; then
+    fail "injected test failure after mutation stage: $stage"
+  fi
+}
+
+validate_legacy_state() {
+  local state_file="$1"
+  local legacy_commit
+  local legacy_path
+  local legacy_release
+  local legacy_status
+
+  [ -f "$state_file" ] && [ ! -L "$state_file" ] \
+    || fail "Legacy release state is not one regular file: $state_file"
+  validate_exact_state_keys \
+    "$state_file" \
+    release commit path validated_at_utc validation status
+  legacy_release="$(required_state_value "$state_file" "release")"
+  legacy_commit="$(required_state_value "$state_file" "commit")"
+  legacy_path="$(required_state_value "$state_file" "path")"
+  legacy_status="$(required_state_value "$state_file" "status")"
+  [ "$legacy_release" = "$CURRENT_RELEASE_ID" ] \
+    || fail "Legacy release field does not match current."
+  [ "$legacy_path" = "$CURRENT_RELEASE" ] \
+    || fail "Legacy path field does not match current."
+  [[ "$legacy_commit" =~ ^[0-9a-f]{7,39}$ ]] \
+    || fail "Legacy commit field is not an explicit short SHA."
+  case "$ACTUAL_COMMIT" in
+    "$legacy_commit"*) ;;
+    *) fail "Legacy short commit does not prefix the real full commit." ;;
+  esac
+  [ "$legacy_status" = "production-candidate-core" ] \
+    || fail "Legacy status is not the expected production-candidate marker."
+}
+
+validate_adopted_state() {
+  local state_file="$1"
+  local adopted_at
+  local legacy_state_sha256
+  local legacy_commit_prefix
+
+  validate_exact_state_keys \
+    "$state_file" \
+    release requested_ref requested_ref_kind commit path adopted_at_utc \
+    validation_command validation_exit_code validation_result validation_log \
+    validation_log_exit_code launcher_sha256 status provenance \
+    legacy_state_sha256 legacy_commit_prefix
+
+  [ "$(required_state_value "$state_file" "release")" = "$CURRENT_RELEASE_ID" ] \
+    || fail "Adopted state release does not match current."
+  [ "$(required_state_value "$state_file" "requested_ref")" = "$EXPECTED_COMMIT" ] \
+    || fail "Adopted state requested ref does not match the expected commit."
+  [ "$(required_state_value "$state_file" "requested_ref_kind")" = "legacy-host-adoption" ] \
+    || fail "Adopted state has an unexpected requested-ref kind."
+  [ "$(required_state_value "$state_file" "commit")" = "$ACTUAL_COMMIT" ] \
+    || fail "Adopted state commit does not match current."
+  [ "$(required_state_value "$state_file" "path")" = "$CURRENT_RELEASE" ] \
+    || fail "Adopted state path does not match current."
+  [ "$(required_state_value "$state_file" "launcher_sha256")" = "$CURRENT_LAUNCHER_SHA256" ] \
+    || fail "Adopted state launcher does not match current."
+  [ "$(required_state_value "$state_file" "status")" = "adopted-legacy-current" ] \
+    || fail "Adopted state status is invalid."
+  [ "$(required_state_value "$state_file" "provenance")" = "adopted-legacy-current-v1" ] \
+    || fail "Adopted state provenance is invalid."
+  adopted_at="$(required_state_value "$state_file" "adopted_at_utc")"
+  legacy_state_sha256="$(required_state_value "$state_file" "legacy_state_sha256")"
+  legacy_commit_prefix="$(required_state_value "$state_file" "legacy_commit_prefix")"
+  [[ "$adopted_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || fail "Adopted state timestamp is invalid."
+  [[ "$legacy_state_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Adopted state legacy-state SHA-256 is invalid."
+  [[ "$legacy_commit_prefix" =~ ^[0-9a-f]{7,39}$ ]] \
+    || fail "Adopted state legacy commit prefix is invalid."
+  case "$ACTUAL_COMMIT" in
+    "$legacy_commit_prefix"*) ;;
+    *) fail "Adopted state legacy commit prefix does not match current." ;;
+  esac
+}
+
+validate_complete_adoption() {
+  local recorded_legacy_sha256
+
+  validate_adopted_state "$CURRENT_DEPLOYMENT_STATE"
+  cmp -s "$CURRENT_DEPLOYMENT_STATE" "$LEGACY_STATE" \
+    || fail "Shared release state differs from the adopted current state."
+  validate_legacy_state "$CURRENT_LEGACY_STATE"
+  [ "$(stat -c '%a' "$CURRENT_LEGACY_STATE")" = "400" ] \
+    || fail "Retained legacy release state is not mode 0400."
+  recorded_legacy_sha256="$(
+    required_state_value "$CURRENT_DEPLOYMENT_STATE" "legacy_state_sha256"
+  )"
+  [ "$(sha256_file "$CURRENT_LEGACY_STATE")" = "$recorded_legacy_sha256" ] \
+    || fail "Retained legacy release state does not match its recorded SHA-256."
+  if [ -n "$RECOVERY_DIR" ]; then
+    cmp -s "$CURRENT_LEGACY_STATE" "$RECOVERY_DIR/shared-release-state" \
+      || fail "Retained legacy release state differs from the pre-adoption snapshot."
+  fi
+  if [ -n "$TRANSACTION_DIR" ] \
+    && [ -f "$TRANSACTION_DIR/RELEASE_STATE.source" ]; then
+    cmp -s \
+      "$CURRENT_DEPLOYMENT_STATE" \
+      "$TRANSACTION_DIR/RELEASE_STATE.source" \
+      || fail "Published adopted state differs from the staged state."
+  fi
+}
+
+MUTATION_STARTED=0
+ADOPTION_WORK_DIR=""
+TRANSACTION_DIR=""
+RECOVERY_DIR=""
+RECOVERY_LOG="/dev/null"
+RECOVERY_LOG_READY=0
+RECOVERY_LOG_FAILED=0
+CURRENT_RELEASE=""
+CURRENT_RELEASE_ID=""
+CURRENT_DEPLOYMENT_DIR=""
+CURRENT_DEPLOYMENT_STATE=""
+CURRENT_DEPLOYMENT_STATE_NEW=""
+CURRENT_LEGACY_STATE=""
+CURRENT_LEGACY_STATE_NEW=""
+CURRENT_GIT_EXCLUDE=""
+DEPLOYMENT_DIR_EXISTED=0
+trap on_exit EXIT
+
+case "$APP_ROOT" in
+  /*) ;;
+  *) fail "HUB_OPTIMUS_APP_ROOT must be an absolute path." ;;
+esac
+case "$EXPECTED_COMMIT" in
+  ""|-h|--help|help)
+    usage
+    if [ -z "$EXPECTED_COMMIT" ]; then
+      exit 2
+    fi
+    exit 0
+    ;;
+esac
+[ "$#" -eq 1 ] || fail "Exactly one expected full commit SHA is required."
+[[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "Expected current commit must be one full lowercase SHA."
+
+exec 9> "$APP_ROOT/shared/deploy.lock"
+flock -n 9 || fail "another deploy, rollback, or adoption is active."
+
+[ -L "$APP_ROOT/current" ] || fail "Current release is not a symlink."
+CURRENT_RELEASE="$(readlink -f "$APP_ROOT/current")"
+case "$CURRENT_RELEASE" in
+  "$APP_ROOT/releases/"*) ;;
+  *) fail "Current release is outside the managed releases directory: $CURRENT_RELEASE" ;;
+esac
+[ -d "$CURRENT_RELEASE" ] \
+  || fail "Current release directory does not exist: $CURRENT_RELEASE"
+CURRENT_RELEASE_ID="$(basename "$CURRENT_RELEASE")"
+
+[ "$(git -C "$CURRENT_RELEASE" rev-parse --is-inside-work-tree)" = "true" ] \
+  || fail "Current release is not a Git worktree."
+[ "$(git -C "$CURRENT_RELEASE" rev-parse --show-toplevel)" = "$CURRENT_RELEASE" ] \
+  || fail "Current release is not the Git worktree root."
+[ "$(git -C "$CURRENT_RELEASE" remote get-url origin)" = "$REPO_URL" ] \
+  || fail "Current release origin does not match the reviewed repository."
+ACTUAL_COMMIT="$(git -C "$CURRENT_RELEASE" rev-parse --verify HEAD)"
+[[ "$ACTUAL_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "Current release does not resolve to one full commit SHA."
+[ "$ACTUAL_COMMIT" = "$EXPECTED_COMMIT" ] \
+  || fail "Current full commit does not match the explicit expected commit."
+[ -z "$(git -C "$CURRENT_RELEASE" status --porcelain --untracked-files=normal)" ] \
+  || fail "Current release worktree is not clean."
+
+CURRENT_LAUNCHER="$CURRENT_RELEASE/ops/ec2/hub-api.sh"
+SHARED_LAUNCHER="$APP_ROOT/shared/bin/hub-api"
+[ -f "$CURRENT_LAUNCHER" ] && [ ! -L "$CURRENT_LAUNCHER" ] \
+  && [ -x "$CURRENT_LAUNCHER" ] \
+  || fail "Current release launcher is not one executable regular file."
+[ -f "$SHARED_LAUNCHER" ] && [ ! -L "$SHARED_LAUNCHER" ] \
+  && [ -x "$SHARED_LAUNCHER" ] \
+  || fail "Shared launcher is not one executable regular file."
+cmp -s "$CURRENT_LAUNCHER" "$SHARED_LAUNCHER" \
+  || fail "Shared launcher does not exactly match the versioned current launcher."
+CURRENT_LAUNCHER_SHA256="$(sha256_file "$CURRENT_LAUNCHER")"
+[ "$(sha256_file "$SHARED_LAUNCHER")" = "$CURRENT_LAUNCHER_SHA256" ] \
+  || fail "Shared launcher SHA-256 does not match current."
+
+CURRENT_MARKER_FILE="$APP_ROOT/shared/current_release"
+[ -f "$CURRENT_MARKER_FILE" ] && [ ! -L "$CURRENT_MARKER_FILE" ] \
+  || fail "Current-release marker is not one regular file."
+[ "$(cat "$CURRENT_MARKER_FILE")" = "$CURRENT_RELEASE_ID" ] \
+  || fail "Current-release marker does not match the current symlink."
+
+LEGACY_STATE="$APP_ROOT/shared/RELEASE_STATE"
+[ -f "$LEGACY_STATE" ] && [ ! -L "$LEGACY_STATE" ] \
+  || fail "Shared release state is not one regular file."
+CURRENT_DEPLOYMENT_DIR="$CURRENT_RELEASE/.hub-deployment"
+CURRENT_DEPLOYMENT_STATE="$CURRENT_DEPLOYMENT_DIR/RELEASE_STATE"
+CURRENT_LEGACY_STATE="$CURRENT_DEPLOYMENT_DIR/LEGACY_RELEASE_STATE"
+CURRENT_GIT_EXCLUDE="$CURRENT_RELEASE/.git/info/exclude"
+[ -f "$CURRENT_GIT_EXCLUDE" ] && [ ! -L "$CURRENT_GIT_EXCLUDE" ] \
+  || fail "Current Git exclude file is not one regular file."
+
+if [ -f "$CURRENT_DEPLOYMENT_STATE" ]; then
+  [ -d "$CURRENT_DEPLOYMENT_DIR" ] && [ ! -L "$CURRENT_DEPLOYMENT_DIR" ] \
+    || fail "Current deployment directory is not one real directory."
+  [ ! -L "$CURRENT_DEPLOYMENT_STATE" ] \
+    || fail "Current deployment state must not be a symlink."
+  validate_complete_adoption
+  echo "[legacy-adoption] Current release is already adopted and exact."
+  echo "[legacy-adoption] Commit: $ACTUAL_COMMIT"
+  echo "[legacy-adoption] Launcher SHA-256: $CURRENT_LAUNCHER_SHA256"
+  exit 0
+fi
+[ ! -e "$CURRENT_DEPLOYMENT_DIR" ] \
+  || fail "Current deployment directory exists without an adopted release state."
+
+validate_legacy_state "$LEGACY_STATE"
+LEGACY_COMMIT="$(required_state_value "$LEGACY_STATE" "commit")"
+LEGACY_STATE_SHA256="$(sha256_file "$LEGACY_STATE")"
+
+ADOPTION_WORK_DIR="$(
+  mktemp -d "$APP_ROOT/shared/legacy-adoption.$(date -u +%Y%m%dT%H%M%SZ).XXXXXX"
+)"
+TRANSACTION_DIR="$ADOPTION_WORK_DIR/transaction"
+RECOVERY_DIR="$ADOPTION_WORK_DIR/pre-adoption-state"
+RECOVERY_LOG="${HUB_OPTIMUS_TEST_LEGACY_ADOPTION_RECOVERY_LOG_PATH:-$ADOPTION_WORK_DIR/recovery.log}"
+CURRENT_DEPLOYMENT_STATE_NEW="$CURRENT_DEPLOYMENT_DIR/RELEASE_STATE.new.$(basename "$ADOPTION_WORK_DIR")"
+CURRENT_LEGACY_STATE_NEW="$CURRENT_DEPLOYMENT_DIR/LEGACY_RELEASE_STATE.new.$(basename "$ADOPTION_WORK_DIR")"
+mkdir -p "$TRANSACTION_DIR" "$RECOVERY_DIR"
+chmod 0700 "$ADOPTION_WORK_DIR" "$TRANSACTION_DIR" "$RECOVERY_DIR"
+
+cat > "$TRANSACTION_DIR/RELEASE_STATE.source" <<STATE
+release=$CURRENT_RELEASE_ID
+requested_ref=$EXPECTED_COMMIT
+requested_ref_kind=legacy-host-adoption
+commit=$ACTUAL_COMMIT
+path=$CURRENT_RELEASE
+adopted_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+validation_command=not-run-during-legacy-adoption
+validation_exit_code=not-run
+validation_result=legacy validation claim not re-attested; original state retained by SHA-256
+validation_log=not-applicable
+validation_log_exit_code=not-run
+launcher_sha256=$CURRENT_LAUNCHER_SHA256
+status=adopted-legacy-current
+provenance=adopted-legacy-current-v1
+legacy_state_sha256=$LEGACY_STATE_SHA256
+legacy_commit_prefix=$LEGACY_COMMIT
+STATE
+install -m 0600 \
+  "$TRANSACTION_DIR/RELEASE_STATE.source" \
+  "$TRANSACTION_DIR/current-RELEASE_STATE"
+install -m 0644 \
+  "$TRANSACTION_DIR/RELEASE_STATE.source" \
+  "$TRANSACTION_DIR/shared-RELEASE_STATE"
+install -m 0400 \
+  "$LEGACY_STATE" \
+  "$TRANSACTION_DIR/LEGACY_RELEASE_STATE"
+
+cp -a -- "$CURRENT_GIT_EXCLUDE" "$TRANSACTION_DIR/git-exclude"
+EXCLUDE_COUNT="$(
+  grep -c '^\.hub-deployment/$' "$TRANSACTION_DIR/git-exclude" 2>/dev/null \
+    || true
+)"
+[ "$EXCLUDE_COUNT" -le 1 ] \
+  || fail "Current Git exclude has duplicate .hub-deployment entries."
+if [ "$EXCLUDE_COUNT" -eq 0 ]; then
+  printf '.hub-deployment/\n' >> "$TRANSACTION_DIR/git-exclude"
+fi
+
+snapshot_item "$APP_ROOT/current" "current-symlink"
+snapshot_item "$SHARED_LAUNCHER" "shared-launcher"
+snapshot_item "$APP_ROOT/shared/previous_release" "previous-release-pointer"
+snapshot_item "$CURRENT_MARKER_FILE" "current-release-marker"
+snapshot_item "$LEGACY_STATE" "shared-release-state"
+snapshot_item "$CURRENT_DEPLOYMENT_STATE" "current-release-state"
+snapshot_item "$CURRENT_LEGACY_STATE" "legacy-release-state"
+snapshot_item "$CURRENT_GIT_EXCLUDE" "current-git-exclude"
+
+MUTATION_STARTED=1
+
+echo "[legacy-adoption] Publishing Git exclude boundary"
+mv -Tf "$TRANSACTION_DIR/git-exclude" "$CURRENT_GIT_EXCLUDE"
+inject_test_failure "git-exclude"
+
+echo "[legacy-adoption] Creating per-release deployment state"
+mkdir -p "$CURRENT_DEPLOYMENT_DIR"
+chmod 0700 "$CURRENT_DEPLOYMENT_DIR"
+inject_test_failure "deployment-dir"
+mv -Tf \
+  "$TRANSACTION_DIR/LEGACY_RELEASE_STATE" \
+  "$CURRENT_LEGACY_STATE_NEW"
+mv -Tf "$CURRENT_LEGACY_STATE_NEW" "$CURRENT_LEGACY_STATE"
+inject_test_failure "legacy-state-evidence"
+install -m 0600 \
+  "$TRANSACTION_DIR/current-RELEASE_STATE" \
+  "$CURRENT_DEPLOYMENT_STATE_NEW"
+mv -Tf "$CURRENT_DEPLOYMENT_STATE_NEW" "$CURRENT_DEPLOYMENT_STATE"
+inject_test_failure "release-state"
+
+echo "[legacy-adoption] Publishing exact shared release state"
+mv -Tf \
+  "$TRANSACTION_DIR/shared-RELEASE_STATE" \
+  "$APP_ROOT/shared/RELEASE_STATE"
+inject_test_failure "shared-release-state"
+
+if [ \
+  "${HUB_OPTIMUS_TEST_LEGACY_ADOPTION_CORRUPT_BEFORE_POSTVALIDATE:-}" \
+  = "shared-release-state" \
+]; then
+  printf 'test_corruption=1\n' >> "$APP_ROOT/shared/RELEASE_STATE"
+fi
+validate_complete_adoption
+
+echo "[legacy-adoption] Adopted current legacy release."
+echo "[legacy-adoption] Release: $CURRENT_RELEASE"
+echo "[legacy-adoption] Commit: $ACTUAL_COMMIT"
+echo "[legacy-adoption] Launcher SHA-256: $CURRENT_LAUNCHER_SHA256"
+echo "[legacy-adoption] Done"
+
+MUTATION_STARTED=0
+if ! rm -rf -- "$ADOPTION_WORK_DIR"; then
+  echo "[legacy-adoption:warning] Could not remove completed adoption snapshot." >&2
+fi

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -23,6 +23,17 @@ fail() {
   exit 1
 }
 
+sha256_file() {
+  local path="$1"
+  local digest
+
+  digest="$(sha256sum -- "$path" | awk '{print $1}')"
+  if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+    fail "could not calculate SHA-256 for $path"
+  fi
+  printf '%s\n' "$digest"
+}
+
 state_value() {
   local state_file="$1"
   local key="$2"
@@ -32,54 +43,249 @@ state_value() {
   sed -n "s/^${key}=//p" "$state_file" 2>/dev/null | head -n 1
 }
 
-write_previous_release_state() {
+required_state_value() {
+  local state_file="$1"
+  local key="$2"
+  local count
+
+  count="$(grep -c "^${key}=" "$state_file" 2>/dev/null || true)"
+  [ "$count" -eq 1 ] \
+    || fail "$state_file must contain exactly one $key field."
+  state_value "$state_file" "$key"
+}
+
+validate_release_state() {
+  local previous="$1"
+  local state_file="$2"
+  local actual_commit="$3"
+  local actual_launcher_sha256="$4"
+  local recorded_release
+  local recorded_commit
+  local recorded_path
+  local recorded_launcher_sha256
+
+  [ -f "$state_file" ] \
+    || fail "Rollback target has no deployment state: $state_file"
+
+  recorded_release="$(required_state_value "$state_file" "release")"
+  recorded_commit="$(required_state_value "$state_file" "commit")"
+  recorded_path="$(required_state_value "$state_file" "path")"
+  recorded_launcher_sha256="$(
+    state_value "$state_file" "launcher_sha256"
+  )"
+  if [ "$(grep -c '^launcher_sha256=' "$state_file" 2>/dev/null || true)" -gt 1 ]; then
+    fail "$state_file contains duplicate launcher_sha256 fields."
+  fi
+
+  [ "$recorded_release" = "$(basename "$previous")" ] \
+    || fail "Rollback target release does not match its deployment state."
+  [ "$recorded_commit" = "$actual_commit" ] \
+    || fail "Rollback target commit does not match its deployment state."
+  [ "$recorded_path" = "$previous" ] \
+    || fail "Rollback target path does not match its deployment state."
+
+  if [ -n "$recorded_launcher_sha256" ] \
+    && [ "$recorded_launcher_sha256" != "$actual_launcher_sha256" ]; then
+    fail "Rollback target launcher does not match its deployment state."
+  fi
+}
+
+prepare_previous_release_state() {
   local previous="$1"
   local previous_state="$previous/.hub-deployment/RELEASE_STATE"
+  local shared_state="$APP_ROOT/shared/RELEASE_STATE"
+  local previous_release
+  local previous_commit
+  local previous_launcher_sha256
+  local source_state
+  local recorded_launcher_sha256
+
+  previous_release="$(basename "$previous")"
+  previous_commit="$(git -C "$previous" rev-parse --verify HEAD)"
+  [[ "$previous_commit" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "Rollback target does not resolve to one full commit SHA."
+
+  [ -f "$previous/ops/ec2/hub-api.sh" ] \
+    || fail "Rollback target has no hub-api launcher: $previous/ops/ec2/hub-api.sh"
+  previous_launcher_sha256="$(sha256_file "$previous/ops/ec2/hub-api.sh")"
 
   if [ -f "$previous_state" ]; then
+    source_state="$previous_state"
+  else
+    source_state="$shared_state"
+  fi
+
+  validate_release_state \
+    "$previous" \
+    "$source_state" \
+    "$previous_commit" \
+    "$previous_launcher_sha256"
+
+  PREVIOUS_STATE_PATH="$previous_state"
+  recorded_launcher_sha256="$(
+    state_value "$source_state" "launcher_sha256"
+  )"
+  if [ "$source_state" = "$previous_state" ] \
+    && [ -n "$recorded_launcher_sha256" ]; then
+    PREVIOUS_STATE_INSTALL_SOURCE=""
     return
   fi
 
-  local previous_release
-  local previous_commit
-  local previous_validated_at
-  local previous_validation
-  local previous_status
+  PREVIOUS_STATE_INSTALL_SOURCE="$DEPLOYMENT_DIR/PREVIOUS_RELEASE_STATE"
+  sed '/^launcher_sha256=/d' \
+    "$source_state" \
+    > "$PREVIOUS_STATE_INSTALL_SOURCE"
+  printf 'launcher_sha256=%s\n' "$previous_launcher_sha256" \
+    >> "$PREVIOUS_STATE_INSTALL_SOURCE"
+  if [ "$source_state" = "$shared_state" ]; then
+    printf 'provenance=adopted-pre-1832\n' \
+      >> "$PREVIOUS_STATE_INSTALL_SOURCE"
+  fi
+  chmod 0600 "$PREVIOUS_STATE_INSTALL_SOURCE"
+}
 
-  previous_release="$(basename "$previous")"
-  previous_commit="$(git -C "$previous" rev-parse HEAD)"
-  previous_validated_at="$(
-    state_value "$APP_ROOT/shared/RELEASE_STATE" "validated_at_utc"
-  )"
-  previous_validation="$(
-    state_value "$APP_ROOT/shared/RELEASE_STATE" "validation"
-  )"
-  previous_status="$(
-    state_value "$APP_ROOT/shared/RELEASE_STATE" "status"
-  )"
+snapshot_item() {
+  local source="$1"
+  local name="$2"
 
-  mkdir -p "$previous/.hub-deployment"
-  chmod 0700 "$previous/.hub-deployment"
-  if [ -d "$previous/.git/info" ]; then
-    grep -qxF ".hub-deployment/" "$previous/.git/info/exclude" \
-      || echo ".hub-deployment/" >> "$previous/.git/info/exclude"
+  if [ -e "$source" ] || [ -L "$source" ]; then
+    printf 'present\n' > "$RECOVERY_DIR/$name.presence"
+    cp -a -- "$source" "$RECOVERY_DIR/$name"
+  else
+    printf 'absent\n' > "$RECOVERY_DIR/$name.presence"
+  fi
+}
+
+restore_item() {
+  local target="$1"
+  local name="$2"
+  local presence
+
+  presence="$(cat "$RECOVERY_DIR/$name.presence")"
+  if [ -d "$target" ] && [ ! -L "$target" ]; then
+    echo "[deploy:recovery:error] Refusing to replace directory: $target" >&2
+    return 1
+  fi
+  rm -f -- "$target"
+
+  case "$presence" in
+    present)
+      cp -a -- "$RECOVERY_DIR/$name" "$target"
+      ;;
+    absent)
+      ;;
+    *)
+      echo "[deploy:recovery:error] Invalid snapshot marker for $target" >&2
+      return 1
+      ;;
+  esac
+}
+
+recover_predeploy_state() {
+  local state_restore_failed=0
+  local recovery_succeeded=0
+
+  RECOVERY_LOG_READY=0
+  RECOVERY_LOG_FAILED=0
+
+  set +e
+  if [ -n "$RECOVERY_LOG" ] \
+    && { exec 8>> "$RECOVERY_LOG"; } 2>/dev/null; then
+    RECOVERY_LOG_READY=1
+    chmod 0600 "$RECOVERY_LOG" 2>/dev/null || RECOVERY_LOG_FAILED=1
+  else
+    RECOVERY_LOG_FAILED=1
   fi
 
-  cat > "$previous_state" <<STATE
-release=$previous_release
-requested_ref=unrecorded-pre-1764
-requested_ref_kind=legacy
-commit=$previous_commit
-path=$previous
-validated_at_utc=${previous_validated_at:-unknown}
-validation_command=unrecorded-pre-1764
-validation_exit_code=unknown
-validation_result=unverified legacy metadata: ${previous_validation:-not recorded}
-status=${previous_status:-legacy-release}
-provenance=adopted-pre-1764
-STATE
-  chmod 0600 "$previous_state"
+  recovery_note \
+    "[deploy:recovery] Restoring exact pre-deploy operational state" \
+    allow-missing-log
+  if [ -n "$PREVIOUS_STATE_PATH" ]; then
+    restore_item "$PREVIOUS_STATE_PATH" "previous-release-state" \
+      || state_restore_failed=1
+  fi
+  restore_item "$APP_ROOT/shared/bin/hub-api" "shared-launcher" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/RELEASE_STATE" "shared-release-state" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/current_release" "current-release-marker" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/previous_release" "previous-release-pointer" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/current" "current-symlink" \
+    || state_restore_failed=1
+  rm -f -- "$CURRENT_NEW" || state_restore_failed=1
+  if [ -n "$PREVIOUS_STATE_NEW" ]; then
+    rm -f -- "$PREVIOUS_STATE_NEW" || state_restore_failed=1
+  fi
+
+  if [ "$state_restore_failed" -eq 0 ] \
+    && [ "$RECOVERY_LOG_FAILED" -eq 0 ] \
+    && recovery_note \
+      "[deploy:recovery] Pre-deploy operational state restored" \
+      require-log; then
+    recovery_succeeded=1
+  elif [ "$state_restore_failed" -eq 0 ]; then
+    recovery_note \
+      "[deploy:recovery:error] Operational state restored, but recovery evidence could not be recorded; treating recovery as failed" \
+      allow-missing-log
+  else
+    recovery_note \
+      "[deploy:recovery:error] Recovery was incomplete; inspect the retained snapshot" \
+      allow-missing-log
+  fi
+
+  if [ "$RECOVERY_LOG_READY" -eq 1 ]; then
+    exec 8>&-
+  fi
+  set -e
+  [ "$recovery_succeeded" -eq 1 ]
 }
+
+recovery_note() {
+  local message="$1"
+  local log_requirement="$2"
+
+  if [ "$RECOVERY_LOG_READY" -eq 1 ]; then
+    if ! printf '%s\n' "$message" >&8; then
+      RECOVERY_LOG_FAILED=1
+      RECOVERY_LOG_READY=0
+      [ "$log_requirement" != "require-log" ] || return 1
+    fi
+  elif [ "$log_requirement" = "require-log" ]; then
+    return 1
+  fi
+  printf '%s\n' "$message" >&2 || true
+}
+
+on_exit() {
+  local exit_code="$?"
+
+  trap - EXIT
+  if [ "$exit_code" -ne 0 ] && [ "$MUTATION_STARTED" -eq 1 ]; then
+    recover_predeploy_state || exit_code=1
+  fi
+  exit "$exit_code"
+}
+
+inject_test_failure() {
+  local stage="$1"
+
+  if [ "${HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION:-}" = "$stage" ]; then
+    fail "injected test failure after mutation stage: $stage"
+  fi
+}
+
+MUTATION_STARTED=0
+PREVIOUS_STATE_PATH=""
+PREVIOUS_STATE_INSTALL_SOURCE=""
+RECOVERY_DIR=""
+RECOVERY_LOG="/dev/null"
+RECOVERY_LOG_READY=0
+RECOVERY_LOG_FAILED=0
+CURRENT_NEW=""
+PREVIOUS_STATE_NEW=""
+trap on_exit EXIT
 
 case "$APP_ROOT" in
   /*) ;;
@@ -143,6 +349,15 @@ fi
 git -C "$RELEASE_DIR" checkout --quiet --detach "$RESOLVED_COMMIT"
 
 echo "[deploy] Resolved commit: $RESOLVED_COMMIT"
+echo "[deploy] Verifying hub-api launcher source"
+if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then
+  fail "Missing hub-api launcher source: $RELEASE_DIR/ops/ec2/hub-api.sh"
+fi
+CANDIDATE_LAUNCHER_SHA256="$(
+  sha256_file "$RELEASE_DIR/ops/ec2/hub-api.sh"
+)"
+echo "[deploy] Candidate launcher SHA-256: $CANDIDATE_LAUNCHER_SHA256"
+
 echo "[deploy] Creating venv"
 cd "$RELEASE_DIR"
 python3 -m venv .venv
@@ -189,6 +404,7 @@ validation_exit_code=$VALIDATION_EXIT_CODE
 validation_result=$VALIDATION_RESULT
 validation_log=$VALIDATION_LOG
 validation_log_exit_code=$VALIDATION_LOG_EXIT_CODE
+launcher_sha256=$CANDIDATE_LAUNCHER_SHA256
 status=$RELEASE_STATUS
 STATE
 chmod 0600 "$DEPLOYMENT_STATE" "$VALIDATION_LOG"
@@ -207,31 +423,92 @@ if [ "$VALIDATION_EXIT_CODE" -ne 0 ]; then
   fail "validation failed (exit $VALIDATION_EXIT_CODE): $VALIDATION_RESULT"
 fi
 
-echo "[deploy] Verifying hub-api launcher source"
-if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then
-  echo "[deploy:error] Missing hub-api launcher source: $RELEASE_DIR/ops/ec2/hub-api.sh" >&2
-  exit 1
-fi
-
+PREVIOUS=""
 if [ -L "$APP_ROOT/current" ]; then
   PREVIOUS="$(readlink -f "$APP_ROOT/current")"
-  write_previous_release_state "$PREVIOUS"
-  echo "$PREVIOUS" > "$APP_ROOT/shared/previous_release"
+  case "$PREVIOUS" in
+    "$APP_ROOT/releases/"*) ;;
+    *) fail "Rollback target is outside the managed releases directory: $PREVIOUS" ;;
+  esac
+  [ -d "$PREVIOUS" ] \
+    || fail "Rollback target directory does not exist: $PREVIOUS"
+  prepare_previous_release_state "$PREVIOUS"
   echo "[deploy] Previous release: $PREVIOUS"
+elif [ -e "$APP_ROOT/current" ]; then
+  fail "Current exists but is not a symlink: $APP_ROOT/current"
 else
   echo "[deploy] No previous release detected"
 fi
 
+TRANSACTION_DIR="$DEPLOYMENT_DIR/transaction"
+RECOVERY_DIR="$DEPLOYMENT_DIR/pre-deploy-state"
+RECOVERY_LOG="${HUB_OPTIMUS_TEST_RECOVERY_LOG_PATH:-$DEPLOYMENT_DIR/recovery.log}"
+CURRENT_NEW="$APP_ROOT/current.new.$RELEASE_ID"
+mkdir -p "$TRANSACTION_DIR" "$RECOVERY_DIR"
+chmod 0700 "$TRANSACTION_DIR" "$RECOVERY_DIR"
+
+install -m 0755 \
+  "$RELEASE_DIR/ops/ec2/hub-api.sh" \
+  "$TRANSACTION_DIR/hub-api"
+install -m 0644 "$DEPLOYMENT_STATE" "$TRANSACTION_DIR/RELEASE_STATE"
+printf '%s\n' "$RELEASE_ID" > "$TRANSACTION_DIR/current_release"
+if [ -n "$PREVIOUS" ]; then
+  printf '%s\n' "$PREVIOUS" > "$TRANSACTION_DIR/previous_release"
+fi
+
+snapshot_item "$APP_ROOT/current" "current-symlink"
+snapshot_item "$APP_ROOT/shared/bin/hub-api" "shared-launcher"
+snapshot_item "$APP_ROOT/shared/RELEASE_STATE" "shared-release-state"
+snapshot_item "$APP_ROOT/shared/current_release" "current-release-marker"
+snapshot_item "$APP_ROOT/shared/previous_release" "previous-release-pointer"
+if [ -n "$PREVIOUS_STATE_PATH" ]; then
+  snapshot_item "$PREVIOUS_STATE_PATH" "previous-release-state"
+fi
+
+MUTATION_STARTED=1
+
+if [ -n "$PREVIOUS_STATE_INSTALL_SOURCE" ]; then
+  echo "[deploy] Completing rollback-target deployment state"
+  mkdir -p "$(dirname "$PREVIOUS_STATE_PATH")"
+  chmod 0700 "$(dirname "$PREVIOUS_STATE_PATH")"
+  PREVIOUS_STATE_NEW="$PREVIOUS_STATE_PATH.new.$RELEASE_ID"
+  install -m 0600 \
+    "$PREVIOUS_STATE_INSTALL_SOURCE" \
+    "$PREVIOUS_STATE_NEW"
+  mv -Tf \
+    "$PREVIOUS_STATE_NEW" \
+    "$PREVIOUS_STATE_PATH"
+  inject_test_failure "previous-release-state"
+fi
+
+if [ -n "$PREVIOUS" ]; then
+  echo "[deploy] Recording rollback target"
+  mv -Tf \
+    "$TRANSACTION_DIR/previous_release" \
+    "$APP_ROOT/shared/previous_release"
+  inject_test_failure "previous-release"
+fi
+
 echo "[deploy] Switching current symlink"
-ln -sfn "$RELEASE_DIR" "$APP_ROOT/current.new"
-mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
+ln -s "$RELEASE_DIR" "$CURRENT_NEW"
+mv -Tf "$CURRENT_NEW" "$APP_ROOT/current"
+inject_test_failure "current"
 
 echo "[deploy] Syncing hub-api launcher"
-install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"
+mv -Tf "$TRANSACTION_DIR/hub-api" "$APP_ROOT/shared/bin/hub-api"
+inject_test_failure "launcher"
 
-install -m 0644 "$DEPLOYMENT_STATE" "$APP_ROOT/shared/RELEASE_STATE.new"
-mv -Tf "$APP_ROOT/shared/RELEASE_STATE.new" "$APP_ROOT/shared/RELEASE_STATE"
-echo "$RELEASE_ID" > "$APP_ROOT/shared/current_release"
+echo "[deploy] Publishing release state"
+mv -Tf \
+  "$TRANSACTION_DIR/RELEASE_STATE" \
+  "$APP_ROOT/shared/RELEASE_STATE"
+inject_test_failure "release-state"
+
+echo "[deploy] Publishing current-release marker"
+mv -Tf \
+  "$TRANSACTION_DIR/current_release" \
+  "$APP_ROOT/shared/current_release"
+inject_test_failure "current-release"
 
 cd "$APP_ROOT/current"
 
@@ -248,3 +525,7 @@ echo "[deploy] Release state:"
 cat "$APP_ROOT/shared/RELEASE_STATE"
 
 echo "[deploy] Done"
+MUTATION_STARTED=0
+if ! rm -rf -- "$RECOVERY_DIR" "$TRANSACTION_DIR"; then
+  echo "[deploy:warning] Could not remove completed transaction snapshot." >&2
+fi

--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -1,9 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_ROOT="/opt/hub-optimus"
+APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 API_DIR="$APP_ROOT/shared/api"
 API_FILE="$API_DIR/hub_api.py"
+
+case "$APP_ROOT" in
+  /*) ;;
+  *)
+    echo "[hub-api:error] HUB_OPTIMUS_APP_ROOT must be an absolute path." >&2
+    exit 1
+    ;;
+esac
+
+RUNNING_RELEASE="$(readlink -f "$APP_ROOT/current")"
+case "$RUNNING_RELEASE" in
+  "$APP_ROOT/releases/"*) ;;
+  *)
+    echo "[hub-api:error] current is outside the managed releases directory." >&2
+    exit 1
+    ;;
+esac
+[ -d "$RUNNING_RELEASE" ] || {
+  echo "[hub-api:error] running release directory does not exist." >&2
+  exit 1
+}
+
+RUNNING_COMMIT="$(git -C "$RUNNING_RELEASE" rev-parse --verify HEAD)"
+[[ "$RUNNING_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "[hub-api:error] running release has no full commit identity." >&2
+  exit 1
+}
+
+RUNNING_LAUNCHER_SHA256="$(sha256sum -- "$0" | awk '{print $1}')"
+[[ "$RUNNING_LAUNCHER_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+  echo "[hub-api:error] launcher SHA-256 could not be captured." >&2
+  exit 1
+}
+
+export HUB_OPTIMUS_API_APP_ROOT="$APP_ROOT"
+export HUB_OPTIMUS_API_RUNNING_RELEASE="$RUNNING_RELEASE"
+export HUB_OPTIMUS_API_RUNNING_COMMIT="$RUNNING_COMMIT"
+export HUB_OPTIMUS_API_RUNNING_LAUNCHER_SHA256="$RUNNING_LAUNCHER_SHA256"
 
 mkdir -p "$API_DIR"
 
@@ -46,9 +84,15 @@ from urllib.request import (
     build_opener,
 )
 
-APP_ROOT = Path("/opt/hub-optimus")
+APP_ROOT = Path(os.environ.get("HUB_OPTIMUS_API_APP_ROOT", "/opt/hub-optimus"))
 CURRENT = APP_ROOT / "current"
 SHARED = APP_ROOT / "shared"
+RUNNING_RELEASE = os.environ.get("HUB_OPTIMUS_API_RUNNING_RELEASE", "")
+RUNNING_COMMIT = os.environ.get("HUB_OPTIMUS_API_RUNNING_COMMIT", "")
+RUNNING_LAUNCHER_SHA256 = os.environ.get(
+    "HUB_OPTIMUS_API_RUNNING_LAUNCHER_SHA256",
+    "",
+)
 
 MAX_URL_LENGTH = 2048
 MAX_URL_BODY_LENGTH = 4096
@@ -647,20 +691,36 @@ def run_command(args: list[str], input_text: str | None = None) -> tuple[int, st
 
 
 def product_status() -> dict:
-    current_path = ""
-    commit = ""
+    configured_current_release = ""
+    configured_current_commit = ""
     if CURRENT.is_symlink():
-        current_path = str(CURRENT.resolve())
-        code, stdout, _ = run_command(["git", "-C", current_path, "rev-parse", "--short", "HEAD"])
+        configured_current_release = str(CURRENT.resolve())
+        code, stdout, _ = run_command(
+            [
+                "git",
+                "-C",
+                configured_current_release,
+                "rev-parse",
+                "--verify",
+                "HEAD",
+            ]
+        )
         if code == 0:
-            commit = stdout.strip()
+            candidate = stdout.strip()
+            if re.fullmatch(r"[0-9a-f]{40}", candidate):
+                configured_current_commit = candidate
 
     release_state = read_text(SHARED / "RELEASE_STATE")
 
     return {
         "product": "HUB_Optimus backend v0.1",
-        "current": current_path,
-        "commit": commit,
+        "current": RUNNING_RELEASE,
+        "commit": RUNNING_COMMIT,
+        "running_release": RUNNING_RELEASE,
+        "running_commit": RUNNING_COMMIT,
+        "running_launcher_sha256": RUNNING_LAUNCHER_SHA256,
+        "configured_current_release": configured_current_release,
+        "configured_current_commit": configured_current_commit,
         "release_state": release_state,
         "capabilities": {
             "semantic_analyze": True,

--- a/ops/ec2/intake-smoke-evidence.py
+++ b/ops/ec2/intake-smoke-evidence.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Render only the reviewed allowlist from one localhost intake response."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+FULL_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("response", type=Path)
+    parser.add_argument("http_status")
+    parser.add_argument("curl_exit_code", type=int)
+    parser.add_argument("target_commit")
+    return parser.parse_args()
+
+
+def controlled_string(payload: dict, key: str) -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) else None
+
+
+def reject_non_standard_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
+def main() -> int:
+    args = parse_args()
+    if not FULL_COMMIT_RE.fullmatch(args.target_commit):
+        raise SystemExit("target_commit must be one full lowercase commit SHA")
+    if not re.fullmatch(r"[0-9]{3}", args.http_status):
+        raise SystemExit("http_status must be a three-digit value")
+
+    try:
+        raw = args.response.read_text(encoding="utf-8")
+        payload = json.loads(raw, parse_constant=reject_non_standard_constant)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise SystemExit("controlled intake returned unreadable JSON") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit("controlled intake response must be a JSON object")
+
+    text = payload.get("text", "")
+    if not isinstance(text, str):
+        raise SystemExit("controlled intake text field must be a string")
+
+    final_url = controlled_string(payload, "final_url")
+    final_domain = urlparse(final_url).hostname if final_url else None
+    source_domain = controlled_string(payload, "source_domain")
+    if final_domain is not None:
+        final_domain = final_domain.lower()
+
+    evidence = {
+        "target_commit": args.target_commit,
+        "curl_exit_code": args.curl_exit_code,
+        "http_status": int(args.http_status),
+        "response_status": controlled_string(payload, "status"),
+        "error_code": controlled_string(payload, "error"),
+        "source_domain": source_domain,
+        "final_domain": final_domain,
+        "final_url": final_url,
+        "content_type": controlled_string(payload, "content_type"),
+        "retrieved_at_utc": controlled_string(payload, "retrieved_at_utc"),
+        "bytes_read": (
+            payload.get("bytes_read")
+            if isinstance(payload.get("bytes_read"), int)
+            and not isinstance(payload.get("bytes_read"), bool)
+            else None
+        ),
+        "truncated": (
+            payload.get("truncated")
+            if isinstance(payload.get("truncated"), bool)
+            else None
+        ),
+        "verification_status": controlled_string(
+            payload,
+            "verification_status",
+        ),
+        "text_present": bool(text.strip()),
+        "text_characters": len(text),
+        "text_sha256": (
+            hashlib.sha256(text.encode("utf-8")).hexdigest() if text else None
+        ),
+    }
+    print(json.dumps(evidence, indent=2, sort_keys=True, ensure_ascii=False))
+
+    if args.http_status != "200":
+        raise SystemExit("controlled intake did not return required HTTP 200")
+    if args.curl_exit_code != 0:
+        raise SystemExit("controlled intake transport failed")
+    if evidence["response_status"] != "ok":
+        raise SystemExit("controlled intake returned an application failure")
+    if evidence["verification_status"] != "unreviewed":
+        raise SystemExit("verification boundary changed unexpectedly")
+    if not evidence["text_present"]:
+        raise SystemExit("controlled intake returned empty extracted text")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/ec2/preflight-deploy.sh
+++ b/ops/ec2/preflight-deploy.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
+REPO_URL="${HUB_OPTIMUS_REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
+TARGET_SHA="${1:-}"
+REFERENCE_URL="${2:-}"
+
+# Fail-closed floor for the reviewed t3.small deployment operation.
+MIN_DISK_KIB=3145728
+MIN_FREE_INODES=50000
+MIN_AVAILABLE_MEMORY_KIB=524288
+MAX_LOAD_1M=2.00
+
+fail() {
+  echo "[preflight:error] $*" >&2
+  exit 1
+}
+
+required_state_value() {
+  local state_file="$1"
+  local key="$2"
+  local count
+
+  count="$(grep -c "^${key}=" "$state_file" 2>/dev/null || true)"
+  [ "$count" -eq 1 ] \
+    || fail "$state_file must contain exactly one $key field."
+  sed -n "s/^${key}=//p" "$state_file"
+}
+
+sha256_file() {
+  local path="$1"
+  local digest
+
+  digest="$(sha256sum -- "$path" | awk '{print $1}')"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Could not calculate SHA-256 for $path"
+  printf '%s\n' "$digest"
+}
+
+inspect_release_directory() {
+  local release_path="$1"
+  local actual_commit
+  local actual_launcher_sha256
+
+  case "$release_path" in
+    "$APP_ROOT/releases/"*) ;;
+    *) fail "Release is outside the managed releases directory: $release_path" ;;
+  esac
+  [ -d "$release_path" ] \
+    || fail "Release directory does not exist: $release_path"
+  [ "$(git -C "$release_path" rev-parse --is-inside-work-tree)" = "true" ] \
+    || fail "Release is not a Git worktree: $release_path"
+  [ "$(git -C "$release_path" rev-parse --show-toplevel)" = "$release_path" ] \
+    || fail "Release is not the Git worktree root: $release_path"
+  [ "$(git -C "$release_path" remote get-url origin)" = "$REPO_URL" ] \
+    || fail "Release origin is not the reviewed repository: $release_path"
+  [ -z "$(git -C "$release_path" status --porcelain --untracked-files=normal)" ] \
+    || fail "Release worktree is not clean: $release_path"
+  [ -f "$release_path/ops/ec2/hub-api.sh" ] \
+    && [ ! -L "$release_path/ops/ec2/hub-api.sh" ] \
+    && [ -x "$release_path/ops/ec2/hub-api.sh" ] \
+    || fail "Release launcher is not one executable regular file: $release_path"
+
+  actual_commit="$(git -C "$release_path" rev-parse --verify HEAD)"
+  [[ "$actual_commit" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "Release does not resolve to one full commit SHA: $release_path"
+  actual_launcher_sha256="$(sha256_file "$release_path/ops/ec2/hub-api.sh")"
+
+  printf '%s\t%s\n' "$actual_commit" "$actual_launcher_sha256"
+}
+
+validate_release() {
+  local release_path="$1"
+  local state_file="$2"
+  local require_recorded_launcher="$3"
+  local actual_commit
+  local actual_launcher_sha256
+  local recorded_commit
+  local recorded_path
+  local recorded_release
+  local recorded_launcher_sha256
+
+  [ -f "$state_file" ] && [ ! -L "$state_file" ] \
+    || fail "Release state is not one regular file: $state_file"
+
+  IFS=$'\t' read -r actual_commit actual_launcher_sha256 < <(
+    inspect_release_directory "$release_path"
+  )
+  recorded_commit="$(required_state_value "$state_file" "commit")"
+  recorded_path="$(required_state_value "$state_file" "path")"
+  recorded_release="$(required_state_value "$state_file" "release")"
+
+  [ "$recorded_commit" = "$actual_commit" ] \
+    || fail "Release commit does not match $state_file"
+  [ "$recorded_path" = "$release_path" ] \
+    || fail "Release path does not match $state_file"
+  [ "$recorded_release" = "$(basename "$release_path")" ] \
+    || fail "Release name does not match $state_file"
+
+  recorded_launcher_sha256="$(
+    sed -n 's/^launcher_sha256=//p' "$state_file"
+  )"
+  if [ "$require_recorded_launcher" = "yes" ]; then
+    [[ "$recorded_launcher_sha256" =~ ^[0-9a-f]{64}$ ]] \
+      || fail "Release state has no valid launcher SHA-256: $state_file"
+  fi
+  if [ -n "$recorded_launcher_sha256" ] \
+    && [ "$recorded_launcher_sha256" != "$actual_launcher_sha256" ]; then
+    fail "Release launcher does not match $state_file"
+  fi
+
+  printf '%s\t%s\n' "$actual_commit" "$actual_launcher_sha256"
+}
+
+case "$APP_ROOT" in
+  /*) ;;
+  *) fail "HUB_OPTIMUS_APP_ROOT must be an absolute path." ;;
+esac
+[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "One exact lowercase 40-character target commit is required."
+case "$REFERENCE_URL" in
+  https://*) ;;
+  *) fail "One HTTPS reference URL is required for the egress check." ;;
+esac
+
+for command_name in \
+  awk basename bash cat chmod cmp cp curl date df dirname flock free git grep \
+  head install ln mkdir mktemp mv python3 readlink rm rmdir sed sha256sum stat \
+  sudo systemctl tee timeout tr; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "Required tool is unavailable: $command_name"
+done
+
+[ -d "$APP_ROOT/shared" ] || fail "Shared directory is missing: $APP_ROOT/shared"
+[ -L "$APP_ROOT/current" ] || fail "Current release is not a symlink."
+[ -f "$APP_ROOT/shared/bin/hub-api" ] \
+  && [ ! -L "$APP_ROOT/shared/bin/hub-api" ] \
+  && [ -x "$APP_ROOT/shared/bin/hub-api" ] \
+  || fail "Shared hub-api launcher is not one executable regular file."
+[ -f "$APP_ROOT/shared/current_release" ] \
+  && [ ! -L "$APP_ROOT/shared/current_release" ] \
+  || fail "Current-release marker is not one regular file."
+
+sudo -n true >/dev/null 2>&1 \
+  || fail "Passwordless non-interactive sudo is unavailable."
+sudo -n systemctl is-active --quiet hub-api.service \
+  || fail "hub-api.service is not active."
+
+CURRENT_RELEASE="$(readlink -f "$APP_ROOT/current")"
+SHARED_RELEASE_STATE="$APP_ROOT/shared/RELEASE_STATE"
+[ -f "$SHARED_RELEASE_STATE" ] && [ ! -L "$SHARED_RELEASE_STATE" ] \
+  || fail "Shared release state is not one regular file: $SHARED_RELEASE_STATE"
+IFS=$'\t' read -r CURRENT_COMMIT CURRENT_LAUNCHER_SHA256 < <(
+  validate_release "$CURRENT_RELEASE" "$SHARED_RELEASE_STATE" "yes"
+)
+
+CURRENT_RELEASE_STATE="$CURRENT_RELEASE/.hub-deployment/RELEASE_STATE"
+[ -f "$CURRENT_RELEASE_STATE" ] \
+  || fail "Current per-release state is missing; run explicit legacy adoption first."
+IFS=$'\t' read -r RELEASE_COMMIT RELEASE_LAUNCHER_SHA256 < <(
+  validate_release "$CURRENT_RELEASE" "$CURRENT_RELEASE_STATE" "yes"
+)
+[ "$RELEASE_COMMIT" = "$CURRENT_COMMIT" ] \
+  && [ "$RELEASE_LAUNCHER_SHA256" = "$CURRENT_LAUNCHER_SHA256" ] \
+  && cmp -s "$CURRENT_RELEASE_STATE" "$SHARED_RELEASE_STATE" \
+  || fail "Shared RELEASE_STATE is not the exact current release state."
+
+CURRENT_MARKER="$(cat "$APP_ROOT/shared/current_release")"
+[ "$CURRENT_MARKER" = "$(basename "$CURRENT_RELEASE")" ] \
+  || fail "Current-release marker does not match the current symlink."
+SHARED_LAUNCHER_SHA256="$(sha256_file "$APP_ROOT/shared/bin/hub-api")"
+[ "$SHARED_LAUNCHER_SHA256" = "$CURRENT_LAUNCHER_SHA256" ] \
+  || fail "Shared launcher does not match the current release launcher."
+
+PREVIOUS_RELEASE="none"
+PREVIOUS_COMMIT="none"
+PREVIOUS_LAUNCHER_SHA256="none"
+PREVIOUS_STATE_STATUS="none"
+if [ -L "$APP_ROOT/shared/previous_release" ]; then
+  fail "Previous-release pointer must not be a symlink."
+elif [ -f "$APP_ROOT/shared/previous_release" ]; then
+  PREVIOUS_RELEASE="$(readlink -f "$(cat "$APP_ROOT/shared/previous_release")")"
+  if [ -f "$PREVIOUS_RELEASE/.hub-deployment/RELEASE_STATE" ]; then
+    IFS=$'\t' read -r PREVIOUS_COMMIT PREVIOUS_LAUNCHER_SHA256 < <(
+      validate_release \
+        "$PREVIOUS_RELEASE" \
+        "$PREVIOUS_RELEASE/.hub-deployment/RELEASE_STATE" \
+        "yes"
+    )
+    PREVIOUS_STATE_STATUS="attested"
+  else
+    # This historical pointer is not the rollback target created by the next
+    # deploy. Inventory its real checkout and launcher without manufacturing
+    # provenance from an ambiguous legacy state file.
+    IFS=$'\t' read -r PREVIOUS_COMMIT PREVIOUS_LAUNCHER_SHA256 < <(
+      inspect_release_directory "$PREVIOUS_RELEASE"
+    )
+    PREVIOUS_STATE_STATUS="legacy-unattested-not-deploy-rollback-target"
+  fi
+fi
+
+DISK_AVAILABLE_KIB="$(df -Pk "$APP_ROOT" | awk 'NR == 2 {print $4}')"
+[[ "$DISK_AVAILABLE_KIB" =~ ^[0-9]+$ ]] \
+  || fail "Could not determine available disk space."
+[ "$DISK_AVAILABLE_KIB" -ge "$MIN_DISK_KIB" ] \
+  || fail "Available disk is below ${MIN_DISK_KIB} KiB."
+
+FREE_INODES="$(df -Pi "$APP_ROOT" | awk 'NR == 2 {print $4}')"
+[[ "$FREE_INODES" =~ ^[0-9]+$ ]] \
+  || fail "Could not determine available inodes."
+[ "$FREE_INODES" -ge "$MIN_FREE_INODES" ] \
+  || fail "Available inodes are below $MIN_FREE_INODES."
+
+AVAILABLE_MEMORY_KIB="$(free -k | awk '/^Mem:/ {print $7}')"
+[[ "$AVAILABLE_MEMORY_KIB" =~ ^[0-9]+$ ]] \
+  || fail "Could not determine available memory."
+[ "$AVAILABLE_MEMORY_KIB" -ge "$MIN_AVAILABLE_MEMORY_KIB" ] \
+  || fail "Available memory is below ${MIN_AVAILABLE_MEMORY_KIB} KiB."
+
+LOAD_1M="$(awk '{print $1}' /proc/loadavg)"
+awk -v actual="$LOAD_1M" -v maximum="$MAX_LOAD_1M" \
+  'BEGIN { exit !(actual + 0 <= maximum + 0) }' \
+  || fail "One-minute load $LOAD_1M exceeds $MAX_LOAD_1M."
+
+GIT_TERMINAL_PROMPT=0 timeout 15 git ls-remote "$REPO_URL" HEAD >/dev/null \
+  || fail "Git repository egress check failed."
+curl \
+  --proto '=https' \
+  --tlsv1.2 \
+  --fail \
+  --silent \
+  --show-error \
+  --connect-timeout 5 \
+  --max-time 15 \
+  --range 0-0 \
+  --output /dev/null \
+  "$REFERENCE_URL" \
+  || fail "Reference URL egress check failed."
+
+printf 'target_commit=%s\n' "$TARGET_SHA"
+printf 'current_release=%s\n' "$CURRENT_RELEASE"
+printf 'current_commit=%s\n' "$CURRENT_COMMIT"
+printf 'current_launcher_sha256=%s\n' "$CURRENT_LAUNCHER_SHA256"
+printf 'shared_launcher_sha256=%s\n' "$SHARED_LAUNCHER_SHA256"
+printf 'previous_release=%s\n' "$PREVIOUS_RELEASE"
+printf 'previous_commit=%s\n' "$PREVIOUS_COMMIT"
+printf 'previous_launcher_sha256=%s\n' "$PREVIOUS_LAUNCHER_SHA256"
+printf 'previous_state_status=%s\n' "$PREVIOUS_STATE_STATUS"
+printf 'disk_available_kib=%s (minimum=%s)\n' "$DISK_AVAILABLE_KIB" "$MIN_DISK_KIB"
+printf 'free_inodes=%s (minimum=%s)\n' "$FREE_INODES" "$MIN_FREE_INODES"
+printf 'available_memory_kib=%s (minimum=%s)\n' \
+  "$AVAILABLE_MEMORY_KIB" "$MIN_AVAILABLE_MEMORY_KIB"
+printf 'load_1m=%s (maximum=%s)\n' "$LOAD_1M" "$MAX_LOAD_1M"
+printf '[preflight] PASS\n'

--- a/ops/ec2/rollback-current.sh
+++ b/ops/ec2/rollback-current.sh
@@ -14,6 +14,164 @@ state_value() {
   sed -n "s/^${key}=//p" "$state_file" | head -n 1
 }
 
+required_state_value() {
+  local state_file="$1"
+  local key="$2"
+  local count
+
+  count="$(grep -c "^${key}=" "$state_file" 2>/dev/null || true)"
+  [ "$count" -eq 1 ] \
+    || fail "$state_file must contain exactly one $key field."
+  state_value "$state_file" "$key"
+}
+
+sha256_file() {
+  local path="$1"
+  local digest
+
+  digest="$(sha256sum -- "$path" | awk '{print $1}')"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Could not calculate launcher SHA-256: $path"
+  printf '%s\n' "$digest"
+}
+
+snapshot_item() {
+  local source="$1"
+  local name="$2"
+
+  if [ -e "$source" ] || [ -L "$source" ]; then
+    printf 'present\n' > "$RECOVERY_DIR/$name.presence"
+    cp -a -- "$source" "$RECOVERY_DIR/$name"
+  else
+    printf 'absent\n' > "$RECOVERY_DIR/$name.presence"
+  fi
+}
+
+restore_item() {
+  local target="$1"
+  local name="$2"
+  local presence
+
+  presence="$(cat "$RECOVERY_DIR/$name.presence")"
+  if [ -d "$target" ] && [ ! -L "$target" ]; then
+    echo "[rollback:recovery:error] Refusing to replace directory: $target" >&2
+    return 1
+  fi
+  rm -f -- "$target"
+
+  case "$presence" in
+    present)
+      cp -a -- "$RECOVERY_DIR/$name" "$target"
+      ;;
+    absent)
+      ;;
+    *)
+      echo "[rollback:recovery:error] Invalid snapshot marker for $target" >&2
+      return 1
+      ;;
+  esac
+}
+
+recovery_note() {
+  local message="$1"
+  local log_requirement="$2"
+
+  if [ "$RECOVERY_LOG_READY" -eq 1 ]; then
+    if ! printf '%s\n' "$message" >&8; then
+      RECOVERY_LOG_FAILED=1
+      RECOVERY_LOG_READY=0
+      [ "$log_requirement" != "require-log" ] || return 1
+    fi
+  elif [ "$log_requirement" = "require-log" ]; then
+    return 1
+  fi
+  printf '%s\n' "$message" >&2 || true
+}
+
+recover_pre_rollback_state() {
+  local state_restore_failed=0
+  local recovery_succeeded=0
+
+  RECOVERY_LOG_READY=0
+  RECOVERY_LOG_FAILED=0
+  set +e
+
+  if [ -n "$RECOVERY_LOG" ] \
+    && { exec 8>> "$RECOVERY_LOG"; } 2>/dev/null; then
+    RECOVERY_LOG_READY=1
+    chmod 0600 "$RECOVERY_LOG" 2>/dev/null || RECOVERY_LOG_FAILED=1
+  else
+    RECOVERY_LOG_FAILED=1
+  fi
+
+  recovery_note \
+    "[rollback:recovery] Restoring exact pre-rollback operational state" \
+    allow-missing-log
+  restore_item "$APP_ROOT/shared/last_rollback_from" "last-rollback-from" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/bin/hub-api" "shared-launcher" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/RELEASE_STATE" "shared-release-state" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/ROLLBACK_STATE" "rollback-state" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/shared/current_release" "current-release-marker" \
+    || state_restore_failed=1
+  restore_item "$APP_ROOT/current" "current-symlink" \
+    || state_restore_failed=1
+  rm -f -- "$CURRENT_NEW" || state_restore_failed=1
+
+  if [ "$state_restore_failed" -eq 0 ] \
+    && [ "$RECOVERY_LOG_FAILED" -eq 0 ] \
+    && recovery_note \
+      "[rollback:recovery] Pre-rollback operational state restored" \
+      require-log; then
+    recovery_succeeded=1
+  elif [ "$state_restore_failed" -eq 0 ]; then
+    recovery_note \
+      "[rollback:recovery:error] Operational state restored, but recovery evidence could not be recorded; treating recovery as failed" \
+      allow-missing-log
+  else
+    recovery_note \
+      "[rollback:recovery:error] Recovery was incomplete; inspect the retained snapshot" \
+      allow-missing-log
+  fi
+
+  if [ "$RECOVERY_LOG_READY" -eq 1 ]; then
+    exec 8>&-
+  fi
+  set -e
+  [ "$recovery_succeeded" -eq 1 ]
+}
+
+on_exit() {
+  local exit_code="$?"
+
+  trap - EXIT
+  if [ "$exit_code" -ne 0 ] && [ "$MUTATION_STARTED" -eq 1 ]; then
+    recover_pre_rollback_state || exit_code=1
+  fi
+  exit "$exit_code"
+}
+
+inject_test_failure() {
+  local stage="$1"
+
+  if [ "${HUB_OPTIMUS_TEST_ROLLBACK_FAIL_AFTER_MUTATION:-}" = "$stage" ]; then
+    fail "injected test failure after mutation stage: $stage"
+  fi
+}
+
+MUTATION_STARTED=0
+ROLLBACK_WORK_DIR=""
+TRANSACTION_DIR=""
+RECOVERY_DIR=""
+RECOVERY_LOG="/dev/null"
+RECOVERY_LOG_READY=0
+RECOVERY_LOG_FAILED=0
+CURRENT_NEW=""
+trap on_exit EXIT
+
 case "$APP_ROOT" in
   /*) ;;
   *) fail "HUB_OPTIMUS_APP_ROOT must be an absolute path." ;;
@@ -25,7 +183,6 @@ flock -n 9 || fail "another deploy or rollback operation is active."
 if [ ! -L "$APP_ROOT/current" ]; then
   fail "Current symlink does not exist."
 fi
-
 if [ ! -f "$APP_ROOT/shared/previous_release" ]; then
   fail "No previous release recorded."
 fi
@@ -33,14 +190,16 @@ fi
 CURRENT="$(readlink -f "$APP_ROOT/current")"
 PREVIOUS="$(readlink -f "$(cat "$APP_ROOT/shared/previous_release")")"
 
+case "$CURRENT" in
+  "$APP_ROOT/releases/"*) ;;
+  *) fail "Current release is outside the managed releases directory: $CURRENT" ;;
+esac
 case "$PREVIOUS" in
   "$APP_ROOT/releases/"*) ;;
   *) fail "Previous release is outside the managed releases directory: $PREVIOUS" ;;
 esac
-
-if [ ! -d "$PREVIOUS" ]; then
-  fail "Previous release path does not exist: $PREVIOUS"
-fi
+[ -d "$CURRENT" ] || fail "Current release path does not exist: $CURRENT"
+[ -d "$PREVIOUS" ] || fail "Previous release path does not exist: $PREVIOUS"
 
 if [ "$CURRENT" = "$PREVIOUS" ]; then
   echo "[rollback] Current release already matches previous_release target:"
@@ -49,52 +208,115 @@ if [ "$CURRENT" = "$PREVIOUS" ]; then
 fi
 
 PREVIOUS_STATE="$PREVIOUS/.hub-deployment/RELEASE_STATE"
-if [ ! -f "$PREVIOUS_STATE" ]; then
-  fail "Previous release has no recorded deployment state: $PREVIOUS_STATE"
-fi
+[ -f "$PREVIOUS_STATE" ] \
+  || fail "Previous release has no recorded deployment state: $PREVIOUS_STATE"
+[ -f "$PREVIOUS/ops/ec2/hub-api.sh" ] \
+  || fail "Previous release has no hub-api launcher: $PREVIOUS/ops/ec2/hub-api.sh"
 
-if [ ! -f "$PREVIOUS/ops/ec2/hub-api.sh" ]; then
-  fail "Previous release has no hub-api launcher: $PREVIOUS/ops/ec2/hub-api.sh"
-fi
+RECORDED_COMMIT="$(required_state_value "$PREVIOUS_STATE" "commit")"
+RECORDED_PATH="$(required_state_value "$PREVIOUS_STATE" "path")"
+RECORDED_RELEASE="$(required_state_value "$PREVIOUS_STATE" "release")"
+RECORDED_LAUNCHER_SHA256="$(
+  required_state_value "$PREVIOUS_STATE" "launcher_sha256"
+)"
+ACTUAL_COMMIT="$(git -C "$PREVIOUS" rev-parse --verify HEAD)"
+[[ "$ACTUAL_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "Previous release does not resolve to one full commit SHA."
+[ "$RECORDED_COMMIT" = "$ACTUAL_COMMIT" ] \
+  || fail "Previous release commit does not match its deployment state."
+[ "$RECORDED_PATH" = "$PREVIOUS" ] \
+  || fail "Previous release path does not match its deployment state."
+[ "$RECORDED_RELEASE" = "$(basename "$PREVIOUS")" ] \
+  || fail "Previous release name does not match its deployment state."
+[[ "$RECORDED_LAUNCHER_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+  || fail "Previous release state has no valid launcher SHA-256."
+ACTUAL_LAUNCHER_SHA256="$(sha256_file "$PREVIOUS/ops/ec2/hub-api.sh")"
+[ "$RECORDED_LAUNCHER_SHA256" = "$ACTUAL_LAUNCHER_SHA256" ] \
+  || fail "Previous release launcher does not match its deployment state."
 
-RECORDED_COMMIT="$(state_value "$PREVIOUS_STATE" "commit")"
-ACTUAL_COMMIT="$(git -C "$PREVIOUS" rev-parse HEAD)"
-if [ -z "$RECORDED_COMMIT" ] || [ "$RECORDED_COMMIT" != "$ACTUAL_COMMIT" ]; then
-  fail "Previous release commit does not match its deployment state."
-fi
-
-CURRENT_COMMIT="$(git -C "$CURRENT" rev-parse HEAD)"
+CURRENT_COMMIT="$(git -C "$CURRENT" rev-parse --verify HEAD)"
+[[ "$CURRENT_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "Current release does not resolve to one full commit SHA."
 CURRENT_RELEASE="$(basename "$CURRENT")"
 PREVIOUS_RELEASE="$(basename "$PREVIOUS")"
 
-echo "$CURRENT" > "$APP_ROOT/shared/last_rollback_from"
+ROLLBACK_WORK_DIR="$(
+  mktemp -d "$APP_ROOT/shared/rollback-transaction.$(date -u +%Y%m%dT%H%M%SZ).XXXXXX"
+)"
+TRANSACTION_DIR="$ROLLBACK_WORK_DIR/transaction"
+RECOVERY_DIR="$ROLLBACK_WORK_DIR/pre-rollback-state"
+RECOVERY_LOG="${HUB_OPTIMUS_TEST_ROLLBACK_RECOVERY_LOG_PATH:-$ROLLBACK_WORK_DIR/recovery.log}"
+CURRENT_NEW="$APP_ROOT/current.rollback-new.$(basename "$ROLLBACK_WORK_DIR")"
+mkdir -p "$TRANSACTION_DIR" "$RECOVERY_DIR"
+chmod 0700 "$ROLLBACK_WORK_DIR" "$TRANSACTION_DIR" "$RECOVERY_DIR"
 
-ln -sfn "$PREVIOUS" "$APP_ROOT/current.new"
-mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"
-
+printf '%s\n' "$CURRENT" > "$TRANSACTION_DIR/last_rollback_from"
 install -m 0755 \
-  "$APP_ROOT/current/ops/ec2/hub-api.sh" \
-  "$APP_ROOT/shared/bin/hub-api"
-install -m 0644 "$PREVIOUS_STATE" "$APP_ROOT/shared/RELEASE_STATE.new"
-mv -Tf "$APP_ROOT/shared/RELEASE_STATE.new" "$APP_ROOT/shared/RELEASE_STATE"
-
-cat > "$APP_ROOT/shared/ROLLBACK_STATE.new" <<STATE
+  "$PREVIOUS/ops/ec2/hub-api.sh" \
+  "$TRANSACTION_DIR/hub-api"
+install -m 0644 "$PREVIOUS_STATE" "$TRANSACTION_DIR/RELEASE_STATE"
+cat > "$TRANSACTION_DIR/ROLLBACK_STATE" <<STATE
 rolled_back_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 from_release=$CURRENT_RELEASE
 from_commit=$CURRENT_COMMIT
 to_release=$PREVIOUS_RELEASE
 to_commit=$ACTUAL_COMMIT
+to_launcher_sha256=$ACTUAL_LAUNCHER_SHA256
 STATE
-chmod 0600 "$APP_ROOT/shared/ROLLBACK_STATE.new"
-mv -Tf "$APP_ROOT/shared/ROLLBACK_STATE.new" "$APP_ROOT/shared/ROLLBACK_STATE"
+chmod 0600 "$TRANSACTION_DIR/ROLLBACK_STATE"
+printf '%s\n' "$PREVIOUS_RELEASE" > "$TRANSACTION_DIR/current_release"
 
-echo "$PREVIOUS_RELEASE" > "$APP_ROOT/shared/current_release"
+snapshot_item "$APP_ROOT/shared/last_rollback_from" "last-rollback-from"
+snapshot_item "$APP_ROOT/shared/bin/hub-api" "shared-launcher"
+snapshot_item "$APP_ROOT/shared/RELEASE_STATE" "shared-release-state"
+snapshot_item "$APP_ROOT/shared/ROLLBACK_STATE" "rollback-state"
+snapshot_item "$APP_ROOT/shared/current_release" "current-release-marker"
+snapshot_item "$APP_ROOT/current" "current-symlink"
+
+MUTATION_STARTED=1
+
+echo "[rollback] Recording rollback source"
+mv -Tf \
+  "$TRANSACTION_DIR/last_rollback_from" \
+  "$APP_ROOT/shared/last_rollback_from"
+inject_test_failure "last-rollback-from"
+
+echo "[rollback] Switching current symlink"
+ln -s "$PREVIOUS" "$CURRENT_NEW"
+mv -Tf "$CURRENT_NEW" "$APP_ROOT/current"
+inject_test_failure "current"
+
+echo "[rollback] Syncing hub-api launcher"
+mv -Tf "$TRANSACTION_DIR/hub-api" "$APP_ROOT/shared/bin/hub-api"
+inject_test_failure "launcher"
+
+echo "[rollback] Publishing release state"
+mv -Tf \
+  "$TRANSACTION_DIR/RELEASE_STATE" \
+  "$APP_ROOT/shared/RELEASE_STATE"
+inject_test_failure "release-state"
+
+echo "[rollback] Publishing rollback transition"
+mv -Tf \
+  "$TRANSACTION_DIR/ROLLBACK_STATE" \
+  "$APP_ROOT/shared/ROLLBACK_STATE"
+inject_test_failure "rollback-state"
+
+echo "[rollback] Publishing current-release marker"
+mv -Tf \
+  "$TRANSACTION_DIR/current_release" \
+  "$APP_ROOT/shared/current_release"
+inject_test_failure "current-release"
 
 echo "[rollback] Rolled back to:"
 readlink -f "$APP_ROOT/current"
-
 echo "[rollback] Release state:"
 cat "$APP_ROOT/shared/RELEASE_STATE"
-
 echo "[rollback] Rollback state:"
 cat "$APP_ROOT/shared/ROLLBACK_STATE"
+echo "[rollback] Done"
+
+MUTATION_STARTED=0
+if ! rm -rf -- "$ROLLBACK_WORK_DIR"; then
+  echo "[rollback:warning] Could not remove completed transaction snapshot." >&2
+fi

--- a/tests/fixtures/ec2/legacy_release_state_9d677.txt
+++ b/tests/fixtures/ec2/legacy_release_state_9d677.txt
@@ -1,0 +1,6 @@
+release=20260720T225606Z
+commit=9d67719
+path=/opt/hub-optimus/releases/20260720T225606Z
+validated_at_utc=2026-07-20T22:56:06Z
+validation=pytest 55 passed
+status=production-candidate-core

--- a/tests/test_ec2_deploy_hub_api_sync.py
+++ b/tests/test_ec2_deploy_hub_api_sync.py
@@ -12,21 +12,24 @@ def test_deploy_syncs_hub_api_launcher_into_shared_bin():
     assert '"$APP_ROOT/shared/bin"' in text
     assert "[deploy] Verifying hub-api launcher source" in text
     assert 'if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then' in text
-    assert "[deploy:error] Missing hub-api launcher source" in text
+    assert "Missing hub-api launcher source" in text
+    assert "launcher_sha256=$CANDIDATE_LAUNCHER_SHA256" in text
     assert "[deploy] Syncing hub-api launcher" in text
-    assert 'install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"' in text
+    assert '"$TRANSACTION_DIR/hub-api"' in text
+    assert '"$APP_ROOT/shared/bin/hub-api"' in text
 
 
 def test_deploy_syncs_launcher_after_current_symlink_switch():
     text = DEPLOY.read_text(encoding="utf-8")
 
     verify_source = text.index('if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then')
+    stage_launcher = text.index('"$TRANSACTION_DIR/hub-api"')
     switch_current = text.index('echo "[deploy] Switching current symlink"')
-    move_current = text.index('mv -Tf "$APP_ROOT/current.new" "$APP_ROOT/current"')
-    install_launcher = text.index('install -m 0755 "$APP_ROOT/current/ops/ec2/hub-api.sh" "$APP_ROOT/shared/bin/hub-api"')
+    move_current = text.index('mv -Tf "$CURRENT_NEW" "$APP_ROOT/current"')
+    publish_launcher = text.index('mv -Tf "$TRANSACTION_DIR/hub-api" "$APP_ROOT/shared/bin/hub-api"')
 
-    assert verify_source < switch_current
-    assert move_current < install_launcher
+    assert verify_source < stage_launcher < switch_current
+    assert move_current < publish_launcher
 
 
 def test_systemd_execstart_uses_synced_shared_launcher():

--- a/tests/test_ec2_legacy_adoption.py
+++ b/tests/test_ec2_legacy_adoption.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADOPT = ROOT / "ops" / "ec2" / "adopt-legacy-current.sh"
+PREFLIGHT = ROOT / "ops" / "ec2" / "preflight-deploy.sh"
+LEGACY_FIXTURE = (
+    ROOT / "tests" / "fixtures" / "ec2" / "legacy_release_state_9d677.txt"
+)
+LEGACY_COMMIT = "9d6771994095e4fc04e8fdbf2caa644ccb002ab1"
+LEGACY_LAUNCHER_SHA256 = (
+    "f29996d6078c0b7ecbd29699383fd0e71a05d5e35f7ecf3437dbd0cc0e87a219"
+)
+
+
+def _run(
+    args: list[str | Path],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(arg) for arg in args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = _run(["git", "-C", repo, *args])
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _state(path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in path.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def _source_repository(
+    path: Path,
+    *,
+    launcher_bytes: bytes | None = None,
+) -> str:
+    path.mkdir()
+    assert _run(["git", "init", "-q", path]).returncode == 0
+    _git(path, "config", "user.email", "tests@example.invalid")
+    _git(path, "config", "user.name", "HUB tests")
+    launcher = path / "ops" / "ec2" / "hub-api.sh"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_bytes(
+        launcher_bytes
+        if launcher_bytes is not None
+        else b"#!/usr/bin/env bash\necho legacy-api\n"
+    )
+    launcher.chmod(0o755)
+    (path / "tracked.txt").write_text("reviewed release\n", encoding="utf-8")
+    _git(path, "add", ".")
+    _git(path, "commit", "-qm", "reviewed legacy release")
+    return _git(path, "rev-parse", "HEAD")
+
+
+def _legacy_environment(
+    case_root: Path,
+    *,
+    launcher_bytes: bytes | None = None,
+    fixture_format: bool = False,
+) -> tuple[Path, Path, str, dict[str, str]]:
+    source = case_root / "source"
+    commit = _source_repository(source, launcher_bytes=launcher_bytes)
+    app_root = case_root / "app"
+    release = app_root / "releases" / "20260720T225606Z"
+    release.parent.mkdir(parents=True)
+    clone = _run(["git", "clone", "-q", "--no-hardlinks", source, release])
+    assert clone.returncode == 0, clone.stderr
+    _git(release, "checkout", "-q", "--detach", commit)
+
+    shared = app_root / "shared"
+    shared_launcher = shared / "bin" / "hub-api"
+    shared_launcher.parent.mkdir(parents=True)
+    shutil.copy2(release / "ops" / "ec2" / "hub-api.sh", shared_launcher)
+    (app_root / "current").symlink_to(release, target_is_directory=True)
+    (shared / "current_release").write_text(
+        f"{release.name}\n",
+        encoding="utf-8",
+    )
+    (shared / "previous_release").write_text(
+        f"{app_root / 'releases' / 'historical-before-1831'}\n",
+        encoding="utf-8",
+    )
+    if fixture_format:
+        legacy_state = LEGACY_FIXTURE.read_text(encoding="utf-8")
+        legacy_state = legacy_state.replace("/opt/hub-optimus", str(app_root))
+        legacy_state = legacy_state.replace("commit=9d67719", f"commit={commit[:7]}")
+    else:
+        legacy_state = "\n".join(
+            (
+                f"release={release.name}",
+                f"commit={commit[:7]}",
+                f"path={release}",
+                "validated_at_utc=2026-07-20T22:56:06Z",
+                "validation=pytest 55 passed",
+                "status=production-candidate-core",
+                "",
+            )
+        )
+    (shared / "RELEASE_STATE").write_text(legacy_state, encoding="utf-8")
+    env = os.environ.copy()
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+    env["HUB_OPTIMUS_REPO_URL"] = str(source)
+    return app_root, release, commit, env
+
+
+def _snapshot(app_root: Path, release: Path) -> dict[str, object]:
+    snapshot: dict[str, object] = {
+        "deployment_dir_present": (release / ".hub-deployment").exists(),
+    }
+    for name, path in {
+        "current": app_root / "current",
+        "shared_launcher": app_root / "shared" / "bin" / "hub-api",
+        "shared_state": app_root / "shared" / "RELEASE_STATE",
+        "current_marker": app_root / "shared" / "current_release",
+        "previous_pointer": app_root / "shared" / "previous_release",
+        "release_state": release / ".hub-deployment" / "RELEASE_STATE",
+        "legacy_evidence": (
+            release / ".hub-deployment" / "LEGACY_RELEASE_STATE"
+        ),
+        "git_exclude": release / ".git" / "info" / "exclude",
+    }.items():
+        present = path.exists() or path.is_symlink()
+        snapshot[f"{name}_present"] = present
+        if not present:
+            continue
+        snapshot[f"{name}_mode"] = stat.S_IMODE(path.lstat().st_mode)
+        if path.is_symlink():
+            snapshot[f"{name}_target"] = os.readlink(path)
+        else:
+            snapshot[f"{name}_bytes"] = path.read_bytes()
+    return snapshot
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_adopts_9d677_format_and_is_idempotent(tmp_path: Path) -> None:
+    fixture = LEGACY_FIXTURE.read_text(encoding="utf-8")
+    assert "commit=9d67719\n" in fixture
+    assert _git(ROOT, "rev-parse", "--short=7", LEGACY_COMMIT) == "9d67719"
+    historical_launcher = subprocess.run(
+        ["git", "-C", str(ROOT), "show", f"{LEGACY_COMMIT}:ops/ec2/hub-api.sh"],
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert hashlib.sha256(historical_launcher).hexdigest() == LEGACY_LAUNCHER_SHA256
+    app_root, release, commit, env = _legacy_environment(
+        tmp_path,
+        launcher_bytes=historical_launcher,
+        fixture_format=True,
+    )
+    shared = app_root / "shared"
+    shared_launcher = shared / "bin" / "hub-api"
+    rendered_fixture = (shared / "RELEASE_STATE").read_text(encoding="utf-8")
+    legacy_state_sha256 = hashlib.sha256(rendered_fixture.encode()).hexdigest()
+
+    first = _run([ADOPT, commit], env=env)
+
+    assert first.returncode == 0, first.stderr
+    release_state_path = release / ".hub-deployment" / "RELEASE_STATE"
+    state = _state(release_state_path)
+    legacy_evidence = release / ".hub-deployment" / "LEGACY_RELEASE_STATE"
+    assert state["commit"] == commit
+    assert state["requested_ref"] == commit
+    assert state["requested_ref_kind"] == "legacy-host-adoption"
+    assert state["launcher_sha256"] == LEGACY_LAUNCHER_SHA256
+    assert state["provenance"] == "adopted-legacy-current-v1"
+    assert state["legacy_state_sha256"] == legacy_state_sha256
+    assert state["legacy_commit_prefix"] == commit[:7]
+    assert state["validation_command"] == "not-run-during-legacy-adoption"
+    assert legacy_evidence.read_bytes() == rendered_fixture.encode()
+    assert stat.S_IMODE(legacy_evidence.stat().st_mode) == 0o400
+    assert (shared / "RELEASE_STATE").read_bytes() == release_state_path.read_bytes()
+    assert hashlib.sha256(shared_launcher.read_bytes()).hexdigest() == (
+        LEGACY_LAUNCHER_SHA256
+    )
+    exclude = (release / ".git" / "info" / "exclude").read_text(encoding="utf-8")
+    assert exclude.splitlines().count(".hub-deployment/") == 1
+    assert not list(shared.glob("legacy-adoption.*"))
+
+    before_second_run = _snapshot(app_root, release)
+    second = _run([ADOPT, commit], env=env)
+
+    assert second.returncode == 0, second.stderr
+    assert "already adopted and exact" in second.stdout
+    assert _snapshot(app_root, release) == before_second_run
+    assert not list(shared.glob("legacy-adoption.*"))
+
+
+def test_success_is_postvalidated_before_transaction_closes() -> None:
+    text = ADOPT.read_text(encoding="utf-8")
+    publish = text.index("Publishing exact shared release state")
+    postvalidate = text.index("validate_complete_adoption", publish)
+    close = text.index("MUTATION_STARTED=0", postvalidate)
+
+    assert publish < postvalidate < close
+    assert 'LEGACY_RELEASE_STATE"' in text
+    assert "install -m 0400" in text
+
+
+def test_preflight_inventories_unattested_historical_pointer(
+    tmp_path: Path,
+) -> None:
+    app_root, current, commit, env = _legacy_environment(tmp_path)
+    adopted = _run([ADOPT, commit], env=env)
+    assert adopted.returncode == 0, adopted.stderr
+
+    source = Path(env["HUB_OPTIMUS_REPO_URL"])
+    previous = app_root / "releases" / "historical-before-1831"
+    clone = _run(["git", "clone", "-q", "--no-hardlinks", source, previous])
+    assert clone.returncode == 0, clone.stderr
+    _git(previous, "checkout", "-q", "--detach", commit)
+    (app_root / "shared" / "previous_release").write_text(
+        f"{previous}\n",
+        encoding="utf-8",
+    )
+    assert not (previous / ".hub-deployment" / "RELEASE_STATE").exists()
+
+    fake_bin = tmp_path / "preflight-bin"
+    fake_bin.mkdir()
+    real_awk = shutil.which("awk")
+    assert real_awk is not None
+    _write_executable(
+        fake_bin / "awk",
+        "#!/usr/bin/env bash\n"
+        "if [ \"${2:-}\" = '/proc/loadavg' ]; then\n"
+        "  printf '0.01\\n'\n"
+        "else\n"
+        f"  exec {real_awk} \"$@\"\n"
+        "fi\n",
+    )
+    _write_executable(
+        fake_bin / "df",
+        "#!/usr/bin/env bash\n"
+        "printf 'Filesystem blocks Used Available Capacity Mounted-on\\n'\n"
+        "printf 'fixture 10000000 1 9000000 1%% /\\n'\n",
+    )
+    _write_executable(
+        fake_bin / "free",
+        "#!/usr/bin/env bash\n"
+        "printf 'Mem: 1000000 1000 1000 0 0 900000\\n'\n",
+    )
+    for command_name in ("curl", "sudo", "systemctl"):
+        _write_executable(fake_bin / command_name, "#!/usr/bin/env bash\nexit 0\n")
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run([PREFLIGHT, "f" * 40, "https://example.com/article"], env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert f"current_release={current}" in result.stdout
+    assert f"previous_release={previous}" in result.stdout
+    assert f"previous_commit={commit}" in result.stdout
+    assert (
+        "previous_state_status=legacy-unattested-not-deploy-rollback-target"
+        in result.stdout
+    )
+    assert "[preflight] PASS" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "stage",
+    (
+        "git-exclude",
+        "deployment-dir",
+        "legacy-state-evidence",
+        "release-state",
+        "shared-release-state",
+    ),
+)
+def test_each_adoption_failpoint_restores_exact_legacy_state(
+    tmp_path: Path,
+    stage: str,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    before = _snapshot(app_root, release)
+    env["HUB_OPTIMUS_TEST_LEGACY_ADOPTION_FAIL_AFTER_MUTATION"] = stage
+
+    failed = _run([ADOPT, commit], env=env)
+
+    assert failed.returncode == 1
+    assert f"injected test failure after mutation stage: {stage}" in failed.stderr
+    assert "Pre-adoption state restored" in failed.stderr
+    assert _snapshot(app_root, release) == before
+    retained = list((app_root / "shared").glob("legacy-adoption.*"))
+    assert len(retained) == 1
+    assert (retained[0] / "pre-adoption-state").is_dir()
+    assert "Pre-adoption state restored" in (
+        retained[0] / "recovery.log"
+    ).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "key",
+    ("release", "commit", "path", "validated_at_utc", "validation", "status"),
+)
+def test_legacy_state_rejects_every_duplicate_field_before_mutation(
+    tmp_path: Path,
+    key: str,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    state_path = app_root / "shared" / "RELEASE_STATE"
+    value = _state(state_path)[key]
+    with state_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{key}={value}\n")
+    before = _snapshot(app_root, release)
+
+    failed = _run([ADOPT, commit], env=env)
+
+    assert failed.returncode == 1
+    assert f"must contain exactly one {key} field" in failed.stderr
+    assert _snapshot(app_root, release) == before
+    assert not list((app_root / "shared").glob("legacy-adoption.*"))
+
+
+def test_failed_postvalidation_restores_exact_legacy_state(tmp_path: Path) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    before = _snapshot(app_root, release)
+    env[
+        "HUB_OPTIMUS_TEST_LEGACY_ADOPTION_CORRUPT_BEFORE_POSTVALIDATE"
+    ] = "shared-release-state"
+
+    failed = _run([ADOPT, commit], env=env)
+
+    assert failed.returncode == 1
+    assert "differs from the adopted current state" in failed.stderr
+    assert "Pre-adoption state restored" in failed.stderr
+    assert _snapshot(app_root, release) == before
+
+
+def test_adoption_still_restores_when_recovery_log_cannot_open(
+    tmp_path: Path,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    before = _snapshot(app_root, release)
+    unusable_log = tmp_path / "recovery-log-is-a-directory"
+    unusable_log.mkdir()
+    env["HUB_OPTIMUS_TEST_LEGACY_ADOPTION_FAIL_AFTER_MUTATION"] = "release-state"
+    env["HUB_OPTIMUS_TEST_LEGACY_ADOPTION_RECOVERY_LOG_PATH"] = str(
+        unusable_log
+    )
+
+    failed = _run([ADOPT, commit], env=env)
+
+    assert failed.returncode == 1
+    assert _snapshot(app_root, release) == before
+    assert "Restoring exact pre-adoption state" in failed.stderr
+    assert "State restored, but recovery evidence could not be recorded" in (
+        failed.stderr
+    )
+    assert "[legacy-adoption:recovery] Pre-adoption state restored" not in (
+        failed.stderr
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_case, expected_error",
+    (
+        ("commit", "Current full commit does not match"),
+        ("origin", "origin does not match"),
+        ("symlink", "outside the managed releases directory"),
+        ("shared-launcher", "does not exactly match"),
+        ("dirty-launcher", "worktree is not clean"),
+    ),
+)
+def test_adoption_rejects_unattested_identity_before_mutation(
+    tmp_path: Path,
+    invalid_case: str,
+    expected_error: str,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    expected_commit = commit
+    if invalid_case == "commit":
+        expected_commit = "0" * 40
+    elif invalid_case == "origin":
+        _git(release, "remote", "set-url", "origin", str(tmp_path / "other"))
+    elif invalid_case == "symlink":
+        outside = tmp_path / "outside-release"
+        outside.mkdir()
+        (app_root / "current").unlink()
+        (app_root / "current").symlink_to(outside, target_is_directory=True)
+    elif invalid_case == "shared-launcher":
+        launcher = app_root / "shared" / "bin" / "hub-api"
+        launcher.write_text("#!/usr/bin/env bash\necho drift\n", encoding="utf-8")
+        launcher.chmod(0o755)
+    elif invalid_case == "dirty-launcher":
+        (release / "ops" / "ec2" / "hub-api.sh").write_text(
+            "#!/usr/bin/env bash\necho dirty\n",
+            encoding="utf-8",
+        )
+    before = _snapshot(app_root, release)
+
+    failed = _run([ADOPT, expected_commit], env=env)
+
+    assert failed.returncode == 1
+    assert expected_error in failed.stderr
+    assert _snapshot(app_root, release) == before
+    assert not list((app_root / "shared").glob("legacy-adoption.*"))

--- a/tests/test_ec2_preflight_and_evidence.py
+++ b/tests/test_ec2_preflight_and_evidence.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PREFLIGHT = ROOT / "ops" / "ec2" / "preflight-deploy.sh"
+EVIDENCE = ROOT / "ops" / "ec2" / "intake-smoke-evidence.py"
+RUNBOOK = ROOT / "ops" / "ec2" / "ISSUE_1831_RUNBOOK.md"
+
+
+def test_host_preflight_is_noninteractive_and_fails_closed() -> None:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+
+    assert "MIN_DISK_KIB=3145728" in text
+    assert "MIN_FREE_INODES=50000" in text
+    assert "MIN_AVAILABLE_MEMORY_KIB=524288" in text
+    assert "MAX_LOAD_1M=2.00" in text
+    assert "sudo -n true" in text
+    assert "sudo -n systemctl is-active --quiet hub-api.service" in text
+    assert 'df -Pk "$APP_ROOT"' in text
+    assert 'df -Pi "$APP_ROOT"' in text
+    assert "free -k" in text
+    assert "/proc/loadavg" in text
+    assert 'git ls-remote "$REPO_URL" HEAD' in text
+    assert "--proto '=https'" in text
+    assert "current_launcher_sha256=" in text
+    assert "previous_launcher_sha256=" in text
+    assert "previous_state_status=" in text
+    assert 'PREVIOUS_STATE_STATUS="legacy-unattested-not-deploy-rollback-target"' in text
+    assert 'validate_release "$CURRENT_RELEASE" "$SHARED_RELEASE_STATE" "yes"' in text
+    assert 'cmp -s "$CURRENT_RELEASE_STATE" "$SHARED_RELEASE_STATE"' in text
+    assert '[ "$SHARED_LAUNCHER_SHA256" = "$CURRENT_LAUNCHER_SHA256" ]' in text
+    for command_name in (
+        "basename",
+        "cat",
+        "cp",
+        "dirname",
+        "head",
+        "stat",
+        "tee",
+        "tr",
+    ):
+        assert command_name in text.split("; do", 1)[0]
+    assert "systemctl restart" not in text
+
+
+def test_runbook_retains_reviewed_tools_and_uses_allowlisted_evidence() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "<fresh-reviewed-main-sha>" in text
+    assert "9d6771994095e4fc04e8fdbf2caa644ccb002ab1" in text
+    assert "shared/reviewed-tools/$TARGET_SHA" in text
+    assert "Do not put it behind an" in text
+    assert "preflight-deploy.sh" in text
+    assert "adopt-legacy-current.sh" in text
+    assert text.index("adopt-legacy-current.sh") < text.index("preflight-deploy.sh")
+    assert "LEGACY_RELEASE_STATE" in text
+    assert "legacy_state_sha256=" in text
+    assert "legacy-unattested-not-deploy-rollback-target" in text
+    assert "sudo -n systemctl restart hub-api.service" in text
+    assert "intake-smoke-evidence.py" in text
+    assert '"running_commit": status.get("running_commit")' in text
+    assert 'expected_launcher_sha256 = sys.argv[4]' in text
+    assert 'evidence["running_launcher_sha256"] != expected_launcher_sha256' in text
+    assert 'cmp -s "$DEPLOYED_RELEASE_STATE" "$APP_ROOT/shared/RELEASE_STATE"' in text
+    assert 'cmp -s "$RESTORED_RELEASE_STATE" "$APP_ROOT/shared/RELEASE_STATE"' in text
+    assert 'if release_state_raw != shared_state_raw:' in text
+    assert 'if versioned_launcher_raw != shared_launcher_raw:' in text
+    assert 'evidence["running_release"] != expected_release' in text
+    assert 'evidence["configured_current_release"] != expected_release' in text
+    assert "--fail-with-body" in text
+    assert 'install -m 0600 /dev/null "$RESPONSE"' in text
+    assert text.index('install -m 0600 /dev/null "$RESPONSE"') < text.index(
+        "set +e\nHTTP_CODE="
+    )
+    assert text.index("CURL_RC=$?") < text.index(
+        'python3 "$DEPLOYED_RELEASE/ops/ec2/intake-smoke-evidence.py"'
+    )
+    assert '"release_state": status.get(' not in text
+    assert "python3 -m json.tool" not in text
+    assert "DNS, TLS, nginx" in text
+    assert "PY_ROLLBACK_STATE" in text
+    assert "PY_ROLLBACK_STATUS" in text
+    assert '"to_launcher_sha256"' in text
+    assert 'evidence["running_commit"] != expected_commit' in text
+
+
+def test_smoke_evidence_ignores_text_and_every_unknown_field(
+    tmp_path: Path,
+) -> None:
+    secret_text = "ARTICLE BODY MUST NEVER BE PRINTED"
+    response = tmp_path / "response.json"
+    response.write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "final_url": "https://example.com/article",
+                "source_domain": "example.com",
+                "retrieved_at_utc": "2026-08-02T12:00:00+00:00",
+                "text": secret_text,
+                "content_type": "text/html; charset=utf-8",
+                "bytes_read": 4096,
+                "truncated": False,
+                "verification_status": "unreviewed",
+                "title": "Must not escape",
+                "message": "Must not escape",
+                "debug": {"raw_body": "Must not escape"},
+                "body": "Must not escape",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            str(EVIDENCE),
+            str(response),
+            "200",
+            "0",
+            "a" * 40,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert secret_text not in result.stdout
+    assert "Must not escape" not in result.stdout
+    evidence = json.loads(result.stdout)
+    assert set(evidence) == {
+        "bytes_read",
+        "content_type",
+        "curl_exit_code",
+        "error_code",
+        "final_domain",
+        "final_url",
+        "http_status",
+        "response_status",
+        "retrieved_at_utc",
+        "source_domain",
+        "target_commit",
+        "text_characters",
+        "text_present",
+        "text_sha256",
+        "truncated",
+        "verification_status",
+    }
+    assert evidence["text_present"] is True
+    assert evidence["text_characters"] == len(secret_text)
+    assert len(evidence["text_sha256"]) == 64
+    assert "text" not in evidence
+    assert "title" not in evidence
+    assert "message" not in evidence
+    assert "debug" not in evidence
+    assert "body" not in evidence
+
+
+def test_controlled_failure_evidence_exposes_only_stable_error_code(
+    tmp_path: Path,
+) -> None:
+    response = tmp_path / "response.json"
+    response.write_text(
+        json.dumps(
+            {
+                "status": "error",
+                "error": "url_fetch_failed",
+                "message": "upstream body or debug detail",
+                "url": "https://example.com/article",
+                "verification_status": "unreviewed",
+                "unexpected_body": "secret",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [str(EVIDENCE), str(response), "502", "22", "b" * 40],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "required HTTP 200" in result.stderr
+    assert "upstream body" not in result.stdout
+    assert "secret" not in result.stdout
+    evidence = json.loads(result.stdout)
+    assert evidence["response_status"] == "error"
+    assert evidence["error_code"] == "url_fetch_failed"
+    assert "message" not in evidence
+    assert "unexpected_body" not in evidence
+
+
+def test_success_payload_is_rejected_without_http_200(
+    tmp_path: Path,
+) -> None:
+    response = tmp_path / "response.json"
+    response.write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "final_url": "https://example.com/article",
+                "source_domain": "example.com",
+                "retrieved_at_utc": "2026-08-02T12:00:00+00:00",
+                "text": "retained but never printed",
+                "content_type": "text/html",
+                "bytes_read": 256,
+                "truncated": False,
+                "verification_status": "unreviewed",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [str(EVIDENCE), str(response), "201", "0", "c" * 40],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "required HTTP 200" in result.stderr
+    assert "retained but never printed" not in result.stdout
+    evidence = json.loads(result.stdout)
+    assert evidence["http_status"] == 201
+    assert evidence["response_status"] == "ok"

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -362,6 +363,110 @@ def test_api_failure_keeps_its_run_identity_and_cleans_input(
     ]
 
 
+def test_api_status_identity_is_bound_to_process_start(
+    tmp_path: Path,
+) -> None:
+    namespace = _load_embedded_api_namespace()
+    app_root = tmp_path / "app"
+    release_a = app_root / "releases" / "release-a"
+    release_b = app_root / "releases" / "release-b"
+    commit_a = _init_git_repo(release_a)
+    _init_git_repo(release_b)
+    (release_b / "tracked.txt").write_text("release-b\n", encoding="utf-8")
+    _git(release_b, "add", "tracked.txt")
+    _git(release_b, "commit", "-qm", "different configured release")
+    commit_b = _git(release_b, "rev-parse", "HEAD")
+    assert commit_a != commit_b
+
+    shared = app_root / "shared"
+    shared.mkdir(parents=True)
+    (shared / "RELEASE_STATE").write_text(
+        f"commit={commit_a}\n",
+        encoding="utf-8",
+    )
+    current = app_root / "current"
+    current.symlink_to(release_a, target_is_directory=True)
+    running_launcher_sha256 = "a" * 64
+
+    namespace["CURRENT"] = current
+    namespace["SHARED"] = shared
+    namespace["RUNNING_RELEASE"] = str(release_a)
+    namespace["RUNNING_COMMIT"] = commit_a
+    namespace["RUNNING_LAUNCHER_SHA256"] = running_launcher_sha256
+
+    before_switch = namespace["product_status"]()
+    replacement = app_root / "current.new"
+    replacement.symlink_to(release_b, target_is_directory=True)
+    os.replace(replacement, current)
+    (shared / "RELEASE_STATE").write_text(
+        f"commit={commit_b}\n",
+        encoding="utf-8",
+    )
+    after_switch = namespace["product_status"]()
+
+    for status in (before_switch, after_switch):
+        assert status["current"] == str(release_a)
+        assert status["commit"] == commit_a
+        assert status["running_release"] == str(release_a)
+        assert status["running_commit"] == commit_a
+        assert status["running_launcher_sha256"] == running_launcher_sha256
+        assert len(status["running_commit"]) == 40
+
+    assert before_switch["configured_current_release"] == str(release_a)
+    assert before_switch["configured_current_commit"] == commit_a
+    assert after_switch["configured_current_release"] == str(release_b)
+    assert after_switch["configured_current_commit"] == commit_b
+
+    launcher = HUB_API.read_text(encoding="utf-8")
+    assert 'sha256sum -- "$0"' in launcher
+    assert 'export HUB_OPTIMUS_API_RUNNING_COMMIT="$RUNNING_COMMIT"' in launcher
+    assert '"--short"' not in launcher
+
+
+def test_api_launcher_captures_real_process_identity_at_start(
+    tmp_path: Path,
+) -> None:
+    app_root = tmp_path / "app"
+    release = app_root / "releases" / "release-a"
+    commit = _init_git_repo(release)
+    shared_launcher = app_root / "shared" / "bin" / "hub-api"
+    shared_launcher.parent.mkdir(parents=True)
+    shared_launcher.write_bytes(HUB_API.read_bytes())
+    shared_launcher.chmod(0o755)
+    (app_root / "current").symlink_to(release, target_is_directory=True)
+
+    fake_bin = tmp_path / "fake-api-bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf 'app_root=%s\\n' \"$HUB_OPTIMUS_API_APP_ROOT\"\n"
+        "printf 'running_release=%s\\n' \"$HUB_OPTIMUS_API_RUNNING_RELEASE\"\n"
+        "printf 'running_commit=%s\\n' \"$HUB_OPTIMUS_API_RUNNING_COMMIT\"\n"
+        "printf 'launcher_sha256=%s\\n' \"$HUB_OPTIMUS_API_RUNNING_LAUNCHER_SHA256\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    env = os.environ.copy()
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run(["bash", shared_launcher], env=env)
+
+    assert result.returncode == 0, result.stderr
+    identity = dict(
+        line.split("=", 1)
+        for line in result.stdout.splitlines()
+        if "=" in line
+    )
+    assert identity["app_root"] == str(app_root)
+    assert identity["running_release"] == str(release)
+    assert identity["running_commit"] == commit
+    assert identity["launcher_sha256"] == hashlib.sha256(
+        shared_launcher.read_bytes()
+    ).hexdigest()
+
+
 def _source_repository(path: Path) -> tuple[str, str]:
     path.mkdir()
     assert _run(["git", "init", "-q", path]).returncode == 0
@@ -425,6 +530,26 @@ def _deploy_env(
     return env
 
 
+def _operational_snapshot(app_root: Path) -> dict[str, object]:
+    snapshot: dict[str, object] = {
+        "current_target": os.readlink(app_root / "current"),
+        "current_resolved": (app_root / "current").resolve(),
+    }
+    for name, path in {
+        "launcher": app_root / "shared" / "bin" / "hub-api",
+        "release_state": app_root / "shared" / "RELEASE_STATE",
+        "current_release": app_root / "shared" / "current_release",
+        "previous_release": app_root / "shared" / "previous_release",
+        "rollback_state": app_root / "shared" / "ROLLBACK_STATE",
+        "last_rollback_from": app_root / "shared" / "last_rollback_from",
+    }.items():
+        snapshot[f"{name}_present"] = path.exists()
+        if path.exists():
+            snapshot[f"{name}_bytes"] = path.read_bytes()
+            snapshot[f"{name}_mode"] = stat.S_IMODE(path.stat().st_mode)
+    return snapshot
+
+
 def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     tmp_path: Path,
 ) -> None:
@@ -457,6 +582,7 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     assert second_state["requested_ref"] == head_commit
     assert second_state["requested_ref_kind"] == "commit"
     assert second_state["commit"] == head_commit
+    assert re.fullmatch(r"[0-9a-f]{64}", second_state["launcher_sha256"])
     assert (app_root / "shared" / "bin" / "hub-api").read_text(
         encoding="utf-8"
     ).endswith("echo api-v2\n")
@@ -474,32 +600,310 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     ).endswith("echo api-v1\n")
 
 
+def test_every_injected_post_switch_failure_restores_exact_state(
+    tmp_path: Path,
+) -> None:
+    stages = (
+        "previous-release",
+        "current",
+        "launcher",
+        "release-state",
+        "current-release",
+    )
+
+    for stage in stages:
+        case_root = tmp_path / stage
+        case_root.mkdir()
+        source_repo = case_root / "source"
+        reviewed_commit, head_commit = _source_repository(source_repo)
+        fake_bin = _fake_deploy_python(case_root)
+        app_root = case_root / "app"
+        env = _deploy_env(app_root, source_repo, fake_bin)
+
+        first = _run([DEPLOY, reviewed_commit], env=env)
+        assert first.returncode == 0, first.stderr
+        before = _operational_snapshot(app_root)
+
+        env["HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION"] = stage
+        failed = _run([DEPLOY, head_commit], env=env)
+
+        assert failed.returncode == 1
+        assert f"injected test failure after mutation stage: {stage}" in failed.stderr
+        assert "Pre-deploy operational state restored" in failed.stderr
+        assert _operational_snapshot(app_root) == before
+
+        candidates = [
+            release
+            for release in (app_root / "releases").iterdir()
+            if (release / ".hub-deployment" / "RELEASE_STATE").is_file()
+            and _state(release / ".hub-deployment" / "RELEASE_STATE").get(
+                "commit"
+            )
+            == head_commit
+        ]
+        assert len(candidates) == 1
+        candidate = candidates[0]
+        assert (candidate / ".hub-deployment" / "validation.log").is_file()
+        recovery_log = candidate / ".hub-deployment" / "recovery.log"
+        assert "Pre-deploy operational state restored" in recovery_log.read_text(
+            encoding="utf-8"
+        )
+        assert (candidate / ".hub-deployment" / "pre-deploy-state").is_dir()
+
+
+def test_deploy_recovery_runs_when_recovery_log_cannot_open(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    before = _operational_snapshot(app_root)
+    unusable_log = tmp_path / "recovery-log-is-a-directory"
+    unusable_log.mkdir()
+    env["HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION"] = "current"
+    env["HUB_OPTIMUS_TEST_RECOVERY_LOG_PATH"] = str(unusable_log)
+
+    failed = _run([DEPLOY, head_commit], env=env)
+
+    assert failed.returncode == 1
+    assert _operational_snapshot(app_root) == before
+    assert "Restoring exact pre-deploy operational state" in failed.stderr
+    assert "Operational state restored, but recovery evidence could not be recorded" in failed.stderr
+    assert "[deploy:recovery] Pre-deploy operational state restored" not in failed.stderr
+
+
+def test_injected_legacy_state_completion_is_recovered(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    current_release = (app_root / "current").resolve()
+    legacy_state = current_release / ".hub-deployment" / "RELEASE_STATE"
+    legacy_state.unlink()
+    before = _operational_snapshot(app_root)
+
+    env["HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION"] = "previous-release-state"
+    result = _run([DEPLOY, head_commit], env=env)
+
+    assert result.returncode == 1
+    assert "injected test failure after mutation stage: previous-release-state" in result.stderr
+    assert "Pre-deploy operational state restored" in result.stderr
+    assert _operational_snapshot(app_root) == before
+    assert not legacy_state.exists()
+
+
+def test_rollback_rejects_launcher_drift_before_switching(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    first_release = (app_root / "current").resolve()
+    second = _run([DEPLOY, head_commit], env=env)
+    assert second.returncode == 0, second.stderr
+    before = _operational_snapshot(app_root)
+    (first_release / "ops" / "ec2" / "hub-api.sh").write_text(
+        "#!/usr/bin/env bash\necho tampered\n",
+        encoding="utf-8",
+    )
+
+    result = _run([ROLLBACK], env=env)
+
+    assert result.returncode == 1
+    assert "launcher does not match its deployment state" in result.stderr
+    assert _operational_snapshot(app_root) == before
+
+
+def test_every_injected_rollback_failure_restores_exact_state(
+    tmp_path: Path,
+) -> None:
+    stages = (
+        "last-rollback-from",
+        "current",
+        "launcher",
+        "release-state",
+        "rollback-state",
+        "current-release",
+    )
+
+    for stage in stages:
+        case_root = tmp_path / stage
+        case_root.mkdir()
+        source_repo = case_root / "source"
+        reviewed_commit, head_commit = _source_repository(source_repo)
+        fake_bin = _fake_deploy_python(case_root)
+        app_root = case_root / "app"
+        env = _deploy_env(app_root, source_repo, fake_bin)
+
+        first = _run([DEPLOY, reviewed_commit], env=env)
+        assert first.returncode == 0, first.stderr
+        second = _run([DEPLOY, head_commit], env=env)
+        assert second.returncode == 0, second.stderr
+        before = _operational_snapshot(app_root)
+        env["HUB_OPTIMUS_TEST_ROLLBACK_FAIL_AFTER_MUTATION"] = stage
+
+        failed = _run([ROLLBACK], env=env)
+
+        assert failed.returncode == 1
+        assert f"injected test failure after mutation stage: {stage}" in failed.stderr
+        assert "Pre-rollback operational state restored" in failed.stderr
+        assert _operational_snapshot(app_root) == before
+        recovery_roots = list(
+            (app_root / "shared").glob("rollback-transaction.*")
+        )
+        assert len(recovery_roots) == 1
+        recovery_log = recovery_roots[0] / "recovery.log"
+        assert "Pre-rollback operational state restored" in recovery_log.read_text(
+            encoding="utf-8"
+        )
+        assert (recovery_roots[0] / "pre-rollback-state").is_dir()
+
+
+def test_rollback_recovery_runs_when_recovery_log_cannot_open(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    assert _run([DEPLOY, reviewed_commit], env=env).returncode == 0
+    assert _run([DEPLOY, head_commit], env=env).returncode == 0
+    before = _operational_snapshot(app_root)
+    unusable_log = tmp_path / "rollback-log-is-a-directory"
+    unusable_log.mkdir()
+    env["HUB_OPTIMUS_TEST_ROLLBACK_FAIL_AFTER_MUTATION"] = "current"
+    env["HUB_OPTIMUS_TEST_ROLLBACK_RECOVERY_LOG_PATH"] = str(unusable_log)
+
+    failed = _run([ROLLBACK], env=env)
+
+    assert failed.returncode == 1
+    assert _operational_snapshot(app_root) == before
+    assert "Restoring exact pre-rollback operational state" in failed.stderr
+    assert "Operational state restored, but recovery evidence could not be recorded" in failed.stderr
+    assert "[rollback:recovery] Pre-rollback operational state restored" not in failed.stderr
+
+
+def test_rollback_state_parser_rejects_duplicate_identity_keys(
+    tmp_path: Path,
+) -> None:
+    for key in ("commit", "path", "release", "launcher_sha256"):
+        case_root = tmp_path / key
+        case_root.mkdir()
+        source_repo = case_root / "source"
+        reviewed_commit, head_commit = _source_repository(source_repo)
+        fake_bin = _fake_deploy_python(case_root)
+        app_root = case_root / "app"
+        env = _deploy_env(app_root, source_repo, fake_bin)
+
+        assert _run([DEPLOY, reviewed_commit], env=env).returncode == 0
+        first_release = (app_root / "current").resolve()
+        assert _run([DEPLOY, head_commit], env=env).returncode == 0
+        previous_state_path = (
+            first_release / ".hub-deployment" / "RELEASE_STATE"
+        )
+        state = _state(previous_state_path)
+        with previous_state_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"{key}={state[key]}\n")
+        before = _operational_snapshot(app_root)
+
+        result = _run([ROLLBACK], env=env)
+
+        assert result.returncode == 1
+        assert f"must contain exactly one {key} field" in result.stderr
+        assert _operational_snapshot(app_root) == before
+        assert not list((app_root / "shared").glob("rollback-transaction.*"))
+
+
+def test_invalid_rollback_target_state_fails_before_mutation(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    current_release = (app_root / "current").resolve()
+    current_state_path = current_release / ".hub-deployment" / "RELEASE_STATE"
+    current_state = current_state_path.read_text(encoding="utf-8")
+    current_state_path.write_text(
+        current_state.replace(
+            f"commit={reviewed_commit}",
+            f"commit={'0' * 40}",
+        ),
+        encoding="utf-8",
+    )
+    before = _operational_snapshot(app_root)
+
+    result = _run([DEPLOY, head_commit], env=env)
+
+    assert result.returncode == 1
+    assert "Rollback target commit does not match" in result.stderr
+    assert "Restoring exact pre-deploy" not in result.stderr
+    assert _operational_snapshot(app_root) == before
+
+
 def test_failed_validation_is_recorded_without_switching_current(
     tmp_path: Path,
 ) -> None:
     source_repo = tmp_path / "source"
-    reviewed_commit, _ = _source_repository(source_repo)
+    reviewed_commit, head_commit = _source_repository(source_repo)
     fake_bin = _fake_deploy_python(tmp_path)
     app_root = tmp_path / "app"
     env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    before = _operational_snapshot(app_root)
+
     env["HUB_TEST_VALIDATION_EXIT"] = "1"
     env["HUB_TEST_VALIDATION_OUTPUT"] = "2 failed in 0.01s"
 
-    result = _run([DEPLOY, reviewed_commit], env=env)
+    result = _run([DEPLOY, head_commit], env=env)
 
     assert result.returncode == 1
     assert "validation failed (exit 1): 2 failed in 0.01s" in result.stderr
-    assert not (app_root / "current").exists()
-    releases = list((app_root / "releases").iterdir())
-    assert len(releases) == 1
-    failed_state = _state(
-        releases[0] / ".hub-deployment" / "RELEASE_STATE"
+    assert _operational_snapshot(app_root) == before
+    failed_releases = [
+        release
+        for release in (app_root / "releases").iterdir()
+        if (release / ".hub-deployment" / "RELEASE_STATE").is_file()
+        and _state(release / ".hub-deployment" / "RELEASE_STATE").get(
+            "status"
+        )
+        == "validation-failed"
+    ]
+    assert len(failed_releases) == 1
+    failed_state_path = (
+        failed_releases[0] / ".hub-deployment" / "RELEASE_STATE"
     )
-    assert failed_state["commit"] == reviewed_commit
+    failed_state = _state(failed_state_path)
+    assert failed_state["commit"] == head_commit
     assert failed_state["validation_command"] == "python -m pytest -q"
     assert failed_state["validation_exit_code"] == "1"
     assert failed_state["validation_result"] == "2 failed in 0.01s"
     assert failed_state["status"] == "validation-failed"
+    assert (failed_releases[0] / ".hub-deployment" / "validation.log").is_file()
 
 
 def test_deploy_requires_explicit_ref_and_hub_ops_forwards_it(

--- a/tests/test_ec2_runbook_attestation.py
+++ b/tests/test_ec2_runbook_attestation.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK = ROOT / "ops" / "ec2" / "ISSUE_1831_RUNBOOK.md"
+
+
+def _heredoc(name: str) -> str:
+    text = RUNBOOK.read_text(encoding="utf-8")
+    match = re.search(rf"<<'{name}'\n(.*?)\n{name}", text, re.DOTALL)
+    assert match is not None, name
+    return match.group(1)
+
+
+def _run_heredoc(name: str, *args: str | Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-", *(str(arg) for arg in args)],
+        input=_heredoc(name),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_bytes(path: Path, data: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    path.chmod(mode)
+
+
+def _state_bytes(fields: dict[str, str]) -> bytes:
+    return ("\n".join(f"{key}={value}" for key, value in fields.items()) + "\n").encode()
+
+
+def _replace_state_pair(
+    release_state: Path,
+    shared_state: Path,
+    transform,
+) -> None:
+    updated = transform(release_state.read_bytes())
+    release_state.write_bytes(updated)
+    shared_state.write_bytes(updated)
+
+
+def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
+    app_root = tmp_path / "app"
+    release = app_root / "releases" / "20260802T120000Z.fixture"
+    commit = "a" * 40
+    launcher = b"#!/usr/bin/env bash\necho deployed\n"
+    launcher_sha256 = hashlib.sha256(launcher).hexdigest()
+    versioned_launcher = release / "ops" / "ec2" / "hub-api.sh"
+    shared_launcher = app_root / "shared" / "bin" / "hub-api"
+    _write_bytes(versioned_launcher, launcher, 0o755)
+    _write_bytes(shared_launcher, launcher, 0o755)
+    (app_root / "current").symlink_to(release, target_is_directory=True)
+
+    deployment_dir = release / ".hub-deployment"
+    validation_log = deployment_dir / "validation.log"
+    _write_bytes(validation_log, b"692 passed\n", 0o600)
+    fields = {
+        "release": release.name,
+        "requested_ref": commit,
+        "requested_ref_kind": "commit",
+        "commit": commit,
+        "path": str(release),
+        "validated_at_utc": "2026-08-02T12:00:00Z",
+        "validation_command": "python -m pytest -q",
+        "validation_exit_code": "0",
+        "validation_result": "692 passed in 30.45s",
+        "validation_log": str(validation_log),
+        "validation_log_exit_code": "0",
+        "launcher_sha256": launcher_sha256,
+        "status": "production-candidate-core",
+    }
+    state_raw = _state_bytes(fields)
+    release_state = deployment_dir / "RELEASE_STATE"
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    _write_bytes(release_state, state_raw, 0o600)
+    _write_bytes(shared_state, state_raw, 0o644)
+    _write_bytes(
+        app_root / "shared" / "current_release",
+        f"{release.name}\n".encode(),
+        0o644,
+    )
+    return {
+        "app_root": app_root,
+        "commit": commit,
+        "launcher_sha256": launcher_sha256,
+        "release": release,
+        "release_state": release_state,
+        "shared_launcher": shared_launcher,
+        "shared_state": shared_state,
+        "versioned_launcher": versioned_launcher,
+    }
+
+
+def test_post_deploy_disk_attestation_accepts_exact_release(tmp_path: Path) -> None:
+    fixture = _deploy_fixture(tmp_path)
+
+    result = _run_heredoc(
+        "PY_DEPLOY_STATE",
+        fixture["app_root"],
+        fixture["release"],
+        fixture["commit"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(result.stdout)
+    assert evidence["release"] == Path(fixture["release"]).name
+    assert evidence["commit"] == fixture["commit"]
+    assert evidence["launcher_sha256"] == fixture["launcher_sha256"]
+
+
+@pytest.mark.parametrize(
+    "invalid_case, expected_error",
+    (
+        ("state-parity", "shared and per-release RELEASE_STATE differ"),
+        ("duplicate", "duplicate release-state key"),
+        ("malformed", "malformed release-state line"),
+        ("extra-field", "exact field set"),
+        ("release", "wrong release name"),
+        ("path", "wrong release path"),
+        ("state-launcher", "launcher hashes do not match"),
+        ("versioned-launcher", "shared and versioned launchers differ"),
+        ("shared-launcher", "shared and versioned launchers differ"),
+    ),
+)
+def test_post_deploy_disk_attestation_rejects_every_identity_drift(
+    tmp_path: Path,
+    invalid_case: str,
+    expected_error: str,
+) -> None:
+    fixture = _deploy_fixture(tmp_path)
+    release_state = Path(fixture["release_state"])
+    shared_state = Path(fixture["shared_state"])
+    if invalid_case == "state-parity":
+        shared_state.write_bytes(shared_state.read_bytes() + b"status=drift\n")
+    elif invalid_case == "duplicate":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw + f"commit={fixture['commit']}\n".encode(),
+        )
+    elif invalid_case == "malformed":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw + b"malformed-line\n",
+        )
+    elif invalid_case == "extra-field":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw + b"unexpected=value\n",
+        )
+    elif invalid_case == "release":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw.replace(
+                f"release={Path(fixture['release']).name}\n".encode(),
+                b"release=wrong\n",
+            ),
+        )
+    elif invalid_case == "path":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw.replace(
+                f"path={fixture['release']}\n".encode(),
+                b"path=/tmp/wrong\n",
+            ),
+        )
+    elif invalid_case == "state-launcher":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw.replace(
+                f"launcher_sha256={fixture['launcher_sha256']}\n".encode(),
+                f"launcher_sha256={'0' * 64}\n".encode(),
+            ),
+        )
+    elif invalid_case == "versioned-launcher":
+        _write_bytes(
+            Path(fixture["versioned_launcher"]),
+            b"#!/usr/bin/env bash\necho versioned-drift\n",
+            0o755,
+        )
+    elif invalid_case == "shared-launcher":
+        _write_bytes(
+            Path(fixture["shared_launcher"]),
+            b"#!/usr/bin/env bash\necho shared-drift\n",
+            0o755,
+        )
+
+    result = _run_heredoc(
+        "PY_DEPLOY_STATE",
+        fixture["app_root"],
+        fixture["release"],
+        fixture["commit"],
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+def _status_fixture(tmp_path: Path) -> dict[str, object]:
+    release = tmp_path / "app" / "releases" / "release"
+    release.mkdir(parents=True)
+    commit = "b" * 40
+    launcher_sha256 = "c" * 64
+    status = {
+        "product": "HUB_Optimus",
+        "running_release": str(release),
+        "running_commit": commit,
+        "running_launcher_sha256": launcher_sha256,
+        "configured_current_release": str(release),
+        "configured_current_commit": commit,
+    }
+    response = tmp_path / "status.json"
+    response.write_text(json.dumps(status), encoding="utf-8")
+    return {
+        "commit": commit,
+        "launcher_sha256": launcher_sha256,
+        "release": release,
+        "response": response,
+        "status": status,
+    }
+
+
+@pytest.mark.parametrize("block", ("PY_STATUS", "PY_ROLLBACK_STATUS"))
+def test_process_attestation_accepts_exact_release_identity(
+    tmp_path: Path,
+    block: str,
+) -> None:
+    fixture = _status_fixture(tmp_path)
+
+    result = _run_heredoc(
+        block,
+        fixture["response"],
+        fixture["release"],
+        fixture["commit"],
+        fixture["launcher_sha256"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(result.stdout)
+    assert evidence["running_release"] == str(fixture["release"])
+    assert evidence["configured_current_release"] == str(fixture["release"])
+
+
+@pytest.mark.parametrize("block", ("PY_STATUS", "PY_ROLLBACK_STATUS"))
+@pytest.mark.parametrize(
+    "field",
+    ("running_release", "configured_current_release"),
+)
+def test_process_attestation_rejects_wrong_release_identity(
+    tmp_path: Path,
+    block: str,
+    field: str,
+) -> None:
+    fixture = _status_fixture(tmp_path)
+    status = dict(fixture["status"])
+    status[field] = str(tmp_path / "app" / "releases" / "wrong")
+    Path(fixture["response"]).write_text(json.dumps(status), encoding="utf-8")
+
+    result = _run_heredoc(
+        block,
+        fixture["response"],
+        fixture["release"],
+        fixture["commit"],
+        fixture["launcher_sha256"],
+    )
+
+    assert result.returncode == 1
+    assert "release" in result.stderr
+
+
+def _rollback_fixture(tmp_path: Path) -> dict[str, object]:
+    app_root = tmp_path / "app"
+    restored = app_root / "releases" / "legacy"
+    deployed = app_root / "releases" / "deployed"
+    deployed.mkdir(parents=True)
+    restored_commit = "d" * 40
+    deployed_commit = "e" * 40
+    legacy_prefix = restored_commit[:7]
+    launcher = b"#!/usr/bin/env bash\necho restored\n"
+    launcher_sha256 = hashlib.sha256(launcher).hexdigest()
+    versioned_launcher = restored / "ops" / "ec2" / "hub-api.sh"
+    shared_launcher = app_root / "shared" / "bin" / "hub-api"
+    _write_bytes(versioned_launcher, launcher, 0o755)
+    _write_bytes(shared_launcher, launcher, 0o755)
+    (app_root / "current").symlink_to(restored, target_is_directory=True)
+
+    legacy_fields = {
+        "release": restored.name,
+        "commit": legacy_prefix,
+        "path": str(restored),
+        "validated_at_utc": "2026-07-20T22:56:06Z",
+        "validation": "pytest 55 passed",
+        "status": "production-candidate-core",
+    }
+    legacy_raw = _state_bytes(legacy_fields)
+    legacy_state = restored / ".hub-deployment" / "LEGACY_RELEASE_STATE"
+    _write_bytes(legacy_state, legacy_raw, 0o400)
+    adopted_fields = {
+        "release": restored.name,
+        "requested_ref": restored_commit,
+        "requested_ref_kind": "legacy-host-adoption",
+        "commit": restored_commit,
+        "path": str(restored),
+        "adopted_at_utc": "2026-08-02T12:00:00Z",
+        "validation_command": "not-run-during-legacy-adoption",
+        "validation_exit_code": "not-run",
+        "validation_result": (
+            "legacy validation claim not re-attested; original state retained by SHA-256"
+        ),
+        "validation_log": "not-applicable",
+        "validation_log_exit_code": "not-run",
+        "launcher_sha256": launcher_sha256,
+        "status": "adopted-legacy-current",
+        "provenance": "adopted-legacy-current-v1",
+        "legacy_state_sha256": hashlib.sha256(legacy_raw).hexdigest(),
+        "legacy_commit_prefix": legacy_prefix,
+    }
+    adopted_raw = _state_bytes(adopted_fields)
+    release_state = restored / ".hub-deployment" / "RELEASE_STATE"
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    _write_bytes(release_state, adopted_raw, 0o600)
+    _write_bytes(shared_state, adopted_raw, 0o644)
+    _write_bytes(
+        app_root / "shared" / "current_release",
+        f"{restored.name}\n".encode(),
+        0o644,
+    )
+    rollback_fields = {
+        "rolled_back_at_utc": "2026-08-02T12:10:00Z",
+        "from_release": deployed.name,
+        "from_commit": deployed_commit,
+        "to_release": restored.name,
+        "to_commit": restored_commit,
+        "to_launcher_sha256": launcher_sha256,
+    }
+    _write_bytes(
+        app_root / "shared" / "ROLLBACK_STATE",
+        _state_bytes(rollback_fields),
+        0o600,
+    )
+    _write_bytes(
+        app_root / "shared" / "last_rollback_from",
+        f"{deployed}\n".encode(),
+        0o644,
+    )
+    return {
+        "app_root": app_root,
+        "deployed": deployed,
+        "deployed_commit": deployed_commit,
+        "launcher_sha256": launcher_sha256,
+        "legacy_state": legacy_state,
+        "release_state": release_state,
+        "restored": restored,
+        "restored_commit": restored_commit,
+        "shared_launcher": shared_launcher,
+        "shared_state": shared_state,
+        "versioned_launcher": versioned_launcher,
+    }
+
+
+def test_post_rollback_disk_attestation_accepts_complete_state(
+    tmp_path: Path,
+) -> None:
+    fixture = _rollback_fixture(tmp_path)
+
+    result = _run_heredoc(
+        "PY_ROLLBACK_STATE",
+        fixture["restored"],
+        fixture["restored_commit"],
+        fixture["launcher_sha256"],
+        fixture["app_root"],
+        fixture["deployed"],
+        fixture["deployed_commit"],
+        fixture["restored_commit"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(result.stdout)
+    assert evidence["to_commit"] == fixture["restored_commit"]
+    assert evidence["to_launcher_sha256"] == fixture["launcher_sha256"]
+
+
+@pytest.mark.parametrize(
+    "invalid_case, expected_error",
+    (
+        ("state-parity", "shared and per-release rollback RELEASE_STATE differ"),
+        ("duplicate", "duplicate state field"),
+        ("malformed", "malformed state line"),
+        ("missing-field", "exact field set"),
+        ("release", "wrong release name"),
+        ("path", "wrong release path"),
+        ("legacy-evidence", "retained legacy state does not match"),
+        ("versioned-launcher", "restored shared and versioned launchers differ"),
+        ("shared-launcher", "restored shared and versioned launchers differ"),
+    ),
+)
+def test_post_rollback_disk_attestation_rejects_incomplete_or_drifted_state(
+    tmp_path: Path,
+    invalid_case: str,
+    expected_error: str,
+) -> None:
+    fixture = _rollback_fixture(tmp_path)
+    release_state = Path(fixture["release_state"])
+    shared_state = Path(fixture["shared_state"])
+    if invalid_case == "state-parity":
+        shared_state.write_bytes(shared_state.read_bytes() + b"status=drift\n")
+    elif invalid_case == "duplicate":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw + f"commit={fixture['restored_commit']}\n".encode(),
+        )
+    elif invalid_case == "malformed":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw + b"malformed-line\n",
+        )
+    elif invalid_case == "missing-field":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: b"\n".join(
+                line
+                for line in raw.splitlines()
+                if not line.startswith(b"provenance=")
+            )
+            + b"\n",
+        )
+    elif invalid_case == "release":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw.replace(
+                f"release={Path(fixture['restored']).name}\n".encode(),
+                b"release=wrong\n",
+            ),
+        )
+    elif invalid_case == "path":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw.replace(
+                f"path={fixture['restored']}\n".encode(),
+                b"path=/tmp/wrong\n",
+            ),
+        )
+    elif invalid_case == "legacy-evidence":
+        legacy_state = Path(fixture["legacy_state"])
+        legacy_state.chmod(0o600)
+        legacy_state.write_bytes(legacy_state.read_bytes() + b"drift=1\n")
+        legacy_state.chmod(0o400)
+    elif invalid_case == "versioned-launcher":
+        _write_bytes(
+            Path(fixture["versioned_launcher"]),
+            b"#!/usr/bin/env bash\necho versioned-drift\n",
+            0o755,
+        )
+    elif invalid_case == "shared-launcher":
+        _write_bytes(
+            Path(fixture["shared_launcher"]),
+            b"#!/usr/bin/env bash\necho shared-drift\n",
+            0o755,
+        )
+
+    result = _run_heredoc(
+        "PY_ROLLBACK_STATE",
+        fixture["restored"],
+        fixture["restored_commit"],
+        fixture["launcher_sha256"],
+        fixture["app_root"],
+        fixture["deployed"],
+        fixture["deployed_commit"],
+        fixture["restored_commit"],
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+def test_runbook_and_preflight_inventory_include_all_mutating_tools() -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    preflight = (ROOT / "ops" / "ec2" / "preflight-deploy.sh").read_text(
+        encoding="utf-8"
+    )
+    for command in (
+        "basename",
+        "chmod",
+        "cmp",
+        "cp",
+        "date",
+        "dirname",
+        "install",
+        "ln",
+        "mkdir",
+        "mktemp",
+        "mv",
+        "rm",
+        "rmdir",
+        "stat",
+        "tee",
+        "tr",
+    ):
+        assert command in runbook.split(")", 1)[0]
+        assert command in preflight.split("; do", 1)[0]


### PR DESCRIPTION
## Summary

Make the EC2 release switch recoverable and bind disk/process evidence to the exact reviewed release before #1831 is allowed to touch the host.

- transactionally restore `current`, shared launcher, shared/per-release state, pointers and evidence after any post-mutation failure;
- bind `/status` to the full process-start commit, exact release and launcher SHA-256 instead of inferring identity from a mutable symlink;
- add fail-closed preflight for tooling, egress, disk, inodes, memory, load, managed paths and rollback usability;
- add explicit one-time adoption of the audited legacy release `9d677199...`, preserving its original state byte-for-byte as mode `0400`;
- reject malformed, duplicate or divergent release-state fields and require byte-identical versioned/shared launchers;
- add allowlisted smoke evidence that requires curl success, HTTP 200, `status=ok`, `verification_status=unreviewed` and non-empty extracted text;
- fully attest disk state and the restarted process after rollback.

Closes #1832 after merge.

## Review history

The first independent review found six deployment/recovery defects. A second adversarial review found gaps in launcher and state attestation. All findings were fixed with negative regressions. Final independent result: **PUBLISH**, with no remaining HIGH or CRITICAL findings.

The remote commit is a single tree-equivalent publication of reviewed local commit `0b3d8a5`.

## Validation

- full suite: `719 passed, 12 skipped` (PowerShell unavailable in the Linux runner environment);
- focused EC2 suite: `74 passed`;
- benchmarks: `3/3`;
- Bash syntax for scripts and all seven runbook fences: clean;
- Python heredoc AST, `py_compile`, mojibake, narrative and `git diff --check`: clean;
- published Git tree exactly matches the independently reviewed local tree;
- remote commit `9ffb898`: CI, Kernel Guard, Link Check and PR Safety all passed.

## Deployment boundary

This PR changes repository code and runbooks only. It does **not** authorize or perform:

- EC2 deployment, restart, rollback or host mutation;
- DNS, TLS, NGINX, Security Group or public API changes;
- credentials, secrets, tenant values or host identifiers in GitHub or chat.

Keep this PR draft pending explicit human approval. After merge, #1831 must be repinned to the resulting exact `main` SHA and the real host must be reattested in a controlled session before #1844/#1835 can be deployed.