### PR TITLE
fix(ec2): honor configured root for analyze

### DIFF
--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -1544,7 +1544,7 @@ class Handler(BaseHTTPRequestHandler):
         cleanup_error: OSError | None = None
         try:
             code, stdout, stderr = run_command([
-                "/opt/hub-optimus/shared/bin/hub-core",
+                str(SHARED / "bin" / "hub-core"),
                 "analyze",
                 str(case_path),
             ])

--- a/tests/semantic_engine/test_case_input_validation.py
+++ b/tests/semantic_engine/test_case_input_validation.py
@@ -204,6 +204,7 @@ def test_operator_and_api_handoff_reach_the_same_cli_contract():
     core = (ROOT / "ops" / "ec2" / "hub-core.sh").read_text(encoding="utf-8")
 
     assert "http://127.0.0.1:8080/analyze" in operator
-    assert '"/opt/hub-optimus/shared/bin/hub-core"' in api
+    assert 'str(SHARED / "bin" / "hub-core")' in api
+    assert '"/opt/hub-optimus/shared/bin/hub-core"' not in api
     assert '"analyze"' in api
     assert "python -m semantic_engine.cli analyze" in core

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -241,10 +241,7 @@ def test_api_uses_its_own_run_marker_and_cleans_private_input(
         input_text: str | None = None,
     ) -> tuple[int, str, str]:
         assert input_text is None
-        assert args[:2] == [
-            "/opt/hub-optimus/shared/bin/hub-core",
-            "analyze",
-        ]
+        assert args[:2] == [str(shared / "bin" / "hub-core"), "analyze"]
         case_path = Path(args[2])
         seen_case_paths.append(case_path)
         assert case_path.name.startswith("case-")


### PR DESCRIPTION
## Decision

Address only the configured-root `/analyze` P2 from #1848. This draft does not close #1848; the release-state and validation-log findings remain separate PRs.

## What changed

- derive `hub-core` from the API's configured `SHARED` directory;
- add behavioral coverage with a non-default application root;
- prohibit the former hard-coded production path in the static contract.

## Root cause and impact

The embedded API honored `HUB_OPTIMUS_APP_ROOT` for request files and run results but invoked `hub-core` from `/opt/hub-optimus`. Staging or isolated roots could therefore execute the production-root core or look for results under a different tree.

## Files changed

- `ops/ec2/hub-api.sh`
- `tests/test_ec2_run_identity_and_provenance.py`
- `tests/semantic_engine/test_case_input_validation.py`

## Validation

- full pytest: **719 passed, 12 skipped**; skips are the existing PowerShell-only cases;
- focused affected tests: **31 passed**;
- frozen benchmarks: **3/3 passed**;
- `bash -n ops/ec2/hub-api.sh`: passed;
- mojibake and `git diff --check`: passed;
- independent review: **PUBLISH**, no blocker.

## Handoff and deployment boundary

`docs/context/AI_HANDOFF.md` is not changed in this narrow slice because the overall operational block is unchanged and #1848 still has two unresolved P2s.

This PR performs no EC2 mutation, restart, rollback, DNS, TLS, nginx, Security Group, OIDC or public-API change. #1831 remains blocked and must not be repinned from this PR alone.

Related review thread: https://github.com/Voxterrae/HUB_Optimus/pull/1847#discussion_r3706632033