### PR TITLE
fix(ec2): validate release state exactly

### DIFF
--- a/ops/ec2/adopt-legacy-current.sh
+++ b/ops/ec2/adopt-legacy-current.sh
@@ -290,7 +290,7 @@ validate_complete_adoption() {
   local recorded_legacy_sha256
 
   validate_adopted_state "$CURRENT_DEPLOYMENT_STATE"
-  cmp -s "$CURRENT_DEPLOYMENT_STATE" "$LEGACY_STATE" \
+  cmp -s "$CURRENT_DEPLOYMENT_STATE" "$SHARED_STATE" \
     || fail "Shared release state differs from the adopted current state."
   validate_legacy_state "$CURRENT_LEGACY_STATE"
   [ "$(stat -c '%a' "$CURRENT_LEGACY_STATE")" = "400" ] \
@@ -395,8 +395,8 @@ CURRENT_MARKER_FILE="$APP_ROOT/shared/current_release"
 [ "$(cat "$CURRENT_MARKER_FILE")" = "$CURRENT_RELEASE_ID" ] \
   || fail "Current-release marker does not match the current symlink."
 
-LEGACY_STATE="$APP_ROOT/shared/RELEASE_STATE"
-[ -f "$LEGACY_STATE" ] && [ ! -L "$LEGACY_STATE" ] \
+SHARED_STATE="$APP_ROOT/shared/RELEASE_STATE"
+[ -f "$SHARED_STATE" ] && [ ! -L "$SHARED_STATE" ] \
   || fail "Shared release state is not one regular file."
 CURRENT_DEPLOYMENT_DIR="$CURRENT_RELEASE/.hub-deployment"
 CURRENT_DEPLOYMENT_STATE="$CURRENT_DEPLOYMENT_DIR/RELEASE_STATE"
@@ -419,9 +419,9 @@ fi
 [ ! -e "$CURRENT_DEPLOYMENT_DIR" ] \
   || fail "Current deployment directory exists without an adopted release state."
 
-validate_legacy_state "$LEGACY_STATE"
-LEGACY_COMMIT="$(required_state_value "$LEGACY_STATE" "commit")"
-LEGACY_STATE_SHA256="$(sha256_file "$LEGACY_STATE")"
+validate_legacy_state "$SHARED_STATE"
+LEGACY_COMMIT="$(required_state_value "$SHARED_STATE" "commit")"
+LEGACY_STATE_SHA256="$(sha256_file "$SHARED_STATE")"
 
 ADOPTION_WORK_DIR="$(
   mktemp -d "$APP_ROOT/shared/legacy-adoption.$(date -u +%Y%m%dT%H%M%SZ).XXXXXX"
@@ -459,7 +459,7 @@ install -m 0644 \
   "$TRANSACTION_DIR/RELEASE_STATE.source" \
   "$TRANSACTION_DIR/shared-RELEASE_STATE"
 install -m 0400 \
-  "$LEGACY_STATE" \
+  "$SHARED_STATE" \
   "$TRANSACTION_DIR/LEGACY_RELEASE_STATE"
 
 cp -a -- "$CURRENT_GIT_EXCLUDE" "$TRANSACTION_DIR/git-exclude"
@@ -477,7 +477,7 @@ snapshot_item "$APP_ROOT/current" "current-symlink"
 snapshot_item "$SHARED_LAUNCHER" "shared-launcher"
 snapshot_item "$APP_ROOT/shared/previous_release" "previous-release-pointer"
 snapshot_item "$CURRENT_MARKER_FILE" "current-release-marker"
-snapshot_item "$LEGACY_STATE" "shared-release-state"
+snapshot_item "$SHARED_STATE" "shared-release-state"
 snapshot_item "$CURRENT_DEPLOYMENT_STATE" "current-release-state"
 snapshot_item "$CURRENT_LEGACY_STATE" "legacy-release-state"
 snapshot_item "$CURRENT_GIT_EXCLUDE" "current-git-exclude"

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -5,6 +5,8 @@ APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 REPO_URL="${HUB_OPTIMUS_REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
 DEPLOY_REF="${1:-}"
 VALIDATION_COMMAND_TEXT="python -m pytest -q"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"
 
 usage() {
   cat <<USAGE
@@ -21,6 +23,15 @@ USAGE
 fail() {
   echo "[deploy:error] $*" >&2
   exit 1
+}
+
+validate_release_state_schema() {
+  local state_file="$1"
+
+  [ -f "$STATE_VALIDATOR" ] && [ ! -L "$STATE_VALIDATOR" ] \
+    || fail "Release-state validator is not one regular file: $STATE_VALIDATOR"
+  bash "$STATE_VALIDATOR" "$state_file" >/dev/null \
+    || fail "Complete release-state validation failed: $state_file"
 }
 
 sha256_file() {
@@ -64,8 +75,9 @@ validate_release_state() {
   local recorded_path
   local recorded_launcher_sha256
 
-  [ -f "$state_file" ] \
+  [ -f "$state_file" ] && [ ! -L "$state_file" ] \
     || fail "Rollback target has no deployment state: $state_file"
+  validate_release_state_schema "$state_file"
 
   recorded_release="$(required_state_value "$state_file" "release")"
   recorded_commit="$(required_state_value "$state_file" "commit")"
@@ -109,17 +121,26 @@ prepare_previous_release_state() {
     || fail "Rollback target has no hub-api launcher: $previous/ops/ec2/hub-api.sh"
   previous_launcher_sha256="$(sha256_file "$previous/ops/ec2/hub-api.sh")"
 
-  if [ -f "$previous_state" ]; then
+  [ -f "$shared_state" ] && [ ! -L "$shared_state" ] \
+    || fail "Shared rollback state is not one regular file: $shared_state"
+  validate_release_state \
+    "$previous" \
+    "$shared_state" \
+    "$previous_commit" \
+    "$previous_launcher_sha256"
+
+  if [ -e "$previous_state" ] || [ -L "$previous_state" ]; then
+    validate_release_state \
+      "$previous" \
+      "$previous_state" \
+      "$previous_commit" \
+      "$previous_launcher_sha256"
+    cmp -s "$previous_state" "$shared_state" \
+      || fail "Shared RELEASE_STATE differs from current per-release state."
     source_state="$previous_state"
   else
     source_state="$shared_state"
   fi
-
-  validate_release_state \
-    "$previous" \
-    "$source_state" \
-    "$previous_commit" \
-    "$previous_launcher_sha256"
 
   PREVIOUS_STATE_PATH="$previous_state"
   recorded_launcher_sha256="$(
@@ -142,6 +163,7 @@ prepare_previous_release_state() {
       >> "$PREVIOUS_STATE_INSTALL_SOURCE"
   fi
   chmod 0600 "$PREVIOUS_STATE_INSTALL_SOURCE"
+  validate_release_state_schema "$PREVIOUS_STATE_INSTALL_SOURCE"
 }
 
 snapshot_item() {
@@ -422,6 +444,8 @@ fi
 if [ "$VALIDATION_EXIT_CODE" -ne 0 ]; then
   fail "validation failed (exit $VALIDATION_EXIT_CODE): $VALIDATION_RESULT"
 fi
+
+validate_release_state_schema "$DEPLOYMENT_STATE"
 
 PREVIOUS=""
 if [ -L "$APP_ROOT/current" ]; then

--- a/ops/ec2/preflight-deploy.sh
+++ b/ops/ec2/preflight-deploy.sh
@@ -5,6 +5,8 @@ APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 REPO_URL="${HUB_OPTIMUS_REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
 TARGET_SHA="${1:-}"
 REFERENCE_URL="${2:-}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"
 
 # Fail-closed floor for the reviewed t3.small deployment operation.
 MIN_DISK_KIB=3145728
@@ -15,6 +17,15 @@ MAX_LOAD_1M=2.00
 fail() {
   echo "[preflight:error] $*" >&2
   exit 1
+}
+
+validate_release_state_schema() {
+  local state_file="$1"
+
+  [ -f "$STATE_VALIDATOR" ] && [ ! -L "$STATE_VALIDATOR" ] \
+    || fail "Release-state validator is not one regular file: $STATE_VALIDATOR"
+  bash "$STATE_VALIDATOR" "$state_file" >/dev/null \
+    || fail "Complete release-state validation failed: $state_file"
 }
 
 required_state_value() {
@@ -83,6 +94,7 @@ validate_release() {
 
   [ -f "$state_file" ] && [ ! -L "$state_file" ] \
     || fail "Release state is not one regular file: $state_file"
+  validate_release_state_schema "$state_file"
 
   IFS=$'\t' read -r actual_commit actual_launcher_sha256 < <(
     inspect_release_directory "$release_path"

--- a/ops/ec2/rollback-current.sh
+++ b/ops/ec2/rollback-current.sh
@@ -2,10 +2,21 @@
 set -euo pipefail
 
 APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"
 
 fail() {
   echo "[rollback:error] $*" >&2
   exit 1
+}
+
+validate_release_state_schema() {
+  local state_file="$1"
+
+  [ -f "$STATE_VALIDATOR" ] && [ ! -L "$STATE_VALIDATOR" ] \
+    || fail "Release-state validator is not one regular file: $STATE_VALIDATOR"
+  bash "$STATE_VALIDATOR" "$state_file" >/dev/null \
+    || fail "Complete release-state validation failed: $state_file"
 }
 
 state_value() {
@@ -201,6 +212,32 @@ esac
 [ -d "$CURRENT" ] || fail "Current release path does not exist: $CURRENT"
 [ -d "$PREVIOUS" ] || fail "Previous release path does not exist: $PREVIOUS"
 
+CURRENT_STATE="$CURRENT/.hub-deployment/RELEASE_STATE"
+SHARED_STATE="$APP_ROOT/shared/RELEASE_STATE"
+[ -f "$CURRENT_STATE" ] && [ ! -L "$CURRENT_STATE" ] \
+  || fail "Current release has no regular per-release state: $CURRENT_STATE"
+[ -f "$SHARED_STATE" ] && [ ! -L "$SHARED_STATE" ] \
+  || fail "Current release has no regular shared state: $SHARED_STATE"
+validate_release_state_schema "$CURRENT_STATE"
+validate_release_state_schema "$SHARED_STATE"
+cmp -s "$CURRENT_STATE" "$SHARED_STATE" \
+  || fail "Shared RELEASE_STATE differs from current per-release state."
+
+CURRENT_COMMIT="$(git -C "$CURRENT" rev-parse --verify HEAD)"
+[[ "$CURRENT_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "Current release does not resolve to one full commit SHA."
+[ "$(required_state_value "$CURRENT_STATE" "commit")" = "$CURRENT_COMMIT" ] \
+  || fail "Current release commit does not match its deployment state."
+[ "$(required_state_value "$CURRENT_STATE" "path")" = "$CURRENT" ] \
+  || fail "Current release path does not match its deployment state."
+[ "$(required_state_value "$CURRENT_STATE" "release")" = "$(basename "$CURRENT")" ] \
+  || fail "Current release name does not match its deployment state."
+[ -f "$CURRENT/ops/ec2/hub-api.sh" ] \
+  || fail "Current release has no hub-api launcher: $CURRENT/ops/ec2/hub-api.sh"
+CURRENT_LAUNCHER_SHA256="$(sha256_file "$CURRENT/ops/ec2/hub-api.sh")"
+[ "$(required_state_value "$CURRENT_STATE" "launcher_sha256")" = "$CURRENT_LAUNCHER_SHA256" ] \
+  || fail "Current release launcher does not match its deployment state."
+
 if [ "$CURRENT" = "$PREVIOUS" ]; then
   echo "[rollback] Current release already matches previous_release target:"
   echo "$CURRENT"
@@ -208,10 +245,12 @@ if [ "$CURRENT" = "$PREVIOUS" ]; then
 fi
 
 PREVIOUS_STATE="$PREVIOUS/.hub-deployment/RELEASE_STATE"
-[ -f "$PREVIOUS_STATE" ] \
+[ -f "$PREVIOUS_STATE" ] && [ ! -L "$PREVIOUS_STATE" ] \
   || fail "Previous release has no recorded deployment state: $PREVIOUS_STATE"
 [ -f "$PREVIOUS/ops/ec2/hub-api.sh" ] \
   || fail "Previous release has no hub-api launcher: $PREVIOUS/ops/ec2/hub-api.sh"
+
+validate_release_state_schema "$PREVIOUS_STATE"
 
 RECORDED_COMMIT="$(required_state_value "$PREVIOUS_STATE" "commit")"
 RECORDED_PATH="$(required_state_value "$PREVIOUS_STATE" "path")"
@@ -234,9 +273,6 @@ ACTUAL_LAUNCHER_SHA256="$(sha256_file "$PREVIOUS/ops/ec2/hub-api.sh")"
 [ "$RECORDED_LAUNCHER_SHA256" = "$ACTUAL_LAUNCHER_SHA256" ] \
   || fail "Previous release launcher does not match its deployment state."
 
-CURRENT_COMMIT="$(git -C "$CURRENT" rev-parse --verify HEAD)"
-[[ "$CURRENT_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
-  || fail "Current release does not resolve to one full commit SHA."
 CURRENT_RELEASE="$(basename "$CURRENT")"
 PREVIOUS_RELEASE="$(basename "$PREVIOUS")"
 

--- a/ops/ec2/validate-release-state.sh
+++ b/ops/ec2/validate-release-state.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "[release-state:error] Usage: validate-release-state <state-file>" >&2
+  exit 1
+fi
+
+STATE_FILE="$1"
+
+fail() {
+  echo "[release-state:error] $*" >&2
+  exit 1
+}
+
+[ -f "$STATE_FILE" ] && [ ! -L "$STATE_FILE" ] \
+  || fail "State is not one regular file: $STATE_FILE"
+
+validate_canonical_state_text() {
+  /usr/bin/python3 -I - "$STATE_FILE" <<'PY_CANONICAL_STATE' \
+    || fail "State is not canonical UTF-8/LF text: $STATE_FILE"
+import re
+import sys
+from pathlib import Path
+
+
+path = Path(sys.argv[1])
+raw = path.read_bytes()
+if not raw or not raw.endswith(b"\n"):
+    raise SystemExit(1)
+try:
+    text = raw.decode("utf-8")
+except UnicodeDecodeError:
+    raise SystemExit(1)
+
+for character in text:
+    codepoint = ord(character)
+    if character == "\n":
+        continue
+    if codepoint < 0x20 or 0x7F <= codepoint <= 0x9F:
+        raise SystemExit(1)
+    if character in {"\u2028", "\u2029"}:
+        raise SystemExit(1)
+
+for line in text[:-1].split("\n"):
+    if "=" not in line:
+        continue
+    key = line.split("=", 1)[0]
+    if not re.fullmatch(r"[a-z][a-z0-9_]*", key):
+        raise SystemExit(1)
+PY_CANONICAL_STATE
+}
+
+validate_canonical_state_text
+
+declare -A SEEN_STATE_KEYS=()
+STATE_LINE_COUNT=0
+while IFS= read -r line || [ -n "$line" ]; do
+  STATE_LINE_COUNT=$((STATE_LINE_COUNT + 1))
+  [[ "$line" == *=* ]] \
+    || fail "$STATE_FILE contains a malformed state line at $STATE_LINE_COUNT."
+  key="${line%%=*}"
+  [ -n "$key" ] \
+    || fail "$STATE_FILE contains an empty field name at $STATE_LINE_COUNT."
+  if [[ -n "${SEEN_STATE_KEYS[$key]+present}" ]]; then
+    fail "$STATE_FILE contains a duplicate field: $key"
+  fi
+  SEEN_STATE_KEYS["$key"]=1
+done < "$STATE_FILE"
+
+state_value() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "$STATE_FILE"
+}
+
+require_exact_keys() {
+  local expected=" $* "
+  local expected_count="$#"
+  local key
+
+  for key in "${!SEEN_STATE_KEYS[@]}"; do
+    case "$expected" in
+      *" $key "*) ;;
+      *) fail "$STATE_FILE contains an unsupported field: $key" ;;
+    esac
+  done
+  [ "$STATE_LINE_COUNT" -eq "$expected_count" ] \
+    || fail "$STATE_FILE does not contain the exact expected field set."
+  for key in "$@"; do
+    [[ -n "${SEEN_STATE_KEYS[$key]+present}" ]] \
+      || fail "$STATE_FILE does not contain the exact expected field set."
+  done
+}
+
+require_common_identity() {
+  [ -n "$(state_value release)" ] \
+    || fail "$STATE_FILE has an empty release field."
+  [[ "$(state_value path)" == /* ]] \
+    || fail "$STATE_FILE has an invalid release path."
+}
+
+validate_production() {
+  local transitional="$1"
+  local commit
+  local requested_ref
+  local requested_ref_kind
+
+  if [ "$transitional" = "yes" ]; then
+    require_exact_keys \
+      release requested_ref requested_ref_kind commit path validated_at_utc \
+      validation_command validation_exit_code validation_result validation_log \
+      validation_log_exit_code launcher_sha256 status provenance
+    [ "$(state_value provenance)" = "adopted-pre-1832" ] \
+      || fail "$STATE_FILE has unsupported transitional provenance."
+    schema="transitional-adopted-pre-1832"
+  else
+    require_exact_keys \
+      release requested_ref requested_ref_kind commit path validated_at_utc \
+      validation_command validation_exit_code validation_result validation_log \
+      validation_log_exit_code launcher_sha256 status
+    schema="production"
+  fi
+
+  require_common_identity
+  commit="$(state_value commit)"
+  requested_ref="$(state_value requested_ref)"
+  requested_ref_kind="$(state_value requested_ref_kind)"
+  [[ "$commit" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "$STATE_FILE has no full lowercase commit identity."
+  case "$requested_ref_kind" in
+    commit)
+      [[ "$requested_ref" =~ ^[0-9a-fA-F]{40}$ ]] \
+        || fail "$STATE_FILE has an invalid requested commit."
+      [ "${requested_ref,,}" = "$commit" ] \
+        || fail "$STATE_FILE requested commit differs from its resolved commit."
+      ;;
+    tag)
+      [ -n "$requested_ref" ] \
+        || fail "$STATE_FILE has an empty requested tag."
+      git check-ref-format "refs/tags/$requested_ref" >/dev/null 2>&1 \
+        || fail "$STATE_FILE has an invalid requested tag."
+      ;;
+    *) fail "$STATE_FILE has an unsupported requested_ref_kind." ;;
+  esac
+  [[ "$(state_value validated_at_utc)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || fail "$STATE_FILE has an invalid validation timestamp."
+  [ "$(state_value validation_command)" = "python -m pytest -q" ] \
+    || fail "$STATE_FILE has an unexpected validation command."
+  [ "$(state_value validation_exit_code)" = "0" ] \
+    && [ "$(state_value validation_log_exit_code)" = "0" ] \
+    || fail "$STATE_FILE does not record successful validation."
+  [ -n "$(state_value validation_result)" ] \
+    && [ -n "$(state_value validation_log)" ] \
+    || fail "$STATE_FILE has incomplete validation evidence."
+  [[ "$(state_value launcher_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$STATE_FILE has no valid launcher SHA-256."
+  [ "$(state_value status)" = "production-candidate-core" ] \
+    || fail "$STATE_FILE is not a production candidate."
+}
+
+validate_adopted_legacy() {
+  local commit
+  local prefix
+
+  require_exact_keys \
+    release requested_ref requested_ref_kind commit path adopted_at_utc \
+    validation_command validation_exit_code validation_result validation_log \
+    validation_log_exit_code launcher_sha256 status provenance \
+    legacy_state_sha256 legacy_commit_prefix
+  require_common_identity
+  commit="$(state_value commit)"
+  prefix="$(state_value legacy_commit_prefix)"
+  [[ "$commit" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "$STATE_FILE has no full lowercase commit identity."
+  [ "$(state_value requested_ref)" = "$commit" ] \
+    || fail "$STATE_FILE legacy adoption is not commit-bound."
+  [[ "$(state_value adopted_at_utc)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || fail "$STATE_FILE has an invalid adoption timestamp."
+  [ "$(state_value validation_command)" = "not-run-during-legacy-adoption" ] \
+    && [ "$(state_value validation_exit_code)" = "not-run" ] \
+    && [ "$(state_value validation_result)" = "legacy validation claim not re-attested; original state retained by SHA-256" ] \
+    && [ "$(state_value validation_log)" = "not-applicable" ] \
+    && [ "$(state_value validation_log_exit_code)" = "not-run" ] \
+    || fail "$STATE_FILE has invalid legacy-adoption validation metadata."
+  [ "$(state_value status)" = "adopted-legacy-current" ] \
+    && [ "$(state_value provenance)" = "adopted-legacy-current-v1" ] \
+    || fail "$STATE_FILE has invalid legacy-adoption provenance."
+  [[ "$(state_value launcher_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$STATE_FILE has no valid launcher SHA-256."
+  [[ "$(state_value legacy_state_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$STATE_FILE has an invalid legacy-state SHA-256."
+  [[ "$prefix" =~ ^[0-9a-f]{7,39}$ ]] \
+    && [[ "$commit" == "$prefix"* ]] \
+    || fail "$STATE_FILE has an invalid legacy commit prefix."
+  schema="adopted-legacy"
+}
+
+validate_legacy() {
+  require_exact_keys release commit path validated_at_utc validation status
+  require_common_identity
+  [[ "$(state_value commit)" =~ ^[0-9a-f]{7,39}$ ]] \
+    || fail "$STATE_FILE has an invalid legacy commit prefix."
+  [[ "$(state_value validated_at_utc)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || fail "$STATE_FILE has an invalid validation timestamp."
+  [ -n "$(state_value validation)" ] \
+    || fail "$STATE_FILE has an empty validation claim."
+  [ "$(state_value status)" = "production-candidate-core" ] \
+    || fail "$STATE_FILE is not a legacy production candidate."
+  schema="legacy"
+}
+
+if [[ -n "${SEEN_STATE_KEYS[requested_ref_kind]+present}" ]]; then
+  case "$(state_value requested_ref_kind)" in
+    commit|tag)
+      if [[ -n "${SEEN_STATE_KEYS[provenance]+present}" ]]; then
+        validate_production yes
+      else
+        validate_production no
+      fi
+      ;;
+    legacy-host-adoption) validate_adopted_legacy ;;
+    *) fail "$STATE_FILE has an unsupported requested_ref_kind." ;;
+  esac
+else
+  validate_legacy
+fi
+
+printf '[release-state] PASS %s %s\n' "$schema" "$STATE_FILE"

--- a/tests/test_ec2_legacy_adoption.py
+++ b/tests/test_ec2_legacy_adoption.py
@@ -280,6 +280,43 @@ def test_preflight_inventories_unattested_historical_pointer(
 
 
 @pytest.mark.parametrize(
+    ("corruption", "expected_error"),
+    (
+        ("status=duplicate", "contains a duplicate field: status"),
+        ("malformed-state-line", "contains a malformed state line"),
+    ),
+)
+def test_preflight_rejects_matching_but_malformed_current_state(
+    tmp_path: Path,
+    corruption: str,
+    expected_error: str,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    adopted = _run([ADOPT, commit], env=env)
+    assert adopted.returncode == 0, adopted.stderr
+
+    release_state = release / ".hub-deployment" / "RELEASE_STATE"
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    corrupted = release_state.read_text(encoding="utf-8") + f"{corruption}\n"
+    release_state.write_text(corrupted, encoding="utf-8")
+    shared_state.write_text(corrupted, encoding="utf-8")
+
+    fake_bin = tmp_path / "preflight-schema-bin"
+    fake_bin.mkdir()
+    for command_name in ("sudo", "systemctl"):
+        _write_executable(fake_bin / command_name, "#!/usr/bin/env bash\nexit 0\n")
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run(
+        [PREFLIGHT, "f" * 40, "https://example.com/article"],
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+@pytest.mark.parametrize(
     "stage",
     (
         "git-exclude",

--- a/tests/test_ec2_release_state_validator.py
+++ b/tests/test_ec2_release_state_validator.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "ops" / "ec2" / "validate-release-state.sh"
+PREFLIGHT = ROOT / "ops" / "ec2" / "preflight-deploy.sh"
+DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
+ROLLBACK = ROOT / "ops" / "ec2" / "rollback-current.sh"
+
+COMMIT = "b" * 40
+LAUNCHER_SHA256 = "c" * 64
+LEGACY_SHA256 = "d" * 64
+ADOPTION_RESULT = (
+    "legacy validation claim not re-attested; original state retained by SHA-256"
+)
+
+
+def _run(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(VALIDATOR), str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_state(path: Path, fields: list[tuple[str, str]]) -> None:
+    path.write_text(
+        "".join(f"{key}={value}\n" for key, value in fields),
+        encoding="utf-8",
+    )
+
+
+def _production_fields(*, transitional: bool = False) -> list[tuple[str, str]]:
+    fields = [
+        ("release", "20260803T120000Z.ABC123"),
+        ("requested_ref", COMMIT),
+        ("requested_ref_kind", "commit"),
+        ("commit", COMMIT),
+        ("path", "/opt/hub-optimus/releases/20260803T120000Z.ABC123"),
+        ("validated_at_utc", "2026-08-03T12:00:00Z"),
+        ("validation_command", "python -m pytest -q"),
+        ("validation_exit_code", "0"),
+        ("validation_result", "719 passed in 30.45s"),
+        (
+            "validation_log",
+            "/opt/hub-optimus/releases/20260803T120000Z.ABC123/"
+            ".hub-deployment/validation.log",
+        ),
+        ("validation_log_exit_code", "0"),
+        ("launcher_sha256", LAUNCHER_SHA256),
+        ("status", "production-candidate-core"),
+    ]
+    if transitional:
+        fields.append(("provenance", "adopted-pre-1832"))
+    return fields
+
+
+def _adopted_fields() -> list[tuple[str, str]]:
+    return [
+        ("release", "20260720T225606Z"),
+        ("requested_ref", COMMIT),
+        ("requested_ref_kind", "legacy-host-adoption"),
+        ("commit", COMMIT),
+        ("path", "/opt/hub-optimus/releases/20260720T225606Z"),
+        ("adopted_at_utc", "2026-08-03T12:00:00Z"),
+        ("validation_command", "not-run-during-legacy-adoption"),
+        ("validation_exit_code", "not-run"),
+        ("validation_result", ADOPTION_RESULT),
+        ("validation_log", "not-applicable"),
+        ("validation_log_exit_code", "not-run"),
+        ("launcher_sha256", LAUNCHER_SHA256),
+        ("status", "adopted-legacy-current"),
+        ("provenance", "adopted-legacy-current-v1"),
+        ("legacy_state_sha256", LEGACY_SHA256),
+        ("legacy_commit_prefix", COMMIT[:7]),
+    ]
+
+
+def _legacy_fields() -> list[tuple[str, str]]:
+    return [
+        ("release", "20260720T225606Z"),
+        ("commit", COMMIT[:7]),
+        ("path", "/opt/hub-optimus/releases/20260720T225606Z"),
+        ("validated_at_utc", "2026-07-20T22:56:06Z"),
+        ("validation", "pytest 55 passed"),
+        ("status", "production-candidate-core"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("schema_name", "expected_kind", "fields"),
+    (
+        ("production", "production", _production_fields()),
+        (
+            "transitional",
+            "transitional-adopted-pre-1832",
+            _production_fields(transitional=True),
+        ),
+        ("adopted-legacy", "adopted-legacy", _adopted_fields()),
+        ("six-field-legacy", "legacy", _legacy_fields()),
+    ),
+)
+def test_validator_accepts_each_supported_exact_schema(
+    tmp_path: Path,
+    schema_name: str,
+    expected_kind: str,
+    fields: list[tuple[str, str]],
+) -> None:
+    state = tmp_path / schema_name
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 0, result.stderr
+    assert f"PASS {expected_kind}" in result.stdout
+
+
+def test_validator_accepts_an_exact_tag_state(tmp_path: Path) -> None:
+    fields = _production_fields()
+    fields[1] = ("requested_ref", "v2.3.4")
+    fields[2] = ("requested_ref_kind", "tag")
+    state = tmp_path / "tag-state"
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 0, result.stderr
+    assert "PASS production" in result.stdout
+
+
+def test_validator_rejects_an_invalid_tag_name(tmp_path: Path) -> None:
+    fields = _production_fields()
+    fields[1] = ("requested_ref", "not a valid git tag")
+    fields[2] = ("requested_ref_kind", "tag")
+    state = tmp_path / "invalid-tag-state"
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert "invalid requested tag" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "fields",
+    (
+        _production_fields(),
+        _production_fields(transitional=True),
+        _adopted_fields(),
+        _legacy_fields(),
+    ),
+    ids=("production", "transitional", "adopted-legacy", "six-field-legacy"),
+)
+@pytest.mark.parametrize(
+    "corruption",
+    (
+        "nul",
+        "invalid-utf8",
+        "crlf",
+        "nel",
+        "line-separator",
+        "paragraph-separator",
+        "control-byte",
+        "missing-terminal-lf",
+        "noncanonical-key",
+    ),
+)
+def test_validator_rejects_noncanonical_state_bytes_for_every_schema(
+    tmp_path: Path,
+    fields: list[tuple[str, str]],
+    corruption: str,
+) -> None:
+    state = tmp_path / f"noncanonical-{corruption}"
+    _write_state(state, fields)
+    raw = state.read_bytes()
+    free_text_key = (
+        b"validation_result="
+        if b"validation_result=" in raw
+        else b"validation="
+    )
+
+    if corruption == "nul":
+        raw = raw.replace(b"status=", b"status=\x00", 1)
+    elif corruption == "invalid-utf8":
+        raw = raw.replace(free_text_key, free_text_key + b"\xff", 1)
+    elif corruption == "crlf":
+        raw = raw.replace(b"\n", b"\r\n", 1)
+    elif corruption == "nel":
+        raw = raw.replace(free_text_key, free_text_key + "\u0085".encode(), 1)
+    elif corruption == "line-separator":
+        raw = raw.replace(free_text_key, free_text_key + "\u2028".encode(), 1)
+    elif corruption == "paragraph-separator":
+        raw = raw.replace(free_text_key, free_text_key + "\u2029".encode(), 1)
+    elif corruption == "control-byte":
+        raw = raw.replace(free_text_key, free_text_key + b"\x01", 1)
+    elif corruption == "missing-terminal-lf":
+        raw = raw[:-1]
+    else:
+        raw = raw.replace(b"release=", b"Release=", 1)
+    state.write_bytes(raw)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert "not canonical UTF-8/LF text" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("corruption", "expected_error"),
+    (
+        ("duplicate", "duplicate field: status"),
+        ("malformed", "malformed state line"),
+        ("unknown", "unsupported field: unexpected"),
+        ("partial", "exact expected field set"),
+        ("mixed", "unsupported field: validation"),
+    ),
+)
+def test_validator_rejects_malformed_duplicate_unknown_partial_and_mixed_state(
+    tmp_path: Path,
+    corruption: str,
+    expected_error: str,
+) -> None:
+    fields = _production_fields()
+    state = tmp_path / "corrupted-state"
+    if corruption == "duplicate":
+        fields.append(("status", "production-candidate-core"))
+        _write_state(state, fields)
+    elif corruption == "malformed":
+        _write_state(state, fields)
+        state.write_text(
+            state.read_text(encoding="utf-8") + "malformed-state-line\n",
+            encoding="utf-8",
+        )
+    elif corruption == "unknown":
+        fields.append(("unexpected", "value"))
+        _write_state(state, fields)
+    elif corruption == "partial":
+        _write_state(state, fields[:-1])
+    else:
+        fields.append(("validation", "legacy-only-field"))
+        _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    (
+        ("provenance", "forged", "unsupported transitional provenance"),
+        ("validation_exit_code", "1", "does not record successful validation"),
+        ("status", "validation-failed", "not a production candidate"),
+    ),
+)
+def test_validator_rejects_semantically_invalid_transitional_state(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    expected_error: str,
+) -> None:
+    fields = [
+        (key, value if key == field else original)
+        for key, original in _production_fields(transitional=True)
+    ]
+    state = tmp_path / "invalid-transitional"
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+def test_preflight_deploy_and_rollback_use_the_shared_validator() -> None:
+    for script in (PREFLIGHT, DEPLOY, ROLLBACK):
+        source = script.read_text(encoding="utf-8")
+        assert 'STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"' in source
+        assert 'bash "$STATE_VALIDATOR" "$state_file"' in source
+
+
+def test_validator_scope_excludes_follow_up_attestation_and_hardening() -> None:
+    sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (VALIDATOR, PREFLIGHT, DEPLOY, ROLLBACK)
+    )
+
+    assert "validation_log_sha256" not in sources
+    assert "validate-release-worktree" not in sources
+    assert "recovery-snapshot" not in sources

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -9,6 +9,8 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 HUB_CORE = ROOT / "ops" / "ec2" / "hub-core.sh"
@@ -827,9 +829,50 @@ def test_rollback_state_parser_rejects_duplicate_identity_keys(
         result = _run([ROLLBACK], env=env)
 
         assert result.returncode == 1
-        assert f"must contain exactly one {key} field" in result.stderr
+        assert f"contains a duplicate field: {key}" in result.stderr
         assert _operational_snapshot(app_root) == before
         assert not list((app_root / "shared").glob("rollback-transaction.*"))
+
+
+@pytest.mark.parametrize(
+    "state_location",
+    ("current", "shared", "matching-current-and-shared", "previous"),
+)
+def test_rollback_rejects_malformed_managed_state_before_mutation(
+    tmp_path: Path,
+    state_location: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    assert _run([DEPLOY, reviewed_commit], env=env).returncode == 0
+    previous_release = (app_root / "current").resolve()
+    assert _run([DEPLOY, head_commit], env=env).returncode == 0
+    current_release = (app_root / "current").resolve()
+    current_state = current_release / ".hub-deployment" / "RELEASE_STATE"
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    previous_state = previous_release / ".hub-deployment" / "RELEASE_STATE"
+
+    targets = {
+        "current": (current_state,),
+        "shared": (shared_state,),
+        "matching-current-and-shared": (current_state, shared_state),
+        "previous": (previous_state,),
+    }[state_location]
+    for target in targets:
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write("status=production-candidate-core\n")
+    before = _operational_snapshot(app_root)
+
+    result = _run([ROLLBACK], env=env)
+
+    assert result.returncode == 1
+    assert "contains a duplicate field: status" in result.stderr
+    assert _operational_snapshot(app_root) == before
+    assert not list((app_root / "shared").glob("rollback-transaction.*"))
 
 
 def test_invalid_rollback_target_state_fails_before_mutation(
@@ -858,8 +901,53 @@ def test_invalid_rollback_target_state_fails_before_mutation(
     result = _run([DEPLOY, head_commit], env=env)
 
     assert result.returncode == 1
-    assert "Rollback target commit does not match" in result.stderr
+    assert "requested commit differs from its resolved commit" in result.stderr
     assert "Restoring exact pre-deploy" not in result.stderr
+    assert _operational_snapshot(app_root) == before
+
+
+@pytest.mark.parametrize(
+    ("corruption", "expected_error"),
+    (
+        ("malformed", "contains a malformed state line"),
+        (
+            "valid-but-divergent",
+            "Shared RELEASE_STATE differs from current per-release state",
+        ),
+    ),
+)
+def test_deploy_rejects_shared_only_state_drift_before_mutation(
+    tmp_path: Path,
+    corruption: str,
+    expected_error: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    fake_bin = _fake_deploy_python(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo, fake_bin)
+
+    first = _run([DEPLOY, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    shared_state = app_root / "shared" / "RELEASE_STATE"
+    if corruption == "malformed":
+        with shared_state.open("a", encoding="utf-8") as handle:
+            handle.write("malformed-state-line\n")
+    else:
+        shared_state.write_text(
+            shared_state.read_text(encoding="utf-8").replace(
+                "validation_result=17 passed in 0.01s",
+                "validation_result=18 passed in 0.01s",
+            ),
+            encoding="utf-8",
+        )
+    before = _operational_snapshot(app_root)
+
+    result = _run([DEPLOY, head_commit], env=env)
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+    assert "Restoring exact pre-deploy operational state" not in result.stderr
     assert _operational_snapshot(app_root) == before
 
 


### PR DESCRIPTION
## Summary

- add one exact shared release-state validator for production, transitional, adopted-legacy, and six-field legacy schemas;
- reject malformed, duplicate, unknown, partial, mixed, noncanonical, or invalid-tag state before preflight, deploy, or rollback mutation;
- require deploy and rollback to validate shared/per-release state and exact byte parity;
- rename the ambiguous shared `LEGACY_STATE` variable to `SHARED_STATE`.

This is the state-validation slice of #1848 and intentionally does **not** close the issue. Validation-log SHA/result binding follows in a separate stacked draft.

## Verification

- 104 focused EC2 tests passed;
- full suite: 779 passed, 12 skipped (PowerShell unavailable in this environment);
- Bash syntax passed for all five touched scripts;
- mojibake: 292 Markdown files passed;
- narrative consistency: 0 errors, 0 warnings;
- frozen benchmarks: 3/3 passed;
- independent adversarial review: PUBLISH, no #1848-scope blocker.

## Operational safety

Draft only. No merge, EC2 mutation, restart, rollback, DNS, TLS, nginx, Security Group, IAM, or AWS action was performed. #1831 remains hard-blocked and read-only.

The separately tracked hardening work in #1851–#1855 is out of scope. `AI_HANDOFF.md` is unchanged here because the operational block has not changed; the final attestation slice carries the focused runbook/handoff update.