### PR TITLE
fix(ec2): bind validation state to its log

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -128,6 +128,9 @@ Issue #1832 hardens that boundary before the blocked host operation in #1831:
   and recovers transactionally at every mutation failpoint;
 - candidate validation still completes before operational mutation; a failed
   candidate and validation log remain inspectable without changing `current`;
+- every successful production state records the complete validation log's
+  SHA-256 and must match that log's final non-empty line; preflight, deploy, and
+  rollback reject truncated, replaced, or result-divergent evidence;
 - before mutation, deploy validates the managed rollback target's directory,
   full commit, release/path state, launcher presence, and launcher SHA-256;
 - replacement launcher, release state, current marker, and rollback pointer are

--- a/ops/ec2/ISSUE_1831_RUNBOOK.md
+++ b/ops/ec2/ISSUE_1831_RUNBOOK.md
@@ -134,9 +134,10 @@ test "$(git -C "$DEPLOYED_RELEASE" rev-parse --verify HEAD)" = "$TARGET_SHA"
 DEPLOYED_RELEASE_STATE="$DEPLOYED_RELEASE/.hub-deployment/RELEASE_STATE"
 cmp -s "$DEPLOYED_RELEASE_STATE" "$APP_ROOT/shared/RELEASE_STATE"
 
-python3 - "$APP_ROOT" "$DEPLOYED_RELEASE" "$TARGET_SHA" <<'PY_DEPLOY_STATE'
+/usr/bin/python3 -I - "$APP_ROOT" "$DEPLOYED_RELEASE" "$TARGET_SHA" <<'PY_DEPLOY_STATE'
 import hashlib
 import json
+import os
 import re
 import stat
 import sys
@@ -157,6 +158,7 @@ required_keys = {
     "validation_result",
     "validation_log",
     "validation_log_exit_code",
+    "validation_log_sha256",
     "launcher_sha256",
     "status",
 }
@@ -169,6 +171,72 @@ def require_regular(path, *, executable=False, mode=None):
         raise SystemExit(f"not executable: {path}")
     if mode is not None and actual_mode != mode:
         raise SystemExit(f"unexpected mode for {path}: {actual_mode:o}")
+
+def read_canonical_validation_log(path, *, mode):
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise SystemExit("O_NOFOLLOW is unavailable for validation-log attestation")
+    flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise SystemExit(
+            f"could not open validation log without following links: {path}: {exc}"
+        ) from exc
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise SystemExit(f"validation log is not one regular file: {path}")
+        actual_mode = stat.S_IMODE(opened.st_mode)
+        if actual_mode != mode:
+            raise SystemExit(
+                f"unexpected validation-log mode for {path}: {actual_mode:o}"
+            )
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        raw = b"".join(chunks)
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise SystemExit("validation log is not UTF-8") from exc
+        if not raw.endswith(b"\n"):
+            raise SystemExit("validation log has no terminal LF")
+        for character in text:
+            codepoint = ord(character)
+            if character in {"\n", "\t"}:
+                continue
+            if codepoint < 0x20 or 0x7F <= codepoint <= 0x9F:
+                raise SystemExit("validation log is not canonical UTF-8/LF text")
+            if character in {"\u2028", "\u2029"}:
+                raise SystemExit("validation log is not canonical UTF-8/LF text")
+
+        finished = os.fstat(descriptor)
+        visible = os.stat(path, follow_symlinks=False)
+        identity_fields = (
+            "st_dev",
+            "st_ino",
+            "st_mode",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+        if any(
+            getattr(opened, field) != getattr(finished, field)
+            for field in identity_fields
+        ):
+            raise SystemExit("validation log changed while it was being attested")
+        if any(
+            getattr(finished, field) != getattr(visible, field)
+            for field in identity_fields
+        ):
+            raise SystemExit("validation log path changed while it was being attested")
+        return raw, text
+    finally:
+        os.close(descriptor)
 
 def exact_state(path, raw):
     try:
@@ -230,7 +298,20 @@ if not state["validation_result"]:
 expected_validation_log = deployed / ".hub-deployment" / "validation.log"
 if state["validation_log"] != str(expected_validation_log):
     raise SystemExit("release-state validation log path differs")
-require_regular(expected_validation_log, mode=0o600)
+validation_log_raw, validation_log_text = read_canonical_validation_log(
+    expected_validation_log,
+    mode=0o600,
+)
+validation_log_sha256 = hashlib.sha256(validation_log_raw).hexdigest()
+if state["validation_log_sha256"] != validation_log_sha256:
+    raise SystemExit("validation log does not match RELEASE_STATE")
+validation_result_lines = [
+    line for line in validation_log_text[:-1].split("\n") if line.split()
+]
+if not validation_result_lines:
+    raise SystemExit("validation log has no non-empty result line")
+if validation_result_lines[-1] != state["validation_result"]:
+    raise SystemExit("validation result does not match the validation log")
 if not re.fullmatch(r"[0-9a-f]{64}", state["launcher_sha256"]):
     raise SystemExit("launcher identity is missing")
 if state["status"] != "production-candidate-core":
@@ -262,6 +343,7 @@ print(json.dumps({
     "release_state_sha256": hashlib.sha256(release_state_raw).hexdigest(),
     "validation_exit_code": state["validation_exit_code"],
     "validation_log_exit_code": state["validation_log_exit_code"],
+    "validation_log_sha256": state["validation_log_sha256"],
 }, indent=2, sort_keys=True))
 PY_DEPLOY_STATE
 
@@ -270,6 +352,11 @@ EXPECTED_LAUNCHER_SHA256="$(
 )"
 [[ "$EXPECTED_LAUNCHER_SHA256" =~ ^[0-9a-f]{64}$ ]]
 ```
+
+The production release state is acceptable only while its mode-`0600`,
+canonical UTF-8/LF validation log can be read from one no-follow regular-file
+snapshot, still matches the recorded SHA-256, and has a final non-empty line
+equal to `validation_result`.
 
 An internal failure after deployment mutation begins automatically restores the
 exact pre-deploy `current` symlink, shared launcher, shared release state,

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -406,6 +406,7 @@ VALIDATION_RESULT="$(
   awk 'NF { result=$0 } END { print result == "" ? "no output" : result }' \
     "$VALIDATION_LOG"
 )"
+VALIDATION_LOG_SHA256="$(sha256_file "$VALIDATION_LOG")"
 
 if [ "$VALIDATION_EXIT_CODE" -eq 0 ] \
   && [ "$VALIDATION_LOG_EXIT_CODE" -eq 0 ]; then
@@ -426,6 +427,7 @@ validation_exit_code=$VALIDATION_EXIT_CODE
 validation_result=$VALIDATION_RESULT
 validation_log=$VALIDATION_LOG
 validation_log_exit_code=$VALIDATION_LOG_EXIT_CODE
+validation_log_sha256=$VALIDATION_LOG_SHA256
 launcher_sha256=$CANDIDATE_LAUNCHER_SHA256
 status=$RELEASE_STATUS
 STATE

--- a/ops/ec2/validate-release-state.sh
+++ b/ops/ec2/validate-release-state.sh
@@ -104,12 +104,24 @@ validate_production() {
   local commit
   local requested_ref
   local requested_ref_kind
+  local digest_bound="no"
+  local validation_log
+  local validation_log_sha256
 
   if [ "$transitional" = "yes" ]; then
-    require_exact_keys \
-      release requested_ref requested_ref_kind commit path validated_at_utc \
-      validation_command validation_exit_code validation_result validation_log \
-      validation_log_exit_code launcher_sha256 status provenance
+    if [[ -n "${SEEN_STATE_KEYS[validation_log_sha256]+present}" ]]; then
+      require_exact_keys \
+        release requested_ref requested_ref_kind commit path validated_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code validation_log_sha256 launcher_sha256 status \
+        provenance
+      digest_bound="yes"
+    else
+      require_exact_keys \
+        release requested_ref requested_ref_kind commit path validated_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code launcher_sha256 status provenance
+    fi
     [ "$(state_value provenance)" = "adopted-pre-1832" ] \
       || fail "$STATE_FILE has unsupported transitional provenance."
     schema="transitional-adopted-pre-1832"
@@ -117,8 +129,9 @@ validate_production() {
     require_exact_keys \
       release requested_ref requested_ref_kind commit path validated_at_utc \
       validation_command validation_exit_code validation_result validation_log \
-      validation_log_exit_code launcher_sha256 status
+      validation_log_exit_code validation_log_sha256 launcher_sha256 status
     schema="production"
+    digest_bound="yes"
   fi
 
   require_common_identity
@@ -152,6 +165,107 @@ validate_production() {
   [ -n "$(state_value validation_result)" ] \
     && [ -n "$(state_value validation_log)" ] \
     || fail "$STATE_FILE has incomplete validation evidence."
+
+  if [ "$digest_bound" = "yes" ]; then
+    validation_log="$(state_value validation_log)"
+    [ "$validation_log" = "$(state_value path)/.hub-deployment/validation.log" ] \
+      || fail "$STATE_FILE has the wrong validation-log path."
+    [ -f "$validation_log" ] && [ ! -L "$validation_log" ] \
+      || fail "Validation log is not one regular file: $validation_log"
+    validation_log_sha256="$(state_value validation_log_sha256)"
+    [[ "$validation_log_sha256" =~ ^[0-9a-f]{64}$ ]] \
+      || fail "$STATE_FILE has no valid validation-log SHA-256."
+    /usr/bin/python3 -I - \
+      "$validation_log" \
+      "$validation_log_sha256" \
+      "$(state_value validation_result)" <<'PY_VALIDATION_LOG' \
+      || fail "Validation-log attestation failed: $validation_log"
+import hashlib
+import os
+import stat
+import sys
+
+
+path, expected_sha256, expected_result = sys.argv[1:]
+
+
+def fail(message: str) -> None:
+    print(f"[release-state:error] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+flags = os.O_RDONLY | os.O_CLOEXEC
+if not hasattr(os, "O_NOFOLLOW"):
+    fail("O_NOFOLLOW is unavailable for validation-log attestation.")
+flags |= os.O_NOFOLLOW
+try:
+    descriptor = os.open(path, flags)
+except OSError as exc:
+    fail(f"Could not open validation log without following links: {path}: {exc}")
+
+try:
+    opened = os.fstat(descriptor)
+    if not stat.S_ISREG(opened.st_mode):
+        fail(f"Validation log is not one regular file: {path}")
+    if stat.S_IMODE(opened.st_mode) != 0o600:
+        fail(f"Validation log has an unexpected mode: {path}")
+    chunks = []
+    while True:
+        chunk = os.read(descriptor, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    raw = b"".join(chunks)
+
+    if hashlib.sha256(raw).hexdigest() != expected_sha256:
+        fail(f"Validation log does not match {path}")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        fail(f"Validation log is not UTF-8: {path}")
+    if not raw.endswith(b"\n"):
+        fail(f"Validation log has no terminal LF: {path}")
+    for character in text:
+        codepoint = ord(character)
+        if character in {"\n", "\t"}:
+            continue
+        if codepoint < 0x20 or 0x7F <= codepoint <= 0x9F:
+            fail(f"Validation log is not canonical UTF-8/LF text: {path}")
+        if character in {"\u2028", "\u2029"}:
+            fail(f"Validation log is not canonical UTF-8/LF text: {path}")
+    result_lines = [
+        line for line in text[:-1].split("\n") if line.split()
+    ]
+    if not result_lines:
+        fail(f"Validation log has no non-empty result line: {path}")
+    if result_lines[-1] != expected_result:
+        fail("Validation result does not match the validation log.")
+
+    finished = os.fstat(descriptor)
+    visible = os.stat(path, follow_symlinks=False)
+    identity_fields = (
+        "st_dev",
+        "st_ino",
+        "st_mode",
+        "st_size",
+        "st_mtime_ns",
+        "st_ctime_ns",
+    )
+    if any(
+        getattr(opened, field) != getattr(finished, field)
+        for field in identity_fields
+    ):
+        fail(f"Validation log changed while it was being attested: {path}")
+    if any(
+        getattr(finished, field) != getattr(visible, field)
+        for field in identity_fields
+    ):
+        fail(f"Validation log path changed while it was being attested: {path}")
+finally:
+    os.close(descriptor)
+PY_VALIDATION_LOG
+  fi
+
   [[ "$(state_value launcher_sha256)" =~ ^[0-9a-f]{64}$ ]] \
     || fail "$STATE_FILE has no valid launcher SHA-256."
   [ "$(state_value status)" = "production-candidate-core" ] \

--- a/tests/test_ec2_preflight_and_evidence.py
+++ b/tests/test_ec2_preflight_and_evidence.py
@@ -69,6 +69,11 @@ def test_runbook_retains_reviewed_tools_and_uses_allowlisted_evidence() -> None:
     assert 'cmp -s "$RESTORED_RELEASE_STATE" "$APP_ROOT/shared/RELEASE_STATE"' in text
     assert 'if release_state_raw != shared_state_raw:' in text
     assert 'if versioned_launcher_raw != shared_launcher_raw:' in text
+    assert 'state["validation_log_sha256"] != validation_log_sha256' in text
+    assert 'validation_result_lines[-1] != state["validation_result"]' in text
+    assert "flags |= os.O_NOFOLLOW" in text
+    assert "opened = os.fstat(descriptor)" in text
+    assert "visible = os.stat(path, follow_symlinks=False)" in text
     assert 'evidence["running_release"] != expected_release' in text
     assert 'evidence["configured_current_release"] != expected_release' in text
     assert "--fail-with-body" in text
@@ -85,6 +90,7 @@ def test_runbook_retains_reviewed_tools_and_uses_allowlisted_evidence() -> None:
     assert "PY_ROLLBACK_STATE" in text
     assert "PY_ROLLBACK_STATUS" in text
     assert '"to_launcher_sha256"' in text
+    assert '"validation_log_sha256": state["validation_log_sha256"]' in text
     assert 'evidence["running_commit"] != expected_commit' in text
 
 

--- a/tests/test_ec2_release_state_validator.py
+++ b/tests/test_ec2_release_state_validator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from pathlib import Path
 
@@ -15,6 +16,8 @@ ROLLBACK = ROOT / "ops" / "ec2" / "rollback-current.sh"
 COMMIT = "b" * 40
 LAUNCHER_SHA256 = "c" * 64
 LEGACY_SHA256 = "d" * 64
+VALIDATION_RESULT = "719 passed in 30.45s"
+VALIDATION_LOG_RAW = f"collecting tests\n{VALIDATION_RESULT}\n\n".encode()
 ADOPTION_RESULT = (
     "legacy validation claim not re-attested; original state retained by SHA-256"
 )
@@ -46,19 +49,58 @@ def _production_fields(*, transitional: bool = False) -> list[tuple[str, str]]:
         ("validated_at_utc", "2026-08-03T12:00:00Z"),
         ("validation_command", "python -m pytest -q"),
         ("validation_exit_code", "0"),
-        ("validation_result", "719 passed in 30.45s"),
+        ("validation_result", VALIDATION_RESULT),
         (
             "validation_log",
             "/opt/hub-optimus/releases/20260803T120000Z.ABC123/"
             ".hub-deployment/validation.log",
         ),
         ("validation_log_exit_code", "0"),
-        ("launcher_sha256", LAUNCHER_SHA256),
-        ("status", "production-candidate-core"),
     ]
+    if not transitional:
+        fields.append(
+            (
+                "validation_log_sha256",
+                hashlib.sha256(VALIDATION_LOG_RAW).hexdigest(),
+            )
+        )
+    fields.extend(
+        (
+            ("launcher_sha256", LAUNCHER_SHA256),
+            ("status", "production-candidate-core"),
+        )
+    )
     if transitional:
         fields.append(("provenance", "adopted-pre-1832"))
     return fields
+
+
+def _replace_field(
+    fields: list[tuple[str, str]],
+    field: str,
+    value: str,
+) -> list[tuple[str, str]]:
+    return [
+        (key, value if key == field else original)
+        for key, original in fields
+    ]
+
+
+def _production_fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, list[tuple[str, str]]]:
+    release = tmp_path / "releases" / "20260803T120000Z.ABC123"
+    validation_log = release / ".hub-deployment" / "validation.log"
+    validation_log.parent.mkdir(parents=True)
+    validation_log.write_bytes(VALIDATION_LOG_RAW)
+    validation_log.chmod(0o600)
+    fields = _production_fields()
+    fields = _replace_field(fields, "release", release.name)
+    fields = _replace_field(fields, "path", str(release))
+    fields = _replace_field(fields, "validation_log", str(validation_log))
+    state = validation_log.parent / "RELEASE_STATE"
+    _write_state(state, fields)
+    return state, validation_log, fields
 
 
 def _adopted_fields() -> list[tuple[str, str]]:
@@ -112,8 +154,11 @@ def test_validator_accepts_each_supported_exact_schema(
     expected_kind: str,
     fields: list[tuple[str, str]],
 ) -> None:
-    state = tmp_path / schema_name
-    _write_state(state, fields)
+    if schema_name == "production":
+        state, _, fields = _production_fixture(tmp_path)
+    else:
+        state = tmp_path / schema_name
+        _write_state(state, fields)
 
     result = _run(state)
 
@@ -122,16 +167,26 @@ def test_validator_accepts_each_supported_exact_schema(
 
 
 def test_validator_accepts_an_exact_tag_state(tmp_path: Path) -> None:
-    fields = _production_fields()
-    fields[1] = ("requested_ref", "v2.3.4")
-    fields[2] = ("requested_ref_kind", "tag")
-    state = tmp_path / "tag-state"
+    state, _, fields = _production_fixture(tmp_path)
+    fields = _replace_field(fields, "requested_ref", "v2.3.4")
+    fields = _replace_field(fields, "requested_ref_kind", "tag")
     _write_state(state, fields)
 
     result = _run(state)
 
     assert result.returncode == 0, result.stderr
     assert "PASS production" in result.stdout
+
+
+def test_validator_accepts_digest_bound_transitional_state(tmp_path: Path) -> None:
+    state, _, fields = _production_fixture(tmp_path)
+    fields.append(("provenance", "adopted-pre-1832"))
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 0, result.stderr
+    assert "PASS transitional-adopted-pre-1832" in result.stdout
 
 
 def test_validator_rejects_an_invalid_tag_name(tmp_path: Path) -> None:
@@ -252,6 +307,119 @@ def test_validator_rejects_malformed_duplicate_unknown_partial_and_mixed_state(
     assert expected_error in result.stderr
 
 
+def test_pre_digest_production_state_is_not_silently_accepted(
+    tmp_path: Path,
+) -> None:
+    state, _, fields = _production_fixture(tmp_path)
+    fields = [
+        (key, value)
+        for key, value in fields
+        if key != "validation_log_sha256"
+    ]
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert "exact expected field set" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("corruption", "expected_error"),
+    (
+        ("truncated", "Validation log does not match"),
+        ("replaced", "Validation log does not match"),
+        ("digest", "Validation log does not match"),
+        ("result", "Validation result does not match"),
+        ("empty", "no non-empty result line"),
+        ("path", "wrong validation-log path"),
+        ("invalid-utf8", "Validation log is not UTF-8"),
+        ("nul", "not canonical UTF-8/LF text"),
+        ("crlf", "not canonical UTF-8/LF text"),
+        ("line-separator", "not canonical UTF-8/LF text"),
+        ("missing-terminal-lf", "has no terminal LF"),
+        ("mode", "unexpected mode"),
+    ),
+)
+def test_validator_rejects_validation_log_or_result_drift(
+    tmp_path: Path,
+    corruption: str,
+    expected_error: str,
+) -> None:
+    state, validation_log, fields = _production_fixture(tmp_path)
+    if corruption == "truncated":
+        validation_log.write_bytes(VALIDATION_LOG_RAW[:-8])
+    elif corruption == "replaced":
+        validation_log.write_bytes(f"replacement\n{VALIDATION_RESULT}\n\n".encode())
+    elif corruption == "digest":
+        fields = _replace_field(fields, "validation_log_sha256", "0" * 64)
+        _write_state(state, fields)
+    elif corruption == "result":
+        fields = _replace_field(fields, "validation_result", "forged result")
+        _write_state(state, fields)
+    elif corruption == "empty":
+        validation_log.write_bytes(b"\n \t\n")
+        fields = _replace_field(
+            fields,
+            "validation_log_sha256",
+            hashlib.sha256(validation_log.read_bytes()).hexdigest(),
+        )
+        _write_state(state, fields)
+    elif corruption in {
+        "invalid-utf8",
+        "nul",
+        "crlf",
+        "line-separator",
+        "missing-terminal-lf",
+    }:
+        prefix = {
+            "invalid-utf8": b"context=\xff\n",
+            "nul": b"context=has\x00nul\n",
+            "crlf": b"context uses CRLF\r\n",
+            "line-separator": "context uses LS\u2028\n".encode(),
+            "missing-terminal-lf": b"context without terminal LF\n",
+        }[corruption]
+        raw = prefix + f"{VALIDATION_RESULT}\n".encode()
+        if corruption == "missing-terminal-lf":
+            raw = raw[:-1]
+        validation_log.write_bytes(raw)
+        fields = _replace_field(
+            fields,
+            "validation_log_sha256",
+            hashlib.sha256(raw).hexdigest(),
+        )
+        _write_state(state, fields)
+    elif corruption == "mode":
+        validation_log.chmod(0o644)
+    else:
+        fields = _replace_field(
+            fields,
+            "validation_log",
+            str(tmp_path / "replacement-validation.log"),
+        )
+        _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+
+
+def test_validation_log_attestation_uses_one_stable_descriptor_snapshot() -> None:
+    source = VALIDATOR.read_text(encoding="utf-8")
+
+    assert "flags |= os.O_NOFOLLOW" in source
+    assert "descriptor = os.open(path, flags)" in source
+    assert "opened = os.fstat(descriptor)" in source
+    assert "finished = os.fstat(descriptor)" in source
+    assert "visible = os.stat(path, follow_symlinks=False)" in source
+    assert 'raw = b"".join(chunks)' in source
+    assert "hashlib.sha256(raw).hexdigest()" in source
+    assert 'text = raw.decode("utf-8")' in source
+    assert 'sha256sum -- "$validation_log"' not in source
+    assert "NF { result=$0; found=1 }" not in source
+
+
 @pytest.mark.parametrize(
     ("field", "value", "expected_error"),
     (
@@ -286,12 +454,13 @@ def test_preflight_deploy_and_rollback_use_the_shared_validator() -> None:
         assert 'bash "$STATE_VALIDATOR" "$state_file"' in source
 
 
-def test_validator_scope_excludes_follow_up_attestation_and_hardening() -> None:
+def test_attestation_scope_excludes_operational_hardening() -> None:
     sources = "\n".join(
         path.read_text(encoding="utf-8")
         for path in (VALIDATOR, PREFLIGHT, DEPLOY, ROLLBACK)
     )
 
-    assert "validation_log_sha256" not in sources
+    assert "validation_log_sha256" in sources
     assert "validate-release-worktree" not in sources
     assert "recovery-snapshot" not in sources
+    assert "PYTEST_ADDOPTS" not in sources

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -573,6 +573,10 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     assert first_state["validation_exit_code"] == "0"
     assert first_state["validation_log_exit_code"] == "0"
     assert first_state["validation_result"] == "17 passed in 0.01s"
+    first_validation_log = first_release / ".hub-deployment" / "validation.log"
+    assert first_state["validation_log_sha256"] == hashlib.sha256(
+        first_validation_log.read_bytes()
+    ).hexdigest()
     assert "55 passed" not in (app_root / "shared" / "RELEASE_STATE").read_text()
 
     second = _run([DEPLOY, head_commit], env=env)
@@ -935,9 +939,10 @@ def test_deploy_rejects_shared_only_state_drift_before_mutation(
             handle.write("malformed-state-line\n")
     else:
         shared_state.write_text(
-            shared_state.read_text(encoding="utf-8").replace(
-                "validation_result=17 passed in 0.01s",
-                "validation_result=18 passed in 0.01s",
+            re.sub(
+                r"(?m)^validated_at_utc=.*$",
+                "validated_at_utc=2000-01-01T00:00:00Z",
+                shared_state.read_text(encoding="utf-8"),
             ),
             encoding="utf-8",
         )
@@ -990,6 +995,12 @@ def test_failed_validation_is_recorded_without_switching_current(
     assert failed_state["validation_command"] == "python -m pytest -q"
     assert failed_state["validation_exit_code"] == "1"
     assert failed_state["validation_result"] == "2 failed in 0.01s"
+    failed_validation_log = (
+        failed_releases[0] / ".hub-deployment" / "validation.log"
+    )
+    assert failed_state["validation_log_sha256"] == hashlib.sha256(
+        failed_validation_log.read_bytes()
+    ).hexdigest()
     assert failed_state["status"] == "validation-failed"
     assert (failed_releases[0] / ".hub-deployment" / "validation.log").is_file()
 

--- a/tests/test_ec2_runbook_attestation.py
+++ b/tests/test_ec2_runbook_attestation.py
@@ -66,7 +66,8 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
 
     deployment_dir = release / ".hub-deployment"
     validation_log = deployment_dir / "validation.log"
-    _write_bytes(validation_log, b"692 passed\n", 0o600)
+    validation_log_raw = b"collecting tests\n692 passed in 30.45s\n\n"
+    _write_bytes(validation_log, validation_log_raw, 0o600)
     fields = {
         "release": release.name,
         "requested_ref": commit,
@@ -79,6 +80,7 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
         "validation_result": "692 passed in 30.45s",
         "validation_log": str(validation_log),
         "validation_log_exit_code": "0",
+        "validation_log_sha256": hashlib.sha256(validation_log_raw).hexdigest(),
         "launcher_sha256": launcher_sha256,
         "status": "production-candidate-core",
     }
@@ -98,6 +100,7 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
         "launcher_sha256": launcher_sha256,
         "release": release,
         "release_state": release_state,
+        "validation_log": validation_log,
         "shared_launcher": shared_launcher,
         "shared_state": shared_state,
         "versioned_launcher": versioned_launcher,
@@ -119,6 +122,9 @@ def test_post_deploy_disk_attestation_accepts_exact_release(tmp_path: Path) -> N
     assert evidence["release"] == Path(fixture["release"]).name
     assert evidence["commit"] == fixture["commit"]
     assert evidence["launcher_sha256"] == fixture["launcher_sha256"]
+    assert evidence["validation_log_sha256"] == hashlib.sha256(
+        Path(fixture["validation_log"]).read_bytes()
+    ).hexdigest()
 
 
 @pytest.mark.parametrize(
@@ -130,6 +136,33 @@ def test_post_deploy_disk_attestation_accepts_exact_release(tmp_path: Path) -> N
         ("extra-field", "exact field set"),
         ("release", "wrong release name"),
         ("path", "wrong release path"),
+        (
+            "validation-log-truncated",
+            "validation log does not match RELEASE_STATE",
+        ),
+        (
+            "validation-log-replaced",
+            "validation log does not match RELEASE_STATE",
+        ),
+        (
+            "validation-result",
+            "validation result does not match the validation log",
+        ),
+        ("validation-log-invalid-utf8", "validation log is not UTF-8"),
+        (
+            "validation-log-nul",
+            "validation log is not canonical UTF-8/LF text",
+        ),
+        (
+            "validation-log-crlf",
+            "validation log is not canonical UTF-8/LF text",
+        ),
+        (
+            "validation-log-line-separator",
+            "validation log is not canonical UTF-8/LF text",
+        ),
+        ("validation-log-missing-lf", "validation log has no terminal LF"),
+        ("validation-log-mode", "unexpected validation-log mode"),
         ("state-launcher", "launcher hashes do not match"),
         ("versioned-launcher", "shared and versioned launchers differ"),
         ("shared-launcher", "shared and versioned launchers differ"),
@@ -181,6 +214,43 @@ def test_post_deploy_disk_attestation_rejects_every_identity_drift(
                 b"path=/tmp/wrong\n",
             ),
         )
+    elif invalid_case == "validation-log-truncated":
+        Path(fixture["validation_log"]).write_bytes(b"collecting tests\n")
+    elif invalid_case == "validation-log-replaced":
+        Path(fixture["validation_log"]).write_bytes(
+            b"replacement context\n692 passed in 30.45s\n\n"
+        )
+    elif invalid_case == "validation-result":
+        _replace_state_pair(
+            release_state,
+            shared_state,
+            lambda raw: raw.replace(
+                b"validation_result=692 passed in 30.45s\n",
+                b"validation_result=forged result\n",
+            ),
+        )
+    elif invalid_case == "validation-log-invalid-utf8":
+        Path(fixture["validation_log"]).write_bytes(
+            b"invalid=\xff\n692 passed in 30.45s\n"
+        )
+    elif invalid_case == "validation-log-nul":
+        Path(fixture["validation_log"]).write_bytes(
+            b"has=\x00\n692 passed in 30.45s\n"
+        )
+    elif invalid_case == "validation-log-crlf":
+        Path(fixture["validation_log"]).write_bytes(
+            b"uses CRLF\r\n692 passed in 30.45s\n"
+        )
+    elif invalid_case == "validation-log-line-separator":
+        Path(fixture["validation_log"]).write_bytes(
+            "uses LS\u2028\n692 passed in 30.45s\n".encode()
+        )
+    elif invalid_case == "validation-log-missing-lf":
+        Path(fixture["validation_log"]).write_bytes(
+            b"692 passed in 30.45s"
+        )
+    elif invalid_case == "validation-log-mode":
+        Path(fixture["validation_log"]).chmod(0o644)
     elif invalid_case == "state-launcher":
         _replace_state_pair(
             release_state,


### PR DESCRIPTION
## Summary

- record the complete `validation.log` SHA-256 in every new successful production `RELEASE_STATE`;
- attest digest and final non-empty result from one `O_NOFOLLOW`, mode-`0600` regular-file snapshot;
- reject truncation, same-result replacement, digest/result drift, invalid UTF-8, non-LF/control separators, missing terminal LF, mode drift, and fd/path identity drift;
- update the #1831 runbook and focused handoff with the same single-buffer policy;
- preserve explicit pre-digest transitional, adopted-legacy, and six-field legacy compatibility.

This is stacked on #1856 and addresses the validation-log slice of #1848. It does not close #1848 while #1850 and #1856 remain unmerged drafts.

## Verification

- 155 focused EC2/runbook tests passed;
- full suite: 803 passed, 12 skipped (PowerShell unavailable in this environment);
- Bash syntax and `git diff --check` passed;
- mojibake: 292 Markdown files passed;
- narrative consistency: 0 errors, 0 warnings;
- frozen benchmarks: 3/3 passed;
- independent adversarial rereview: PUBLISH, no remaining #1848-scope blocker.

## Stack and merge boundary

- base: `agent/1848-exact-release-state` / #1856;
- merge #1856 first, then retarget this PR to `main` and re-run all checks;
- do not merge or repin #1831 from this draft alone.

## Operational safety

Draft only. No EC2 mutation, restart, rollback, DNS, TLS, nginx, Security Group, IAM, or AWS action was performed. #1831 remains hard-blocked and read-only.

The broader environment, lock, transaction/recovery, process, and dependency hardening in #1851–#1855 remains separate. The no-follow single-descriptor read here is limited to making this attestation internally coherent; it does not implement trusted transaction creation or recovery.