### PR TITLE
fix(ec2): close post-merge deployment gaps

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -118,6 +118,14 @@ These scripts remain a manually installed EC2 backend layer. Repository tests
 exercise their isolated contracts; only a reviewed deployment and runtime
 inspection can attest the state of a real EC2 host.
 
+Post-merge review of PR #1847 adds three fail-closed requirements before the
+blocked host operation in #1831 may resume: `/analyze` must execute `hub-core`
+from the configured application root, preflight must reject every malformed,
+duplicate, missing, or unsupported release-state field, and disk attestation
+must bind `validation_result` to the final non-empty line of the recorded
+validation log. AWS mutation remains blocked until the corrective PR is merged
+and #1831 is repinned to that exact reviewed `main` SHA.
+
 Issue #1832 hardens that boundary before the blocked host operation in #1831:
 
 - the confirmed legacy current release has a separate, explicit adoption

--- a/ops/ec2/ISSUE_1831_RUNBOOK.md
+++ b/ops/ec2/ISSUE_1831_RUNBOOK.md
@@ -231,6 +231,20 @@ expected_validation_log = deployed / ".hub-deployment" / "validation.log"
 if state["validation_log"] != str(expected_validation_log):
     raise SystemExit("release-state validation log path differs")
 require_regular(expected_validation_log, mode=0o600)
+try:
+    validation_lines = expected_validation_log.read_text(
+        encoding="utf-8"
+    ).splitlines()
+except UnicodeDecodeError as exc:
+    raise SystemExit("validation log is not UTF-8") from exc
+actual_validation_result = next(
+    (line for line in reversed(validation_lines) if line.strip()),
+    None,
+)
+if actual_validation_result is None:
+    raise SystemExit("validation log has no non-empty result line")
+if state["validation_result"] != actual_validation_result:
+    raise SystemExit("validation result does not match validation log")
 if not re.fullmatch(r"[0-9a-f]{64}", state["launcher_sha256"]):
     raise SystemExit("launcher identity is missing")
 if state["status"] != "production-candidate-core":

--- a/ops/ec2/adopt-legacy-current.sh
+++ b/ops/ec2/adopt-legacy-current.sh
@@ -290,7 +290,7 @@ validate_complete_adoption() {
   local recorded_legacy_sha256
 
   validate_adopted_state "$CURRENT_DEPLOYMENT_STATE"
-  cmp -s "$CURRENT_DEPLOYMENT_STATE" "$LEGACY_STATE" \
+  cmp -s "$CURRENT_DEPLOYMENT_STATE" "$SHARED_RELEASE_STATE" \
     || fail "Shared release state differs from the adopted current state."
   validate_legacy_state "$CURRENT_LEGACY_STATE"
   [ "$(stat -c '%a' "$CURRENT_LEGACY_STATE")" = "400" ] \
@@ -395,8 +395,8 @@ CURRENT_MARKER_FILE="$APP_ROOT/shared/current_release"
 [ "$(cat "$CURRENT_MARKER_FILE")" = "$CURRENT_RELEASE_ID" ] \
   || fail "Current-release marker does not match the current symlink."
 
-LEGACY_STATE="$APP_ROOT/shared/RELEASE_STATE"
-[ -f "$LEGACY_STATE" ] && [ ! -L "$LEGACY_STATE" ] \
+SHARED_RELEASE_STATE="$APP_ROOT/shared/RELEASE_STATE"
+[ -f "$SHARED_RELEASE_STATE" ] && [ ! -L "$SHARED_RELEASE_STATE" ] \
   || fail "Shared release state is not one regular file."
 CURRENT_DEPLOYMENT_DIR="$CURRENT_RELEASE/.hub-deployment"
 CURRENT_DEPLOYMENT_STATE="$CURRENT_DEPLOYMENT_DIR/RELEASE_STATE"
@@ -419,9 +419,9 @@ fi
 [ ! -e "$CURRENT_DEPLOYMENT_DIR" ] \
   || fail "Current deployment directory exists without an adopted release state."
 
-validate_legacy_state "$LEGACY_STATE"
-LEGACY_COMMIT="$(required_state_value "$LEGACY_STATE" "commit")"
-LEGACY_STATE_SHA256="$(sha256_file "$LEGACY_STATE")"
+validate_legacy_state "$SHARED_RELEASE_STATE"
+LEGACY_COMMIT="$(required_state_value "$SHARED_RELEASE_STATE" "commit")"
+LEGACY_STATE_SHA256="$(sha256_file "$SHARED_RELEASE_STATE")"
 
 ADOPTION_WORK_DIR="$(
   mktemp -d "$APP_ROOT/shared/legacy-adoption.$(date -u +%Y%m%dT%H%M%SZ).XXXXXX"
@@ -459,7 +459,7 @@ install -m 0644 \
   "$TRANSACTION_DIR/RELEASE_STATE.source" \
   "$TRANSACTION_DIR/shared-RELEASE_STATE"
 install -m 0400 \
-  "$LEGACY_STATE" \
+  "$SHARED_RELEASE_STATE" \
   "$TRANSACTION_DIR/LEGACY_RELEASE_STATE"
 
 cp -a -- "$CURRENT_GIT_EXCLUDE" "$TRANSACTION_DIR/git-exclude"
@@ -477,7 +477,7 @@ snapshot_item "$APP_ROOT/current" "current-symlink"
 snapshot_item "$SHARED_LAUNCHER" "shared-launcher"
 snapshot_item "$APP_ROOT/shared/previous_release" "previous-release-pointer"
 snapshot_item "$CURRENT_MARKER_FILE" "current-release-marker"
-snapshot_item "$LEGACY_STATE" "shared-release-state"
+snapshot_item "$SHARED_RELEASE_STATE" "shared-release-state"
 snapshot_item "$CURRENT_DEPLOYMENT_STATE" "current-release-state"
 snapshot_item "$CURRENT_LEGACY_STATE" "legacy-release-state"
 snapshot_item "$CURRENT_GIT_EXCLUDE" "current-git-exclude"

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -54,6 +54,138 @@ required_state_value() {
   state_value "$state_file" "$key"
 }
 
+validate_exact_state_keys() {
+  local state_file="$1"
+  shift
+  local allowed=" $* "
+  local line
+  local key
+  local expected_count="$#"
+  local actual_count=0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    actual_count=$((actual_count + 1))
+    [[ "$line" == *=* ]] \
+      || fail "$state_file contains a malformed state line."
+    key="${line%%=*}"
+    case "$allowed" in
+      *" $key "*) ;;
+      *) fail "$state_file contains an unsupported field: $key" ;;
+    esac
+  done < "$state_file"
+
+  for key in "$@"; do
+    required_state_value "$state_file" "$key" >/dev/null
+  done
+  [ "$actual_count" -eq "$expected_count" ] \
+    || fail "$state_file does not contain the exact expected field set."
+}
+
+validate_release_state_schema() {
+  local state_file="$1"
+  local requested_ref_kind
+  local provenance_count
+  local legacy_commit_prefix
+  local legacy_state_sha256
+  local recorded_commit
+
+  requested_ref_kind="$(
+    required_state_value "$state_file" "requested_ref_kind"
+  )"
+  case "$requested_ref_kind" in
+    commit|tag)
+      provenance_count="$(
+        grep -c '^provenance=' "$state_file" 2>/dev/null || true
+      )"
+      case "$provenance_count" in
+        0)
+          validate_exact_state_keys \
+            "$state_file" \
+            release requested_ref requested_ref_kind commit path \
+            validated_at_utc validation_command validation_exit_code \
+            validation_result validation_log validation_log_exit_code \
+            launcher_sha256 status
+          ;;
+        1)
+          [ "$(required_state_value "$state_file" "provenance")" \
+            = "adopted-pre-1832" ] \
+            || fail "$state_file has unsupported transitional provenance."
+          validate_exact_state_keys \
+            "$state_file" \
+            release requested_ref requested_ref_kind commit path \
+            validated_at_utc validation_command validation_exit_code \
+            validation_result validation_log validation_log_exit_code \
+            launcher_sha256 status provenance
+          ;;
+        *)
+          fail "$state_file contains duplicate provenance fields."
+          ;;
+      esac
+      ;;
+    legacy-host-adoption)
+      validate_exact_state_keys \
+        "$state_file" \
+        release requested_ref requested_ref_kind commit path adopted_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code launcher_sha256 status provenance \
+        legacy_state_sha256 legacy_commit_prefix
+      ;;
+    *)
+      fail "$state_file has an unsupported requested_ref_kind."
+      ;;
+  esac
+
+  case "$requested_ref_kind" in
+    commit|tag)
+      [ "$(required_state_value "$state_file" "validation_command")" \
+        = "python -m pytest -q" ] \
+        || fail "$state_file has an unexpected validation command."
+      [ "$(required_state_value "$state_file" "validation_exit_code")" = "0" ] \
+        && [ "$(required_state_value "$state_file" "validation_log_exit_code")" = "0" ] \
+        || fail "$state_file does not record successful validation."
+      [ -n "$(required_state_value "$state_file" "validation_result")" ] \
+        || fail "$state_file has an empty validation result."
+      [ "$(required_state_value "$state_file" "status")" \
+        = "production-candidate-core" ] \
+        || fail "$state_file is not a production candidate."
+      ;;
+    legacy-host-adoption)
+      recorded_commit="$(required_state_value "$state_file" "commit")"
+      legacy_commit_prefix="$(
+        required_state_value "$state_file" "legacy_commit_prefix"
+      )"
+      legacy_state_sha256="$(
+        required_state_value "$state_file" "legacy_state_sha256"
+      )"
+      [ "$(required_state_value "$state_file" "requested_ref")" \
+        = "$recorded_commit" ] \
+        || fail "$state_file legacy adoption is not commit-bound."
+      [ "$(required_state_value "$state_file" "validation_command")" \
+        = "not-run-during-legacy-adoption" ] \
+        && [ "$(required_state_value "$state_file" "validation_exit_code")" \
+          = "not-run" ] \
+        && [ "$(required_state_value "$state_file" "validation_log")" \
+          = "not-applicable" ] \
+        && [ "$(required_state_value "$state_file" "validation_log_exit_code")" \
+          = "not-run" ] \
+        || fail "$state_file has invalid legacy-adoption validation metadata."
+      [ "$(required_state_value "$state_file" "status")" \
+        = "adopted-legacy-current" ] \
+        && [ "$(required_state_value "$state_file" "provenance")" \
+          = "adopted-legacy-current-v1" ] \
+        || fail "$state_file has invalid legacy-adoption provenance."
+      [[ "$legacy_state_sha256" =~ ^[0-9a-f]{64}$ ]] \
+        || fail "$state_file has an invalid legacy-state SHA-256."
+      [[ "$legacy_commit_prefix" =~ ^[0-9a-f]{7,39}$ ]] \
+        || fail "$state_file has an invalid legacy commit prefix."
+      case "$recorded_commit" in
+        "$legacy_commit_prefix"*) ;;
+        *) fail "$state_file legacy commit prefix does not match commit." ;;
+      esac
+      ;;
+  esac
+}
+
 validate_release_state() {
   local previous="$1"
   local state_file="$2"
@@ -66,6 +198,9 @@ validate_release_state() {
 
   [ -f "$state_file" ] \
     || fail "Rollback target has no deployment state: $state_file"
+  [ ! -L "$state_file" ] \
+    || fail "Rollback target deployment state must not be a symlink: $state_file"
+  validate_release_state_schema "$state_file"
 
   recorded_release="$(required_state_value "$state_file" "release")"
   recorded_commit="$(required_state_value "$state_file" "commit")"
@@ -98,7 +233,6 @@ prepare_previous_release_state() {
   local previous_commit
   local previous_launcher_sha256
   local source_state
-  local recorded_launcher_sha256
 
   previous_release="$(basename "$previous")"
   previous_commit="$(git -C "$previous" rev-parse --verify HEAD)"
@@ -122,26 +256,18 @@ prepare_previous_release_state() {
     "$previous_launcher_sha256"
 
   PREVIOUS_STATE_PATH="$previous_state"
-  recorded_launcher_sha256="$(
-    state_value "$source_state" "launcher_sha256"
-  )"
-  if [ "$source_state" = "$previous_state" ] \
-    && [ -n "$recorded_launcher_sha256" ]; then
+  if [ "$source_state" = "$previous_state" ]; then
     PREVIOUS_STATE_INSTALL_SOURCE=""
     return
   fi
 
   PREVIOUS_STATE_INSTALL_SOURCE="$DEPLOYMENT_DIR/PREVIOUS_RELEASE_STATE"
-  sed '/^launcher_sha256=/d' \
-    "$source_state" \
-    > "$PREVIOUS_STATE_INSTALL_SOURCE"
-  printf 'launcher_sha256=%s\n' "$previous_launcher_sha256" \
-    >> "$PREVIOUS_STATE_INSTALL_SOURCE"
-  if [ "$source_state" = "$shared_state" ]; then
-    printf 'provenance=adopted-pre-1832\n' \
-      >> "$PREVIOUS_STATE_INSTALL_SOURCE"
-  fi
-  chmod 0600 "$PREVIOUS_STATE_INSTALL_SOURCE"
+  install -m 0600 "$source_state" "$PREVIOUS_STATE_INSTALL_SOURCE"
+  validate_release_state \
+    "$previous" \
+    "$PREVIOUS_STATE_INSTALL_SOURCE" \
+    "$previous_commit" \
+    "$previous_launcher_sha256"
 }
 
 snapshot_item() {

--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -1544,7 +1544,7 @@ class Handler(BaseHTTPRequestHandler):
         cleanup_error: OSError | None = None
         try:
             code, stdout, stderr = run_command([
-                "/opt/hub-optimus/shared/bin/hub-core",
+                str(SHARED / "bin" / "hub-core"),
                 "analyze",
                 str(case_path),
             ])

--- a/ops/ec2/preflight-deploy.sh
+++ b/ops/ec2/preflight-deploy.sh
@@ -28,6 +28,138 @@ required_state_value() {
   sed -n "s/^${key}=//p" "$state_file"
 }
 
+validate_exact_state_keys() {
+  local state_file="$1"
+  shift
+  local allowed=" $* "
+  local line
+  local key
+  local expected_count="$#"
+  local actual_count=0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    actual_count=$((actual_count + 1))
+    [[ "$line" == *=* ]] \
+      || fail "$state_file contains a malformed state line."
+    key="${line%%=*}"
+    case "$allowed" in
+      *" $key "*) ;;
+      *) fail "$state_file contains an unsupported field: $key" ;;
+    esac
+  done < "$state_file"
+
+  for key in "$@"; do
+    required_state_value "$state_file" "$key" >/dev/null
+  done
+  [ "$actual_count" -eq "$expected_count" ] \
+    || fail "$state_file does not contain the exact expected field set."
+}
+
+validate_release_state_schema() {
+  local state_file="$1"
+  local requested_ref_kind
+  local provenance_count
+  local legacy_commit_prefix
+  local legacy_state_sha256
+  local recorded_commit
+
+  requested_ref_kind="$(
+    required_state_value "$state_file" "requested_ref_kind"
+  )"
+  case "$requested_ref_kind" in
+    commit|tag)
+      provenance_count="$(
+        grep -c '^provenance=' "$state_file" 2>/dev/null || true
+      )"
+      case "$provenance_count" in
+        0)
+          validate_exact_state_keys \
+            "$state_file" \
+            release requested_ref requested_ref_kind commit path \
+            validated_at_utc validation_command validation_exit_code \
+            validation_result validation_log validation_log_exit_code \
+            launcher_sha256 status
+          ;;
+        1)
+          [ "$(required_state_value "$state_file" "provenance")" \
+            = "adopted-pre-1832" ] \
+            || fail "$state_file has unsupported transitional provenance."
+          validate_exact_state_keys \
+            "$state_file" \
+            release requested_ref requested_ref_kind commit path \
+            validated_at_utc validation_command validation_exit_code \
+            validation_result validation_log validation_log_exit_code \
+            launcher_sha256 status provenance
+          ;;
+        *)
+          fail "$state_file contains duplicate provenance fields."
+          ;;
+      esac
+      ;;
+    legacy-host-adoption)
+      validate_exact_state_keys \
+        "$state_file" \
+        release requested_ref requested_ref_kind commit path adopted_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code launcher_sha256 status provenance \
+        legacy_state_sha256 legacy_commit_prefix
+      ;;
+    *)
+      fail "$state_file has an unsupported requested_ref_kind."
+      ;;
+  esac
+
+  case "$requested_ref_kind" in
+    commit|tag)
+      [ "$(required_state_value "$state_file" "validation_command")" \
+        = "python -m pytest -q" ] \
+        || fail "$state_file has an unexpected validation command."
+      [ "$(required_state_value "$state_file" "validation_exit_code")" = "0" ] \
+        && [ "$(required_state_value "$state_file" "validation_log_exit_code")" = "0" ] \
+        || fail "$state_file does not record successful validation."
+      [ -n "$(required_state_value "$state_file" "validation_result")" ] \
+        || fail "$state_file has an empty validation result."
+      [ "$(required_state_value "$state_file" "status")" \
+        = "production-candidate-core" ] \
+        || fail "$state_file is not a production candidate."
+      ;;
+    legacy-host-adoption)
+      recorded_commit="$(required_state_value "$state_file" "commit")"
+      legacy_commit_prefix="$(
+        required_state_value "$state_file" "legacy_commit_prefix"
+      )"
+      legacy_state_sha256="$(
+        required_state_value "$state_file" "legacy_state_sha256"
+      )"
+      [ "$(required_state_value "$state_file" "requested_ref")" \
+        = "$recorded_commit" ] \
+        || fail "$state_file legacy adoption is not commit-bound."
+      [ "$(required_state_value "$state_file" "validation_command")" \
+        = "not-run-during-legacy-adoption" ] \
+        && [ "$(required_state_value "$state_file" "validation_exit_code")" \
+          = "not-run" ] \
+        && [ "$(required_state_value "$state_file" "validation_log")" \
+          = "not-applicable" ] \
+        && [ "$(required_state_value "$state_file" "validation_log_exit_code")" \
+          = "not-run" ] \
+        || fail "$state_file has invalid legacy-adoption validation metadata."
+      [ "$(required_state_value "$state_file" "status")" \
+        = "adopted-legacy-current" ] \
+        && [ "$(required_state_value "$state_file" "provenance")" \
+          = "adopted-legacy-current-v1" ] \
+        || fail "$state_file has invalid legacy-adoption provenance."
+      [[ "$legacy_state_sha256" =~ ^[0-9a-f]{64}$ ]] \
+        || fail "$state_file has an invalid legacy-state SHA-256."
+      [[ "$legacy_commit_prefix" =~ ^[0-9a-f]{7,39}$ ]] \
+        || fail "$state_file has an invalid legacy commit prefix."
+      case "$recorded_commit" in
+        "$legacy_commit_prefix"*) ;;
+        *) fail "$state_file legacy commit prefix does not match commit." ;;
+      esac
+      ;;
+  esac
+}
+
 sha256_file() {
   local path="$1"
   local digest
@@ -83,6 +215,7 @@ validate_release() {
 
   [ -f "$state_file" ] && [ ! -L "$state_file" ] \
     || fail "Release state is not one regular file: $state_file"
+  validate_release_state_schema "$state_file"
 
   IFS=$'\t' read -r actual_commit actual_launcher_sha256 < <(
     inspect_release_directory "$release_path"

--- a/ops/ec2/rollback-current.sh
+++ b/ops/ec2/rollback-current.sh
@@ -25,6 +25,138 @@ required_state_value() {
   state_value "$state_file" "$key"
 }
 
+validate_exact_state_keys() {
+  local state_file="$1"
+  shift
+  local allowed=" $* "
+  local line
+  local key
+  local expected_count="$#"
+  local actual_count=0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    actual_count=$((actual_count + 1))
+    [[ "$line" == *=* ]] \
+      || fail "$state_file contains a malformed state line."
+    key="${line%%=*}"
+    case "$allowed" in
+      *" $key "*) ;;
+      *) fail "$state_file contains an unsupported field: $key" ;;
+    esac
+  done < "$state_file"
+
+  for key in "$@"; do
+    required_state_value "$state_file" "$key" >/dev/null
+  done
+  [ "$actual_count" -eq "$expected_count" ] \
+    || fail "$state_file does not contain the exact expected field set."
+}
+
+validate_release_state_schema() {
+  local state_file="$1"
+  local requested_ref_kind
+  local provenance_count
+  local legacy_commit_prefix
+  local legacy_state_sha256
+  local recorded_commit
+
+  requested_ref_kind="$(
+    required_state_value "$state_file" "requested_ref_kind"
+  )"
+  case "$requested_ref_kind" in
+    commit|tag)
+      provenance_count="$(
+        grep -c '^provenance=' "$state_file" 2>/dev/null || true
+      )"
+      case "$provenance_count" in
+        0)
+          validate_exact_state_keys \
+            "$state_file" \
+            release requested_ref requested_ref_kind commit path \
+            validated_at_utc validation_command validation_exit_code \
+            validation_result validation_log validation_log_exit_code \
+            launcher_sha256 status
+          ;;
+        1)
+          [ "$(required_state_value "$state_file" "provenance")" \
+            = "adopted-pre-1832" ] \
+            || fail "$state_file has unsupported transitional provenance."
+          validate_exact_state_keys \
+            "$state_file" \
+            release requested_ref requested_ref_kind commit path \
+            validated_at_utc validation_command validation_exit_code \
+            validation_result validation_log validation_log_exit_code \
+            launcher_sha256 status provenance
+          ;;
+        *)
+          fail "$state_file contains duplicate provenance fields."
+          ;;
+      esac
+      ;;
+    legacy-host-adoption)
+      validate_exact_state_keys \
+        "$state_file" \
+        release requested_ref requested_ref_kind commit path adopted_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code launcher_sha256 status provenance \
+        legacy_state_sha256 legacy_commit_prefix
+      ;;
+    *)
+      fail "$state_file has an unsupported requested_ref_kind."
+      ;;
+  esac
+
+  case "$requested_ref_kind" in
+    commit|tag)
+      [ "$(required_state_value "$state_file" "validation_command")" \
+        = "python -m pytest -q" ] \
+        || fail "$state_file has an unexpected validation command."
+      [ "$(required_state_value "$state_file" "validation_exit_code")" = "0" ] \
+        && [ "$(required_state_value "$state_file" "validation_log_exit_code")" = "0" ] \
+        || fail "$state_file does not record successful validation."
+      [ -n "$(required_state_value "$state_file" "validation_result")" ] \
+        || fail "$state_file has an empty validation result."
+      [ "$(required_state_value "$state_file" "status")" \
+        = "production-candidate-core" ] \
+        || fail "$state_file is not a production candidate."
+      ;;
+    legacy-host-adoption)
+      recorded_commit="$(required_state_value "$state_file" "commit")"
+      legacy_commit_prefix="$(
+        required_state_value "$state_file" "legacy_commit_prefix"
+      )"
+      legacy_state_sha256="$(
+        required_state_value "$state_file" "legacy_state_sha256"
+      )"
+      [ "$(required_state_value "$state_file" "requested_ref")" \
+        = "$recorded_commit" ] \
+        || fail "$state_file legacy adoption is not commit-bound."
+      [ "$(required_state_value "$state_file" "validation_command")" \
+        = "not-run-during-legacy-adoption" ] \
+        && [ "$(required_state_value "$state_file" "validation_exit_code")" \
+          = "not-run" ] \
+        && [ "$(required_state_value "$state_file" "validation_log")" \
+          = "not-applicable" ] \
+        && [ "$(required_state_value "$state_file" "validation_log_exit_code")" \
+          = "not-run" ] \
+        || fail "$state_file has invalid legacy-adoption validation metadata."
+      [ "$(required_state_value "$state_file" "status")" \
+        = "adopted-legacy-current" ] \
+        && [ "$(required_state_value "$state_file" "provenance")" \
+          = "adopted-legacy-current-v1" ] \
+        || fail "$state_file has invalid legacy-adoption provenance."
+      [[ "$legacy_state_sha256" =~ ^[0-9a-f]{64}$ ]] \
+        || fail "$state_file has an invalid legacy-state SHA-256."
+      [[ "$legacy_commit_prefix" =~ ^[0-9a-f]{7,39}$ ]] \
+        || fail "$state_file has an invalid legacy commit prefix."
+      case "$recorded_commit" in
+        "$legacy_commit_prefix"*) ;;
+        *) fail "$state_file legacy commit prefix does not match commit." ;;
+      esac
+      ;;
+  esac
+}
+
 sha256_file() {
   local path="$1"
   local digest
@@ -208,11 +340,12 @@ if [ "$CURRENT" = "$PREVIOUS" ]; then
 fi
 
 PREVIOUS_STATE="$PREVIOUS/.hub-deployment/RELEASE_STATE"
-[ -f "$PREVIOUS_STATE" ] \
+[ -f "$PREVIOUS_STATE" ] && [ ! -L "$PREVIOUS_STATE" ] \
   || fail "Previous release has no recorded deployment state: $PREVIOUS_STATE"
 [ -f "$PREVIOUS/ops/ec2/hub-api.sh" ] \
   || fail "Previous release has no hub-api launcher: $PREVIOUS/ops/ec2/hub-api.sh"
 
+validate_release_state_schema "$PREVIOUS_STATE"
 RECORDED_COMMIT="$(required_state_value "$PREVIOUS_STATE" "commit")"
 RECORDED_PATH="$(required_state_value "$PREVIOUS_STATE" "path")"
 RECORDED_RELEASE="$(required_state_value "$PREVIOUS_STATE" "release")"

--- a/tests/semantic_engine/test_case_input_validation.py
+++ b/tests/semantic_engine/test_case_input_validation.py
@@ -204,6 +204,6 @@ def test_operator_and_api_handoff_reach_the_same_cli_contract():
     core = (ROOT / "ops" / "ec2" / "hub-core.sh").read_text(encoding="utf-8")
 
     assert "http://127.0.0.1:8080/analyze" in operator
-    assert '"/opt/hub-optimus/shared/bin/hub-core"' in api
+    assert 'str(SHARED / "bin" / "hub-core")' in api
     assert '"analyze"' in api
     assert "python -m semantic_engine.cli analyze" in core

--- a/tests/test_ec2_legacy_adoption.py
+++ b/tests/test_ec2_legacy_adoption.py
@@ -280,6 +280,68 @@ def test_preflight_inventories_unattested_historical_pointer(
 
 
 @pytest.mark.parametrize(
+    "corruption, expected_error",
+    (
+        ("status=duplicate", "exactly one status field"),
+        ("malformed-state-line", "contains a malformed state line"),
+    ),
+)
+def test_preflight_rejects_matching_malformed_release_states(
+    tmp_path: Path,
+    corruption: str,
+    expected_error: str,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    adopted = _run([ADOPT, commit], env=env)
+    assert adopted.returncode == 0, adopted.stderr
+
+    release_state = release / ".hub-deployment" / "RELEASE_STATE"
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    corrupted = release_state.read_text(encoding="utf-8") + f"{corruption}\n"
+    release_state.write_text(corrupted, encoding="utf-8")
+    shared_state.write_text(corrupted, encoding="utf-8")
+
+    fake_bin = tmp_path / "preflight-schema-bin"
+    fake_bin.mkdir()
+    for command_name in ("sudo", "systemctl"):
+        _write_executable(fake_bin / command_name, "#!/usr/bin/env bash\nexit 0\n")
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run([PREFLIGHT, "f" * 40, "https://example.com/article"], env=env)
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+def test_preflight_rejects_forged_legacy_adoption_provenance(
+    tmp_path: Path,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    adopted = _run([ADOPT, commit], env=env)
+    assert adopted.returncode == 0, adopted.stderr
+
+    release_state = release / ".hub-deployment" / "RELEASE_STATE"
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    forged = release_state.read_text(encoding="utf-8").replace(
+        "provenance=adopted-legacy-current-v1",
+        "provenance=forged-but-schema-valid",
+    )
+    release_state.write_text(forged, encoding="utf-8")
+    shared_state.write_text(forged, encoding="utf-8")
+
+    fake_bin = tmp_path / "preflight-provenance-bin"
+    fake_bin.mkdir()
+    for command_name in ("sudo", "systemctl"):
+        _write_executable(fake_bin / command_name, "#!/usr/bin/env bash\nexit 0\n")
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run([PREFLIGHT, "f" * 40, "https://example.com/article"], env=env)
+
+    assert result.returncode == 1
+    assert "invalid legacy-adoption provenance" in result.stderr
+
+
+@pytest.mark.parametrize(
     "stage",
     (
         "git-exclude",

--- a/tests/test_ec2_preflight_and_evidence.py
+++ b/tests/test_ec2_preflight_and_evidence.py
@@ -13,6 +13,7 @@ RUNBOOK = ROOT / "ops" / "ec2" / "ISSUE_1831_RUNBOOK.md"
 
 def test_host_preflight_is_noninteractive_and_fails_closed() -> None:
     text = PREFLIGHT.read_text(encoding="utf-8")
+    command_inventory = text.split("for command_name in", 1)[1].split("; do", 1)[0]
 
     assert "MIN_DISK_KIB=3145728" in text
     assert "MIN_FREE_INODES=50000" in text
@@ -43,7 +44,7 @@ def test_host_preflight_is_noninteractive_and_fails_closed() -> None:
         "tee",
         "tr",
     ):
-        assert command_name in text.split("; do", 1)[0]
+        assert command_name in command_inventory
     assert "systemctl restart" not in text
 
 

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -9,6 +9,8 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 HUB_CORE = ROOT / "ops" / "ec2" / "hub-core.sh"
@@ -241,10 +243,7 @@ def test_api_uses_its_own_run_marker_and_cleans_private_input(
         input_text: str | None = None,
     ) -> tuple[int, str, str]:
         assert input_text is None
-        assert args[:2] == [
-            "/opt/hub-optimus/shared/bin/hub-core",
-            "analyze",
-        ]
+        assert args[:2] == [str(shared / "bin" / "hub-core"), "analyze"]
         case_path = Path(args[2])
         seen_case_paths.append(case_path)
         assert case_path.name.startswith("case-")
@@ -861,6 +860,124 @@ def test_invalid_rollback_target_state_fails_before_mutation(
     assert "Rollback target commit does not match" in result.stderr
     assert "Restoring exact pre-deploy" not in result.stderr
     assert _operational_snapshot(app_root) == before
+
+
+@pytest.mark.parametrize(
+    "operation, corruption, expected_error",
+    (
+        ("deploy", "status=duplicate", "exactly one status field"),
+        ("deploy", "malformed-state-line", "contains a malformed state line"),
+        ("rollback", "status=duplicate", "exactly one status field"),
+        ("rollback", "malformed-state-line", "contains a malformed state line"),
+    ),
+)
+def test_deploy_and_rollback_reject_malformed_target_state_before_mutation(
+    tmp_path: Path,
+    operation: str,
+    corruption: str,
+    expected_error: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    target_release = (app_root / "current").resolve()
+    target_state = target_release / ".hub-deployment" / "RELEASE_STATE"
+    if operation == "rollback":
+        second = _run([DEPLOY, head_commit], env=env)
+        assert second.returncode == 0, second.stderr
+    corrupted = target_state.read_text(encoding="utf-8") + f"{corruption}\n"
+    target_state.write_text(corrupted, encoding="utf-8")
+    if operation == "deploy":
+        (app_root / "shared" / "RELEASE_STATE").write_text(
+            corrupted,
+            encoding="utf-8",
+        )
+    before = _operational_snapshot(app_root)
+
+    command = [DEPLOY, head_commit] if operation == "deploy" else [ROLLBACK]
+    result = _run(command, env=env)
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+    assert "Restoring exact pre-" not in result.stderr
+    assert _operational_snapshot(app_root) == before
+    assert not list((app_root / "shared").glob("rollback-transaction.*"))
+
+
+@pytest.mark.parametrize("schema_kind", ("normal", "transitional", "adopted"))
+def test_reconstructed_release_state_survives_deploy_rollback_round_trip(
+    tmp_path: Path,
+    schema_kind: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    first_release = (app_root / "current").resolve()
+    first_state_path = first_release / ".hub-deployment" / "RELEASE_STATE"
+    fields = _state(first_state_path)
+    if schema_kind == "transitional":
+        fields["provenance"] = "adopted-pre-1832"
+    elif schema_kind == "adopted":
+        legacy_raw = (
+            f"release={first_release.name}\n"
+            f"commit={reviewed_commit[:7]}\n"
+            f"path={first_release}\n"
+            "validated_at_utc=2026-07-20T22:56:06Z\n"
+            "validation=pytest 55 passed\n"
+            "status=production-candidate-core\n"
+        ).encode()
+        legacy_evidence = first_release / ".hub-deployment" / "LEGACY_RELEASE_STATE"
+        legacy_evidence.write_bytes(legacy_raw)
+        legacy_evidence.chmod(0o400)
+        fields = {
+            "release": first_release.name,
+            "requested_ref": reviewed_commit,
+            "requested_ref_kind": "legacy-host-adoption",
+            "commit": reviewed_commit,
+            "path": str(first_release),
+            "adopted_at_utc": "2026-08-03T12:00:00Z",
+            "validation_command": "not-run-during-legacy-adoption",
+            "validation_exit_code": "not-run",
+            "validation_result": (
+                "legacy validation claim not re-attested; original state retained "
+                "by SHA-256"
+            ),
+            "validation_log": "not-applicable",
+            "validation_log_exit_code": "not-run",
+            "launcher_sha256": fields["launcher_sha256"],
+            "status": "adopted-legacy-current",
+            "provenance": "adopted-legacy-current-v1",
+            "legacy_state_sha256": hashlib.sha256(legacy_raw).hexdigest(),
+            "legacy_commit_prefix": reviewed_commit[:7],
+        }
+    expected_raw = "".join(f"{key}={value}\n" for key, value in fields.items())
+    (app_root / "shared" / "RELEASE_STATE").write_text(
+        expected_raw,
+        encoding="utf-8",
+    )
+    first_state_path.unlink()
+
+    second = _run([DEPLOY, head_commit], env=env)
+    assert second.returncode == 0, second.stderr
+    assert first_state_path.read_text(encoding="utf-8") == expected_raw
+
+    rolled_back = _run([ROLLBACK], env=env)
+
+    assert rolled_back.returncode == 0, rolled_back.stderr
+    assert (app_root / "current").resolve() == first_release
+    assert (app_root / "shared" / "RELEASE_STATE").read_text(
+        encoding="utf-8"
+    ) == expected_raw
 
 
 def test_failed_validation_is_recorded_without_switching_current(

--- a/tests/test_ec2_runbook_attestation.py
+++ b/tests/test_ec2_runbook_attestation.py
@@ -66,7 +66,7 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
 
     deployment_dir = release / ".hub-deployment"
     validation_log = deployment_dir / "validation.log"
-    _write_bytes(validation_log, b"692 passed\n", 0o600)
+    _write_bytes(validation_log, b"692 passed in 30.45s\n", 0o600)
     fields = {
         "release": release.name,
         "requested_ref": commit,
@@ -130,6 +130,8 @@ def test_post_deploy_disk_attestation_accepts_exact_release(tmp_path: Path) -> N
         ("extra-field", "exact field set"),
         ("release", "wrong release name"),
         ("path", "wrong release path"),
+        ("validation-log-empty", "no non-empty result line"),
+        ("validation-log-drift", "validation result does not match validation log"),
         ("state-launcher", "launcher hashes do not match"),
         ("versioned-launcher", "shared and versioned launchers differ"),
         ("shared-launcher", "shared and versioned launchers differ"),
@@ -181,6 +183,12 @@ def test_post_deploy_disk_attestation_rejects_every_identity_drift(
                 b"path=/tmp/wrong\n",
             ),
         )
+    elif invalid_case == "validation-log-empty":
+        validation_log = Path(fixture["release"]) / ".hub-deployment" / "validation.log"
+        validation_log.write_text("\n \n", encoding="utf-8")
+    elif invalid_case == "validation-log-drift":
+        validation_log = Path(fixture["release"]) / ".hub-deployment" / "validation.log"
+        validation_log.write_text("691 passed in 30.45s\n", encoding="utf-8")
     elif invalid_case == "state-launcher":
         _replace_state_pair(
             release_state,
@@ -501,6 +509,9 @@ def test_runbook_and_preflight_inventory_include_all_mutating_tools() -> None:
     preflight = (ROOT / "ops" / "ec2" / "preflight-deploy.sh").read_text(
         encoding="utf-8"
     )
+    command_inventory = preflight.split("for command_name in", 1)[1].split(
+        "; do", 1
+    )[0]
     for command in (
         "basename",
         "chmod",
@@ -520,4 +531,4 @@ def test_runbook_and_preflight_inventory_include_all_mutating_tools() -> None:
         "tr",
     ):
         assert command in runbook.split(")", 1)[0]
-        assert command in preflight.split("; do", 1)[0]
+        assert command in command_inventory


### PR DESCRIPTION
## Summary

Closes the three post-merge P2 deployment gaps reported after #1847 and hardens the same boundary against direct-script bypasses.

- honor the configured HUB core root in `/analyze`
- require exact release-state schemas in preflight, deploy, and rollback
- bind `validation_result` to the final non-empty validation-log line
- preserve legacy-adoption state byte-for-byte through deploy and rollback
- clarify shared release state versus retained legacy evidence
- add regression coverage for normal, transient, and legacy-adoption states

## Root cause

The #1847 review findings landed after merge. The original checks validated important identities, but some paths still accepted malformed state, relied on a fixed core path, or did not cryptographically/semantically bind the recorded validation result to the log evidence.

## Validation

- 731 tests passed
- 12 PowerShell-only tests skipped because PowerShell is unavailable locally
- 96 focused EC2 tests passed
- Bash syntax, mojibake scan, and `git diff --check` passed
- independent adversarial review: PUBLISH, no blocking findings
- reconstructed Git tree: `35d72c3a3014706f2e01e4019430aadca990a46a`, exactly matching reviewed local commit `e827555880cb52a093af7aeb2cb4e5543749adb6`

## Operational boundary

AWS remains blocked under #1831. This draft PR does not authorize deployment, restart, DNS, TLS, Security Group, OIDC, or any AWS mutation.