### PR TITLE
build(ec2): seal reproducible deployment dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup reviewed EC2 Python ABI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,188 @@ jobs:
       - name: Run PowerShell tooling behavior tests
         run: python -m pytest -q tests/test_powershell_tooling_safety.py
 
+  ec2-locked-environment:
+    name: EC2 locked environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup reviewed EC2 Python ABI
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify dependency locks
+        run: bash ops/ec2/dependency-lock-digest.sh "$GITHUB_WORKSPACE"
+
+      - name: Certify reproducible offline dependency installs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python_bin="$(command -v python)"
+          node_bin="$(command -v node)"
+          case "$python_bin" in
+            /*) ;;
+            *)
+              echo "::error::setup-python did not provide an absolute interpreter path"
+              exit 1
+              ;;
+          esac
+          python_bin="$(readlink -f -- "$python_bin")"
+          case "$node_bin" in
+            /*) ;;
+            *)
+              echo "::error::runner did not provide an absolute Node path"
+              exit 1
+              ;;
+          esac
+          node_bin="$(readlink -f -- "$node_bin")"
+          node_dir="$(dirname -- "$node_bin")"
+          test -x "$node_bin"
+
+          workspace="$GITHUB_WORKSPACE"
+          wheelhouse="$RUNNER_TEMP/hub-ec2-wheelhouse"
+          corrupt_wheelhouse="$RUNNER_TEMP/hub-ec2-wheelhouse-corrupt"
+          corrupt_release="$RUNNER_TEMP/hub-ec2-corrupt-release"
+          release_a="$RUNNER_TEMP/hub-ec2-release-a"
+          release_b="$RUNNER_TEMP/hub-ec2-release-b"
+
+          create_release() {
+            local release="$1"
+            mkdir -p "$release/ops/ec2"
+            cp -- "$workspace/ops/ec2/requirements-runtime.lock" \
+              "$release/ops/ec2/requirements-runtime.lock"
+            cp -- "$workspace/ops/ec2/requirements-validation.lock" \
+              "$release/ops/ec2/requirements-validation.lock"
+            "$python_bin" -I -m venv "$release/.venv"
+          }
+
+          sealed_offline_install() {
+            local release="$1"
+            local links="$2"
+            env -i \
+              HOME="$release" \
+              LANG=C.UTF-8 \
+              PATH=/usr/bin:/bin \
+              PYTHONNOUSERSITE=1 \
+              "$python_bin" -I \
+                "$workspace/ops/ec2/verify-installed-dependencies.py" \
+                install-offline \
+                "$release" \
+                "$python_bin" \
+                "$dependency_digest" \
+                "$links"
+          }
+
+          mkdir -p "$wheelhouse"
+          env -i \
+            HOME="$RUNNER_TEMP/hub-ec2-download-home" \
+            LANG=C.UTF-8 \
+            PATH=/usr/bin:/bin \
+            PIP_CONFIG_FILE=/dev/null \
+            PIP_DISABLE_PIP_VERSION_CHECK=1 \
+            PIP_NO_CACHE_DIR=1 \
+            PIP_NO_INPUT=1 \
+            PYTHONNOUSERSITE=1 \
+            "$python_bin" -I -m pip download \
+              --disable-pip-version-check \
+              --index-url https://pypi.org/simple \
+              --isolated \
+              --no-cache-dir \
+              --no-deps \
+              --no-input \
+              --only-binary=:all: \
+              --require-hashes \
+              --dest "$wheelhouse" \
+              --requirement "$workspace/ops/ec2/requirements-validation.lock"
+
+          mapfile -t downloaded_wheels < <(
+            find "$wheelhouse" -maxdepth 1 -type f -name '*.whl' -print \
+              | LC_ALL=C sort
+          )
+          if [ "${#downloaded_wheels[@]}" -eq 0 ]; then
+            echo "::error::allowlisted download produced no wheels"
+            exit 1
+          fi
+
+          dependency_digest="$(
+            bash "$workspace/ops/ec2/dependency-lock-digest.sh" "$workspace"
+          )"
+
+          mkdir -p "$corrupt_wheelhouse"
+          cp -a -- "$wheelhouse/." "$corrupt_wheelhouse/"
+          corrupt_wheel="$corrupt_wheelhouse/$(basename "${downloaded_wheels[0]}")"
+          printf 'intentional-hash-corruption\n' >> "$corrupt_wheel"
+          create_release "$corrupt_release"
+          corrupt_log="$RUNNER_TEMP/hub-ec2-corrupt-wheel.log"
+          if sealed_offline_install \
+            "$corrupt_release" "$corrupt_wheelhouse" \
+            >"$corrupt_log" 2>&1; then
+            echo "::error::pip accepted a wheel whose reviewed hash was corrupted"
+            exit 1
+          fi
+          if ! grep -Fq \
+            'THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE' \
+            "$corrupt_log"; then
+            cat "$corrupt_log" >&2
+            echo "::error::corrupt-wheel install failed for a reason other than hash rejection"
+            exit 1
+          fi
+
+          create_release "$release_a"
+          create_release "$release_b"
+          test "$(
+            bash "$workspace/ops/ec2/dependency-lock-digest.sh" "$release_a"
+          )" = "$dependency_digest"
+          test "$(
+            bash "$workspace/ops/ec2/dependency-lock-digest.sh" "$release_b"
+          )" = "$dependency_digest"
+          token_a="$(
+            sealed_offline_install "$release_a" "$wheelhouse"
+          )"
+          token_b="$(
+            sealed_offline_install "$release_b" "$wheelhouse"
+          )"
+
+          inventory_a="$RUNNER_TEMP/hub-ec2-inventory-a.json"
+          inventory_b="$RUNNER_TEMP/hub-ec2-inventory-b.json"
+          env -i \
+            HOME="$release_a" \
+            LANG=C.UTF-8 \
+            PATH=/usr/bin:/bin \
+            PYTHONNOUSERSITE=1 \
+            "$release_a/.venv/bin/python" -I \
+              "$workspace/ops/ec2/verify-installed-dependencies.py" \
+              verify "$release_a" "$python_bin" "$dependency_digest" "$token_a" \
+              > "$inventory_a"
+          env -i \
+            HOME="$release_b" \
+            LANG=C.UTF-8 \
+            PATH=/usr/bin:/bin \
+            PYTHONNOUSERSITE=1 \
+            "$release_b/.venv/bin/python" -I \
+              "$workspace/ops/ec2/verify-installed-dependencies.py" \
+              verify "$release_b" "$python_bin" "$dependency_digest" "$token_b" \
+              > "$inventory_b"
+          if ! cmp -s -- "$inventory_a" "$inventory_b"; then
+            diff -u -- "$inventory_a" "$inventory_b" || true
+            echo "::error::fresh offline installs produced different inventories"
+            exit 1
+          fi
+
+          cd "$workspace"
+          env -i \
+            HOME="$release_a" \
+            LANG=C.UTF-8 \
+            PATH="$node_dir:/usr/bin:/bin" \
+            PYTHONNOUSERSITE=1 \
+            "$release_a/.venv/bin/python" -m pytest -q
+
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -131,6 +131,15 @@ Issue #1832 hardens that boundary before the blocked host operation in #1831:
 - every successful production state records the complete validation log's
   SHA-256 and must match that log's final non-empty line; preflight, deploy, and
   rollback reject truncated, replaced, or result-divergent evidence;
+- the retained EC2 environment is installed from explicit runtime and
+  validation locks for the reviewed Linux x86_64 CPython 3.12 ABI; ambient
+  `PIP_*` settings, mutable version ranges, unhashed artifacts, unexpected
+  transitive packages, and pip self-upgrade are rejected; the environment must
+  originate from `/usr/bin/python3`, the bootstrap installer is removed, and
+  pip consumes an immutable sealed `memfd` derived from the same no-follow lock
+  snapshot as the digest; path replacement/restoration is rejected, and the
+  exact installed inventory is revalidated after tests, while the combined lock
+  digest, tier, and path are recorded in production release state;
 - before mutation, deploy validates the managed rollback target's directory,
   full commit, release/path state, launcher presence, and launcher SHA-256;
 - replacement launcher, release state, current marker, and rollback pointer are

--- a/ops/ec2/ISSUE_1831_RUNBOOK.md
+++ b/ops/ec2/ISSUE_1831_RUNBOOK.md
@@ -159,6 +159,9 @@ required_keys = {
     "validation_log",
     "validation_log_exit_code",
     "validation_log_sha256",
+    "dependency_tier",
+    "dependency_lock",
+    "dependency_lock_sha256",
     "launcher_sha256",
     "status",
 }
@@ -171,6 +174,34 @@ def require_regular(path, *, executable=False, mode=None):
         raise SystemExit(f"not executable: {path}")
     if mode is not None and actual_mode != mode:
         raise SystemExit(f"unexpected mode for {path}: {actual_mode:o}")
+
+def read_stable_regular(path, *, mode):
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise SystemExit("O_NOFOLLOW is unavailable for dependency-lock attestation")
+    descriptor = os.open(path, flags | os.O_NOFOLLOW)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            raise SystemExit(f"not one regular single-link file: {path}")
+        if stat.S_IMODE(before.st_mode) != mode:
+            raise SystemExit(f"unexpected mode for {path}: {stat.S_IMODE(before.st_mode):o}")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    fields = ("st_dev", "st_ino", "st_mode", "st_nlink", "st_size", "st_mtime_ns", "st_ctime_ns")
+    visible = os.stat(path, follow_symlinks=False)
+    if any(getattr(before, field) != getattr(after, field) for field in fields):
+        raise SystemExit(f"regular file changed while it was read: {path}")
+    if any(getattr(after, field) != getattr(visible, field) for field in fields):
+        raise SystemExit(f"regular file path changed while it was read: {path}")
+    return b"".join(chunks)
 
 def read_canonical_validation_log(path, *, mode):
     flags = os.O_RDONLY | os.O_CLOEXEC
@@ -289,7 +320,11 @@ if not re.fullmatch(
     state["validated_at_utc"],
 ):
     raise SystemExit("release-state validation timestamp is invalid")
-if state["validation_command"] != "python -m pytest -q":
+expected_validation_command = (
+    f"/usr/bin/env -i HOME={deployed} LANG=C.UTF-8 PATH=/usr/bin:/bin "
+    f"PYTHONNOUSERSITE=1 {deployed}/.venv/bin/python -m pytest -q"
+)
+if state["validation_command"] != expected_validation_command:
     raise SystemExit("release-state validation command differs")
 if state["validation_exit_code"] != "0" or state["validation_log_exit_code"] != "0":
     raise SystemExit("candidate validation did not pass")
@@ -312,6 +347,24 @@ if not validation_result_lines:
     raise SystemExit("validation log has no non-empty result line")
 if validation_result_lines[-1] != state["validation_result"]:
     raise SystemExit("validation result does not match the validation log")
+if state["dependency_tier"] != "runtime+validation-v1":
+    raise SystemExit("release state has the wrong dependency tier")
+expected_dependency_lock = deployed / "ops" / "ec2" / "requirements-validation.lock"
+if state["dependency_lock"] != str(expected_dependency_lock):
+    raise SystemExit("release state has the wrong dependency-lock path")
+dependency_digest = hashlib.sha256()
+for relative in (
+    "ops/ec2/requirements-runtime.lock",
+    "ops/ec2/requirements-validation.lock",
+):
+    raw = read_stable_regular(deployed / relative, mode=0o644)
+    relative_raw = relative.encode("ascii")
+    dependency_digest.update(len(relative_raw).to_bytes(4, "big"))
+    dependency_digest.update(relative_raw)
+    dependency_digest.update(len(raw).to_bytes(8, "big"))
+    dependency_digest.update(raw)
+if state["dependency_lock_sha256"] != dependency_digest.hexdigest():
+    raise SystemExit("dependency locks do not match RELEASE_STATE")
 if not re.fullmatch(r"[0-9a-f]{64}", state["launcher_sha256"]):
     raise SystemExit("launcher identity is missing")
 if state["status"] != "production-candidate-core":
@@ -337,6 +390,7 @@ if current_marker.read_bytes() != f"{deployed.name}\n".encode():
 
 print(json.dumps({
     "commit": state["commit"],
+    "dependency_lock_sha256": state["dependency_lock_sha256"],
     "launcher_sha256": state["launcher_sha256"],
     "path": state["path"],
     "release": state["release"],
@@ -356,7 +410,8 @@ EXPECTED_LAUNCHER_SHA256="$(
 The production release state is acceptable only while its mode-`0600`,
 canonical UTF-8/LF validation log can be read from one no-follow regular-file
 snapshot, still matches the recorded SHA-256, and has a final non-empty line
-equal to `validation_result`.
+equal to `validation_result`. Its reviewed runtime and validation locks must
+also reproduce the recorded combined digest.
 
 An internal failure after deployment mutation begins automatically restores the
 exact pre-deploy `current` symlink, shared launcher, shared release state,

--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -83,6 +83,21 @@ command, its exit code, its final output line, and its validation log. Failed
 validation leaves its candidate release and metadata for inspection but never
 switches `current`.
 
+The EC2 release environment is installed from separate runtime and validation
+locks under `ops/ec2`. Both contain exact versions and reviewed wheel hashes for
+the Linux x86_64 CPython 3.12 deployment ABI. Deployment rejects ambient
+`PIP_*` settings, removes the former pip self-upgrade, uses only the fixed
+PyPI simple index with `--require-hashes --no-deps --only-binary`, and runs
+`pip check`. It then removes the bootstrap installer and requires the installed
+name/version inventory and the virtual-environment base interpreter to match
+the reviewed locks exactly, both before and after validation. Pip consumes a
+single sealed Linux `memfd` assembled from the same no-follow lock snapshot that
+produces the evidence digest; path identity tokens also reject temporary atomic
+replacement followed by restoration. The combined lock digest is checked again
+after validation and recorded with the selected tier and lock path in
+`RELEASE_STATE`. The root requirement files remain the portable authoring tiers;
+they are not the EC2 deployment lock.
+
 The release state also records the SHA-256 of the selected `hub-api.sh`
 launcher. Before changing operational state, deployment validates that the
 current release is a managed, usable rollback target and stages all replacement

--- a/ops/ec2/dependency-lock-digest.sh
+++ b/ops/ec2/dependency-lock-digest.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "[dependency-lock:error] Usage: dependency-lock-digest <release-path>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec /usr/bin/python3 -I \
+  "$SCRIPT_DIR/verify-installed-dependencies.py" \
+  digest \
+  "$1"

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -4,9 +4,11 @@ set -euo pipefail
 APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 REPO_URL="${HUB_OPTIMUS_REPO_URL:-https://github.com/Voxterrae/HUB_Optimus.git}"
 DEPLOY_REF="${1:-}"
-VALIDATION_COMMAND_TEXT="python -m pytest -q"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"
+DEPENDENCY_LOCK_TOOL="$SCRIPT_DIR/dependency-lock-digest.sh"
+DEPENDENCY_INVENTORY_TOOL="$SCRIPT_DIR/verify-installed-dependencies.py"
+SYSTEM_PYTHON="/usr/bin/python3"
 
 usage() {
   cat <<USAGE
@@ -25,12 +27,35 @@ fail() {
   exit 1
 }
 
+reject_ambient_pip_environment() {
+  local name
+
+  while IFS= read -r name; do
+    case "$name" in
+      PIP_*) fail "ambient pip setting is not allowed: $name" ;;
+    esac
+  done < <(compgen -e)
+}
+
+dependency_lock_digest() {
+  local release_path="$1"
+  local digest
+
+  [ -f "$DEPENDENCY_LOCK_TOOL" ] && [ ! -L "$DEPENDENCY_LOCK_TOOL" ] \
+    || fail "Dependency-lock validator is not one regular file: $DEPENDENCY_LOCK_TOOL"
+  digest="$(/bin/bash "$DEPENDENCY_LOCK_TOOL" "$release_path")" \
+    || fail "Dependency lock validation failed for $release_path"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Dependency-lock validator returned an invalid digest."
+  printf '%s\n' "$digest"
+}
+
 validate_release_state_schema() {
   local state_file="$1"
 
   [ -f "$STATE_VALIDATOR" ] && [ ! -L "$STATE_VALIDATOR" ] \
     || fail "Release-state validator is not one regular file: $STATE_VALIDATOR"
-  bash "$STATE_VALIDATOR" "$state_file" >/dev/null \
+  /bin/bash "$STATE_VALIDATOR" "$state_file" >/dev/null \
     || fail "Complete release-state validation failed: $state_file"
 }
 
@@ -339,6 +364,21 @@ else
   FETCH_REF="refs/tags/$DEPLOY_REF"
 fi
 
+reject_ambient_pip_environment
+
+"$SYSTEM_PYTHON" -I - <<'PY_DEPLOY_ABI' \
+  || fail "EC2 dependency lock requires CPython 3.12 on Linux x86_64."
+import platform
+import sys
+
+if sys.implementation.name != "cpython":
+    raise SystemExit(1)
+if sys.version_info[:2] != (3, 12):
+    raise SystemExit(1)
+if sys.platform != "linux" or platform.machine() != "x86_64":
+    raise SystemExit(1)
+PY_DEPLOY_ABI
+
 echo "[deploy] Starting HUB_Optimus deploy"
 echo "[deploy] Requested $REF_KIND: $DEPLOY_REF"
 
@@ -380,33 +420,81 @@ CANDIDATE_LAUNCHER_SHA256="$(
 )"
 echo "[deploy] Candidate launcher SHA-256: $CANDIDATE_LAUNCHER_SHA256"
 
+echo "[deploy] Validating reviewed dependency locks"
+DEPENDENCY_LOCK_SHA256="$(dependency_lock_digest "$RELEASE_DIR")"
+DEPENDENCY_LOCK_PATH="$RELEASE_DIR/ops/ec2/requirements-validation.lock"
+echo "[deploy] Dependency-lock SHA-256: $DEPENDENCY_LOCK_SHA256"
+
 echo "[deploy] Creating venv"
 cd "$RELEASE_DIR"
-python3 -m venv .venv
-source .venv/bin/activate
+"$SYSTEM_PYTHON" -I -m venv .venv
+VENV_PYTHON="$RELEASE_DIR/.venv/bin/python"
+[ -x "$VENV_PYTHON" ] \
+  || fail "Virtual-environment Python is not executable."
+[ -f "$DEPENDENCY_INVENTORY_TOOL" ] && [ ! -L "$DEPENDENCY_INVENTORY_TOOL" ] \
+  || fail "Dependency-inventory verifier is not one regular file: $DEPENDENCY_INVENTORY_TOOL"
 
-echo "[deploy] Installing dependencies"
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
+printf -v VALIDATION_COMMAND_TEXT \
+  '/usr/bin/env -i HOME=%q LANG=C.UTF-8 PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 %q -m pytest -q' \
+  "$RELEASE_DIR" \
+  "$VENV_PYTHON"
+
+echo "[deploy] Installing from one sealed, hash-locked dependency snapshot"
+DEPENDENCY_CAPTURE_TOKEN="$(
+  /usr/bin/env -i \
+    HOME="$RELEASE_DIR" \
+    LANG=C.UTF-8 \
+    PATH=/usr/bin:/bin \
+    PYTHONNOUSERSITE=1 \
+    "$SYSTEM_PYTHON" -I \
+      "$DEPENDENCY_INVENTORY_TOOL" \
+      install \
+      "$RELEASE_DIR" \
+      "$SYSTEM_PYTHON" \
+      "$DEPENDENCY_LOCK_SHA256"
+)"
+[[ "$DEPENDENCY_CAPTURE_TOKEN" =~ ^[0-9a-f]{64}$ ]] \
+  || fail "Dependency installer returned an invalid snapshot token."
 
 mkdir -p "$DEPLOYMENT_DIR"
 chmod 0700 "$DEPLOYMENT_DIR"
 
 echo "[deploy] Running validation: $VALIDATION_COMMAND_TEXT"
 set +e
-python -m pytest -q 2>&1 | tee "$VALIDATION_LOG"
+/usr/bin/env -i \
+  HOME="$RELEASE_DIR" \
+  LANG=C.UTF-8 \
+  PATH=/usr/bin:/bin \
+  PYTHONNOUSERSITE=1 \
+  "$VENV_PYTHON" -m pytest -q 2>&1 | tee "$VALIDATION_LOG"
 VALIDATION_PIPE_STATUS=("${PIPESTATUS[@]}")
 set -e
 VALIDATION_EXIT_CODE="${VALIDATION_PIPE_STATUS[0]}"
 VALIDATION_LOG_EXIT_CODE="${VALIDATION_PIPE_STATUS[1]}"
-
-deactivate
 
 VALIDATION_RESULT="$(
   awk 'NF { result=$0 } END { print result == "" ? "no output" : result }' \
     "$VALIDATION_LOG"
 )"
 VALIDATION_LOG_SHA256="$(sha256_file "$VALIDATION_LOG")"
+[ "$(dependency_lock_digest "$RELEASE_DIR")" = "$DEPENDENCY_LOCK_SHA256" ] \
+  || fail "dependency locks changed during installation or validation."
+DEPENDENCY_INVENTORY_AFTER="$(
+  /usr/bin/env -i \
+    HOME="$RELEASE_DIR" \
+    LANG=C.UTF-8 \
+    PATH=/usr/bin:/bin \
+    PYTHONNOUSERSITE=1 \
+    "$VENV_PYTHON" -I \
+      "$DEPENDENCY_INVENTORY_TOOL" \
+      verify \
+      "$RELEASE_DIR" \
+      "$SYSTEM_PYTHON" \
+      "$DEPENDENCY_LOCK_SHA256" \
+      "$DEPENDENCY_CAPTURE_TOKEN"
+)" || fail "Installed dependencies changed during validation."
+[ -n "$DEPENDENCY_INVENTORY_AFTER" ] \
+  || fail "Installed dependency inventory evidence is empty."
 
 if [ "$VALIDATION_EXIT_CODE" -eq 0 ] \
   && [ "$VALIDATION_LOG_EXIT_CODE" -eq 0 ]; then
@@ -428,6 +516,9 @@ validation_result=$VALIDATION_RESULT
 validation_log=$VALIDATION_LOG
 validation_log_exit_code=$VALIDATION_LOG_EXIT_CODE
 validation_log_sha256=$VALIDATION_LOG_SHA256
+dependency_tier=runtime+validation-v1
+dependency_lock=$DEPENDENCY_LOCK_PATH
+dependency_lock_sha256=$DEPENDENCY_LOCK_SHA256
 launcher_sha256=$CANDIDATE_LAUNCHER_SHA256
 status=$RELEASE_STATUS
 STATE

--- a/ops/ec2/requirements-runtime.lock
+++ b/ops/ec2/requirements-runtime.lock
@@ -1,0 +1,16 @@
+# HUB_Optimus EC2 runtime dependency lock.
+# Linux x86_64 wheels for the reviewed EC2 CPython 3.12 ABI.
+# Regenerate and review hashes explicitly; deployment never resolves ranges.
+
+attrs==26.1.0 \
+    --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+jsonschema==4.26.0 \
+    --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
+jsonschema-specifications==2025.9.1 \
+    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+referencing==0.37.0 \
+    --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
+rpds-py==2026.6.3 \
+    --hash=sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8

--- a/ops/ec2/requirements-validation.lock
+++ b/ops/ec2/requirements-validation.lock
@@ -1,0 +1,17 @@
+# HUB_Optimus EC2 validation dependency lock.
+# Runtime dependencies remain a distinct reviewed tier.
+
+-r requirements-runtime.lock
+
+iniconfig==2.3.0 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+pluggy==1.6.0 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+Pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pytest==9.1.1 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
+PyYAML==6.0.3 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc

--- a/ops/ec2/validate-release-state.sh
+++ b/ops/ec2/validate-release-state.sh
@@ -7,6 +7,8 @@ if [ "$#" -ne 1 ]; then
 fi
 
 STATE_FILE="$1"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+DEPENDENCY_LOCK_TOOL="$SCRIPT_DIR/dependency-lock-digest.sh"
 
 fail() {
   echo "[release-state:error] $*" >&2
@@ -105,11 +107,22 @@ validate_production() {
   local requested_ref
   local requested_ref_kind
   local digest_bound="no"
+  local dependency_bound="no"
   local validation_log
   local validation_log_sha256
+  local dependency_lock_sha256
+  local expected_validation_command
 
   if [ "$transitional" = "yes" ]; then
-    if [[ -n "${SEEN_STATE_KEYS[validation_log_sha256]+present}" ]]; then
+    if [[ -n "${SEEN_STATE_KEYS[dependency_lock_sha256]+present}" ]]; then
+      require_exact_keys \
+        release requested_ref requested_ref_kind commit path validated_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code validation_log_sha256 dependency_tier \
+        dependency_lock dependency_lock_sha256 launcher_sha256 status provenance
+      digest_bound="yes"
+      dependency_bound="yes"
+    elif [[ -n "${SEEN_STATE_KEYS[validation_log_sha256]+present}" ]]; then
       require_exact_keys \
         release requested_ref requested_ref_kind commit path validated_at_utc \
         validation_command validation_exit_code validation_result validation_log \
@@ -129,9 +142,11 @@ validate_production() {
     require_exact_keys \
       release requested_ref requested_ref_kind commit path validated_at_utc \
       validation_command validation_exit_code validation_result validation_log \
-      validation_log_exit_code validation_log_sha256 launcher_sha256 status
+      validation_log_exit_code validation_log_sha256 dependency_tier \
+      dependency_lock dependency_lock_sha256 launcher_sha256 status
     schema="production"
     digest_bound="yes"
+    dependency_bound="yes"
   fi
 
   require_common_identity
@@ -157,7 +172,15 @@ validate_production() {
   esac
   [[ "$(state_value validated_at_utc)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
     || fail "$STATE_FILE has an invalid validation timestamp."
-  [ "$(state_value validation_command)" = "python -m pytest -q" ] \
+  if [ "$dependency_bound" = "yes" ]; then
+    printf -v expected_validation_command \
+      '/usr/bin/env -i HOME=%q LANG=C.UTF-8 PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 %q -m pytest -q' \
+      "$(state_value path)" \
+      "$(state_value path)/.venv/bin/python"
+  else
+    expected_validation_command="python -m pytest -q"
+  fi
+  [ "$(state_value validation_command)" = "$expected_validation_command" ] \
     || fail "$STATE_FILE has an unexpected validation command."
   [ "$(state_value validation_exit_code)" = "0" ] \
     && [ "$(state_value validation_log_exit_code)" = "0" ] \
@@ -264,6 +287,20 @@ try:
 finally:
     os.close(descriptor)
 PY_VALIDATION_LOG
+  fi
+
+  if [ "$dependency_bound" = "yes" ]; then
+    [ "$(state_value dependency_tier)" = "runtime+validation-v1" ] \
+      || fail "$STATE_FILE has an unsupported dependency tier."
+    [ "$(state_value dependency_lock)" = "$(state_value path)/ops/ec2/requirements-validation.lock" ] \
+      || fail "$STATE_FILE has the wrong dependency-lock path."
+    dependency_lock_sha256="$(state_value dependency_lock_sha256)"
+    [[ "$dependency_lock_sha256" =~ ^[0-9a-f]{64}$ ]] \
+      || fail "$STATE_FILE has no valid dependency-lock SHA-256."
+    [ -f "$DEPENDENCY_LOCK_TOOL" ] && [ ! -L "$DEPENDENCY_LOCK_TOOL" ] \
+      || fail "Dependency-lock validator is not one regular file: $DEPENDENCY_LOCK_TOOL"
+    [ "$(/bin/bash "$DEPENDENCY_LOCK_TOOL" "$(state_value path)")" = "$dependency_lock_sha256" ] \
+      || fail "$STATE_FILE dependency lock does not match its reviewed release."
   fi
 
   [[ "$(state_value launcher_sha256)" =~ ^[0-9a-f]{64}$ ]] \

--- a/ops/ec2/verify-installed-dependencies.py
+++ b/ops/ec2/verify-installed-dependencies.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import ctypes
+from dataclasses import dataclass
+from importlib.metadata import distributions
+from pathlib import Path
+
+
+INDEX_URL = "https://pypi.org/simple"
+LOCK_SPECS = (
+    (
+        "ops/ec2/requirements-runtime.lock",
+        {
+            "attrs",
+            "jsonschema",
+            "jsonschema-specifications",
+            "referencing",
+            "rpds-py",
+            "typing-extensions",
+        },
+        False,
+    ),
+    (
+        "ops/ec2/requirements-validation.lock",
+        {"iniconfig", "packaging", "pluggy", "pygments", "pytest", "pyyaml"},
+        True,
+    ),
+)
+HASH_RE = re.compile(r"--hash=sha256:([0-9a-f]{64})")
+PIN_RE = re.compile(
+    r"([A-Za-z0-9][A-Za-z0-9._-]*)==([A-Za-z0-9][A-Za-z0-9.!+_-]*)"
+)
+IDENTITY_FIELDS = (
+    "st_dev",
+    "st_ino",
+    "st_mode",
+    "st_nlink",
+    "st_size",
+    "st_mtime_ns",
+    "st_ctime_ns",
+)
+
+
+@dataclass(frozen=True)
+class LockSnapshot:
+    release: Path
+    digest: str
+    expected: dict[str, str]
+    combined_requirements: bytes
+    identities: dict[Path, os.stat_result]
+
+
+def fail(message: str) -> None:
+    print(f"[dependency-lock:error] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def normalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def logical_entries(text: str) -> list[str]:
+    entries: list[str] = []
+    pending = ""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("\\"):
+            pending += line[:-1].rstrip() + " "
+            continue
+        entries.append((pending + line).strip())
+        pending = ""
+    if pending:
+        fail("lock ends in an incomplete continuation")
+    return entries
+
+
+def read_regular(path: Path) -> tuple[bytes, os.stat_result]:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if not hasattr(os, "O_NOFOLLOW"):
+        fail("O_NOFOLLOW is unavailable")
+    flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        fail(f"cannot open lock without following links: {path}: {exc}")
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            fail(f"lock is not one regular single-link file: {path}")
+        if stat.S_IMODE(before.st_mode) != 0o644:
+            fail(f"lock has an unexpected mode: {path}")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if any(getattr(before, field) != getattr(after, field) for field in IDENTITY_FIELDS):
+        fail(f"lock changed while it was read: {path}")
+    visible = os.stat(path, follow_symlinks=False)
+    if any(getattr(after, field) != getattr(visible, field) for field in IDENTITY_FIELDS):
+        fail(f"lock path changed while it was read: {path}")
+    return b"".join(chunks), after
+
+
+def validate_lock(
+    raw: bytes,
+    path: Path,
+    expected_names: set[str],
+    include_runtime: bool,
+) -> tuple[list[str], dict[str, str]]:
+    if not raw or not raw.endswith(b"\n") or b"\r" in raw or b"\x00" in raw:
+        fail(f"lock is not canonical LF text: {path}")
+    try:
+        text = raw.decode("ascii")
+    except UnicodeDecodeError:
+        fail(f"lock is not canonical ASCII: {path}")
+    entries = logical_entries(text)
+    include = "-r requirements-runtime.lock"
+    if include_runtime:
+        if entries.count(include) != 1:
+            fail(f"validation lock must include the runtime lock exactly once: {path}")
+        entries.remove(include)
+    elif any(entry.startswith(("-r ", "--requirement ")) for entry in entries):
+        fail(f"runtime lock must not include another requirements file: {path}")
+
+    pins: dict[str, str] = {}
+    for entry in entries:
+        if entry.startswith("-"):
+            fail(f"lock contains an unsupported option: {entry}")
+        pin = PIN_RE.fullmatch(entry.split()[0])
+        if pin is None:
+            fail(f"dependency is not one exact version pin: {entry}")
+        name = normalize_name(pin.group(1))
+        if name in pins:
+            fail(f"lock contains a duplicate dependency: {name}")
+        pins[name] = pin.group(2)
+        hashes = HASH_RE.findall(entry)
+        remainder = HASH_RE.sub("", entry[len(pin.group(0)) :]).strip()
+        if not hashes or remainder:
+            fail(f"dependency does not contain only reviewed SHA-256 hashes: {name}")
+        if len(hashes) != len(set(hashes)):
+            fail(f"dependency contains a duplicate SHA-256 hash: {name}")
+    if set(pins) != expected_names:
+        missing = ",".join(sorted(expected_names - set(pins))) or "none"
+        unexpected = ",".join(sorted(set(pins) - expected_names)) or "none"
+        fail(f"lock dependency set differs; missing={missing}; unexpected={unexpected}")
+    return entries, pins
+
+
+def load_snapshot(release: Path) -> LockSnapshot:
+    if not release.is_absolute() or str(release) != os.path.abspath(release):
+        fail("release path must be one canonical absolute path")
+    if release.is_symlink() or not release.is_dir():
+        fail("release path is not one real directory")
+
+    digest = hashlib.sha256()
+    expected: dict[str, str] = {}
+    combined_entries: list[str] = []
+    identities: dict[Path, os.stat_result] = {}
+    for relative, expected_names, include_runtime in LOCK_SPECS:
+        path = release / relative
+        raw, identity = read_regular(path)
+        entries, pins = validate_lock(raw, path, expected_names, include_runtime)
+        overlap = set(expected) & set(pins)
+        if overlap:
+            fail(f"dependency appears in more than one tier: {sorted(overlap)[0]}")
+        expected.update(pins)
+        combined_entries.extend(entries)
+        identities[path] = identity
+        relative_raw = relative.encode("ascii")
+        digest.update(len(relative_raw).to_bytes(4, "big"))
+        digest.update(relative_raw)
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+    combined = ("\n".join(combined_entries) + "\n").encode("ascii")
+    return LockSnapshot(
+        release=release,
+        digest=digest.hexdigest(),
+        expected=expected,
+        combined_requirements=combined,
+        identities=identities,
+    )
+
+
+def require_digest(snapshot: LockSnapshot, expected_digest: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+        fail("expected dependency-lock digest is invalid")
+    if snapshot.digest != expected_digest:
+        fail("dependency locks differ from the reviewed input digest")
+
+
+def require_unchanged_paths(snapshot: LockSnapshot) -> None:
+    for path, original in snapshot.identities.items():
+        try:
+            visible = os.stat(path, follow_symlinks=False)
+        except OSError as exc:
+            fail(f"lock path changed after capture: {path}: {exc}")
+        if any(
+            getattr(original, field) != getattr(visible, field)
+            for field in IDENTITY_FIELDS
+        ):
+            fail(f"lock path changed after capture: {path}")
+
+
+def snapshot_token(snapshot: LockSnapshot) -> str:
+    token = hashlib.sha256()
+    token.update(snapshot.digest.encode("ascii"))
+    for path in sorted(snapshot.identities, key=lambda item: str(item)):
+        relative = str(path.relative_to(snapshot.release)).encode("ascii")
+        identity = snapshot.identities[path]
+        token.update(len(relative).to_bytes(4, "big"))
+        token.update(relative)
+        for field in IDENTITY_FIELDS:
+            value = getattr(identity, field)
+            token.update(value.to_bytes(16, "big", signed=False))
+    return token.hexdigest()
+
+
+def require_snapshot_token(snapshot: LockSnapshot, expected_token: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_token):
+        fail("expected dependency-lock snapshot token is invalid")
+    if snapshot_token(snapshot) != expected_token:
+        fail("dependency-lock paths changed since the sealed install snapshot")
+
+
+def canonical_inventory(inventory: dict[str, str]) -> str:
+    return json.dumps(
+        [{"name": name, "version": inventory[name]} for name in sorted(inventory)],
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def installed_inventory() -> dict[str, str]:
+    installed: dict[str, str] = {}
+    for distribution in distributions():
+        raw_name = distribution.metadata.get("Name")
+        if not raw_name:
+            fail("installed distribution has no package name")
+        name = normalize_name(raw_name)
+        if name in installed:
+            fail(f"installed inventory contains a duplicate dependency: {name}")
+        installed[name] = distribution.version
+    return installed
+
+
+def verify_python_identity(release: Path, system_python: Path) -> None:
+    expected_python = release / ".venv" / "bin" / "python"
+    if Path(sys.executable) != expected_python:
+        fail("inventory is not running from the candidate virtual environment")
+    try:
+        if not os.path.samefile(sys._base_executable, system_python):
+            fail("virtual environment was not created by the reviewed system Python")
+    except OSError as exc:
+        fail(f"could not attest the virtual-environment base interpreter: {exc}")
+
+
+def verify_inventory(
+    snapshot: LockSnapshot,
+    system_python: Path,
+) -> str:
+    verify_python_identity(snapshot.release, system_python)
+    installed = installed_inventory()
+    if installed != snapshot.expected:
+        missing = sorted(set(snapshot.expected) - set(installed))
+        unexpected = sorted(set(installed) - set(snapshot.expected))
+        wrong = sorted(
+            name
+            for name in set(snapshot.expected) & set(installed)
+            if snapshot.expected[name] != installed[name]
+        )
+        fail(
+            "installed dependency inventory differs; "
+            f"missing={','.join(missing) or 'none'}; "
+            f"unexpected={','.join(unexpected) or 'none'}; "
+            f"wrong_version={','.join(wrong) or 'none'}"
+        )
+    require_unchanged_paths(snapshot)
+    return canonical_inventory(installed)
+
+
+def sealed_requirements(raw: bytes) -> int:
+    mfd_cloexec = getattr(os, "MFD_CLOEXEC", 0x0001)
+    mfd_allow_sealing = getattr(os, "MFD_ALLOW_SEALING", 0x0002)
+    flags = mfd_cloexec | mfd_allow_sealing
+    if hasattr(os, "memfd_create"):
+        descriptor = os.memfd_create("hub-optimus-dependency-lock", flags)
+    else:
+        # Linux x86_64 syscall number; deploy-current attests that exact ABI.
+        libc = ctypes.CDLL(None, use_errno=True)
+        descriptor = libc.syscall(
+            319,
+            b"hub-optimus-dependency-lock",
+            flags,
+        )
+        if descriptor < 0:
+            error = ctypes.get_errno()
+            fail(f"could not create dependency memfd: {os.strerror(error)}")
+    f_add_seals = getattr(fcntl, "F_ADD_SEALS", 1033)
+    f_get_seals = getattr(fcntl, "F_GET_SEALS", 1034)
+    f_seal_seal = getattr(fcntl, "F_SEAL_SEAL", 0x0001)
+    f_seal_shrink = getattr(fcntl, "F_SEAL_SHRINK", 0x0002)
+    f_seal_grow = getattr(fcntl, "F_SEAL_GROW", 0x0004)
+    f_seal_write = getattr(fcntl, "F_SEAL_WRITE", 0x0008)
+    try:
+        view = memoryview(raw)
+        written = 0
+        while written < len(view):
+            written += os.write(descriptor, view[written:])
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.fchmod(descriptor, 0o400)
+        seals = (
+            f_seal_grow
+            | f_seal_seal
+            | f_seal_shrink
+            | f_seal_write
+        )
+        fcntl.fcntl(descriptor, f_add_seals, seals)
+        if fcntl.fcntl(descriptor, f_get_seals) != seals:
+            fail("dependency requirements memfd is not fully sealed")
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def clean_environment(release: Path) -> dict[str, str]:
+    return {
+        "HOME": str(release),
+        "LANG": "C.UTF-8",
+        "PATH": "/usr/bin:/bin",
+        "PIP_CONFIG_FILE": "/dev/null",
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PIP_NO_CACHE_DIR": "1",
+        "PIP_NO_INPUT": "1",
+        "PYTHONNOUSERSITE": "1",
+    }
+
+
+def run_checked(
+    command: list[str],
+    *,
+    release: Path,
+    environment: dict[str, str],
+    pass_fds=(),
+) -> None:
+    result = subprocess.run(
+        command,
+        cwd=release,
+        env=environment,
+        pass_fds=pass_fds,
+        stdout=sys.stderr,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def install(
+    snapshot: LockSnapshot,
+    system_python: Path,
+    *,
+    wheelhouse: Path | None = None,
+) -> str:
+    venv_python = snapshot.release / ".venv" / "bin" / "python"
+    if not venv_python.is_file() or not os.access(venv_python, os.X_OK):
+        fail("virtual-environment Python is not executable")
+    environment = clean_environment(snapshot.release)
+    location_arguments = ["--index-url", INDEX_URL]
+    if wheelhouse is not None:
+        if (
+            not wheelhouse.is_absolute()
+            or str(wheelhouse) != os.path.abspath(wheelhouse)
+            or wheelhouse.is_symlink()
+            or not wheelhouse.is_dir()
+        ):
+            fail("offline wheelhouse is not one canonical real directory")
+        location_arguments = ["--no-index", "--find-links", str(wheelhouse)]
+    descriptor = sealed_requirements(snapshot.combined_requirements)
+    try:
+        requirement_path = f"/proc/self/fd/{descriptor}"
+        run_checked(
+            [
+                str(venv_python),
+                "-I",
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--isolated",
+                "--no-cache-dir",
+                "--no-deps",
+                "--no-input",
+                "--only-binary=:all:",
+                "--require-hashes",
+                *location_arguments,
+                "--requirement",
+                requirement_path,
+            ],
+            release=snapshot.release,
+            environment=environment,
+            pass_fds=(descriptor,),
+        )
+    finally:
+        os.close(descriptor)
+    require_unchanged_paths(snapshot)
+    run_checked(
+        [str(venv_python), "-I", "-m", "pip", "check"],
+        release=snapshot.release,
+        environment=environment,
+    )
+    run_checked(
+        [str(venv_python), "-I", "-m", "pip", "uninstall", "--yes", "pip"],
+        release=snapshot.release,
+        environment=environment,
+    )
+    verifier = Path(__file__).resolve()
+    result = subprocess.run(
+        [
+            str(venv_python),
+            "-I",
+            str(verifier),
+            "verify",
+            str(snapshot.release),
+            str(system_python),
+            snapshot.digest,
+            snapshot_token(snapshot),
+        ],
+        cwd=snapshot.release,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SystemExit(result.returncode)
+    expected_output = canonical_inventory(snapshot.expected) + "\n"
+    if result.stdout != expected_output:
+        fail("dependency-inventory verifier returned unexpected evidence")
+    require_unchanged_paths(snapshot)
+    return snapshot_token(snapshot)
+
+
+def usage() -> None:
+    fail(
+        "Usage: verify-installed-dependencies "
+        "digest <release> | capture <release> <digest> | "
+        "install <release> <system-python> <digest> | "
+        "install-offline <release> <system-python> <digest> <wheelhouse> | "
+        "verify <release> <system-python> <digest> <snapshot-token>"
+    )
+
+
+if len(sys.argv) < 3:
+    usage()
+operation = sys.argv[1]
+release_path = Path(sys.argv[2])
+snapshot = load_snapshot(release_path)
+if operation == "digest" and len(sys.argv) == 3:
+    print(snapshot.digest)
+elif operation == "capture" and len(sys.argv) == 4:
+    require_digest(snapshot, sys.argv[3])
+    print(snapshot_token(snapshot))
+elif operation == "install" and len(sys.argv) == 5:
+    reviewed_python = Path(sys.argv[3])
+    require_digest(snapshot, sys.argv[4])
+    print(install(snapshot, reviewed_python))
+elif operation == "install-offline" and len(sys.argv) == 6:
+    reviewed_python = Path(sys.argv[3])
+    require_digest(snapshot, sys.argv[4])
+    print(
+        install(
+            snapshot,
+            reviewed_python,
+            wheelhouse=Path(sys.argv[5]),
+        )
+    )
+elif operation == "verify" and len(sys.argv) == 6:
+    reviewed_python = Path(sys.argv[3])
+    require_digest(snapshot, sys.argv[4])
+    require_snapshot_token(snapshot, sys.argv[5])
+    print(verify_inventory(snapshot, reviewed_python))
+else:
+    usage()

--- a/tests/test_ec2_dependency_lock.py
+++ b/tests/test_ec2_dependency_lock.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_TOOL = ROOT / "ops" / "ec2" / "dependency-lock-digest.sh"
+RUNTIME_LOCK = ROOT / "ops" / "ec2" / "requirements-runtime.lock"
+VALIDATION_LOCK = ROOT / "ops" / "ec2" / "requirements-validation.lock"
+DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
+ENVIRONMENT_TOOL = ROOT / "ops" / "ec2" / "verify-installed-dependencies.py"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _release(tmp_path: Path) -> Path:
+    release = tmp_path / "release"
+    lock_dir = release / "ops" / "ec2"
+    lock_dir.mkdir(parents=True)
+    for source in (RUNTIME_LOCK, VALIDATION_LOCK):
+        target = lock_dir / source.name
+        shutil.copyfile(source, target)
+        target.chmod(0o644)
+    return release
+
+
+def _digest(release: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(LOCK_TOOL), str(release)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_reviewed_dependency_locks_have_one_stable_digest(tmp_path: Path) -> None:
+    release = _release(tmp_path)
+
+    first = _digest(release)
+    second = _digest(release)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert first.stdout == second.stdout
+    assert len(first.stdout.strip()) == 64
+    assert set(first.stdout.strip()) <= set("0123456789abcdef")
+
+
+@pytest.mark.parametrize(
+    ("corruption", "expected"),
+    (
+        ("missing-hash", "only reviewed SHA-256 hashes"),
+        ("unexpected-transitive", "dependency set differs"),
+        ("mutable-version", "not one exact version pin"),
+        ("index-override", "unsupported option"),
+        ("duplicate", "duplicate dependency"),
+        ("symlink", "without following links"),
+        ("hardlink", "single-link"),
+        ("mode", "unexpected mode"),
+    ),
+)
+def test_lock_boundary_rejects_unreviewed_inputs(
+    tmp_path: Path,
+    corruption: str,
+    expected: str,
+) -> None:
+    release = _release(tmp_path)
+    runtime = release / "ops" / "ec2" / RUNTIME_LOCK.name
+    validation = release / "ops" / "ec2" / VALIDATION_LOCK.name
+    if corruption == "missing-hash":
+        runtime.write_text(
+            runtime.read_text(encoding="ascii").replace(
+                "    --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309\n",
+                "",
+                1,
+            ),
+            encoding="ascii",
+        )
+    elif corruption == "unexpected-transitive":
+        validation.write_text(
+            validation.read_text(encoding="ascii")
+            + "surprise==1.0 --hash=sha256:" + "a" * 64 + "\n",
+            encoding="ascii",
+        )
+    elif corruption == "mutable-version":
+        runtime.write_text(
+            runtime.read_text(encoding="ascii").replace(
+                "attrs==26.1.0", "attrs>=26.1.0", 1
+            ),
+            encoding="ascii",
+        )
+    elif corruption == "index-override":
+        validation.write_text(
+            "--index-url https://example.invalid/simple\n"
+            + validation.read_text(encoding="ascii"),
+            encoding="ascii",
+        )
+    elif corruption == "duplicate":
+        validation.write_text(
+            validation.read_text(encoding="ascii")
+            + "pytest==9.1.1 --hash=sha256:" + "b" * 64 + "\n",
+            encoding="ascii",
+        )
+    elif corruption == "symlink":
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_bytes(runtime.read_bytes())
+        runtime.unlink()
+        runtime.symlink_to(sentinel)
+    elif corruption == "hardlink":
+        os.link(runtime, tmp_path / "second-link")
+    else:
+        validation.chmod(0o600)
+
+    result = _digest(release)
+
+    assert result.returncode == 1
+    assert expected in result.stderr
+
+
+def test_deploy_uses_only_hash_locked_allowlisted_dependencies() -> None:
+    source = DEPLOY.read_text(encoding="utf-8")
+    tool = ENVIRONMENT_TOOL.read_text(encoding="utf-8")
+
+    assert "pip install --upgrade pip" not in source
+    assert "requirements-dev.txt" not in source
+    assert 'INDEX_URL = "https://pypi.org/simple"' in tool
+    assert "--require-hashes" in tool
+    assert "--only-binary=:all:" in tool
+    assert "--no-deps" in tool
+    assert '"PIP_CONFIG_FILE": "/dev/null"' in tool
+    assert '"PIP_NO_INPUT": "1"' in tool
+    assert "reject_ambient_pip_environment" in source
+    assert '"-I", "-m", "pip", "check"' in tool
+    assert "sealed_requirements(snapshot.combined_requirements)" in tool
+    assert "F_SEAL_WRITE" in tool
+    assert "require_unchanged_paths(snapshot)" in tool
+
+
+def test_dependency_lock_files_are_public_read_only_inputs() -> None:
+    for path in (RUNTIME_LOCK, VALIDATION_LOCK):
+        assert stat.S_IMODE(path.stat().st_mode) == 0o644
+        assert not path.is_symlink()
+
+
+def test_locked_ci_certifies_two_reproducible_offline_environments() -> None:
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["ec2-locked-environment"]["steps"]
+    script = next(
+        step["run"]
+        for step in steps
+        if step.get("name") == "Certify reproducible offline dependency installs"
+    )
+
+    assert script.count("-I -m pip download") == 1
+    assert '"$python_bin" -I -m venv "$release/.venv"' in script
+    assert 'create_release "$release_a"' in script
+    assert 'create_release "$release_b"' in script
+    assert 'sealed_offline_install "$release_a" "$wheelhouse"' in script
+    assert 'sealed_offline_install "$release_b" "$wheelhouse"' in script
+    assert "--index-url https://pypi.org/simple" in script
+    assert '"--no-index", "--find-links"' in ENVIRONMENT_TOOL.read_text(
+        encoding="utf-8"
+    )
+    assert "--require-hashes" in script
+    assert "--no-deps" in script
+    assert "--only-binary=:all:" in script
+    assert "intentional-hash-corruption" in script
+    assert "THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE" in script
+    assert script.count("install-offline") == 1
+    assert script.count("sealed_offline_install") == 4
+    assert script.count("verify-installed-dependencies.py") == 3
+    assert 'cmp -s -- "$inventory_a" "$inventory_b"' in script
+    assert 'node_bin="$(command -v node)"' in script
+    assert 'node_dir="$(dirname -- "$node_bin")"' in script
+    assert 'PATH="$node_dir:/usr/bin:/bin"' in script
+    assert '"$release_a/.venv/bin/python" -m pytest -q' in script

--- a/tests/test_ec2_installed_dependency_verifier.py
+++ b/tests/test_ec2_installed_dependency_verifier.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import re
+import runpy
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "ops" / "ec2" / "verify-installed-dependencies.py"
+LOCK_TOOL = ROOT / "ops" / "ec2" / "dependency-lock-digest.sh"
+RUNTIME_LOCK = (ROOT / "ops" / "ec2" / "requirements-runtime.lock").read_text(
+    encoding="ascii"
+)
+VALIDATION_LOCK = (
+    ROOT / "ops" / "ec2" / "requirements-validation.lock"
+).read_text(encoding="ascii")
+
+
+@dataclass(frozen=True)
+class VerifierResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _release(
+    tmp_path: Path,
+    *,
+    runtime_lock: str = RUNTIME_LOCK,
+    validation_lock: str = VALIDATION_LOCK,
+) -> Path:
+    release = tmp_path / "release"
+    lock_dir = release / "ops" / "ec2"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "requirements-runtime.lock").write_text(
+        runtime_lock,
+        encoding="ascii",
+    )
+    (lock_dir / "requirements-validation.lock").write_text(
+        validation_lock,
+        encoding="ascii",
+    )
+    return release
+
+
+def _distribution(name: str, version: str) -> SimpleNamespace:
+    return SimpleNamespace(metadata={"Name": name}, version=version)
+
+
+def _expected_inventory() -> list[tuple[str, str]]:
+    inventory: dict[str, str] = {}
+    for text in (RUNTIME_LOCK, VALIDATION_LOCK):
+        for match in re.finditer(
+            r"(?m)^([A-Za-z0-9][A-Za-z0-9._-]*)==([^ \\\n]+)",
+            text,
+        ):
+            name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
+            inventory[name] = match.group(2)
+    return sorted(inventory.items())
+
+
+def _run_verifier(
+    release: Path,
+    installed: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    wrong_executable: bool = False,
+    wrong_base_interpreter: bool = False,
+    expected_digest: str | None = None,
+    expected_token: str | None = None,
+) -> VerifierResult:
+    expected_python = release / ".venv" / "bin" / "python"
+    expected_python.parent.mkdir(parents=True, exist_ok=True)
+    expected_python.touch()
+    system_python = release.parent / "reviewed-system-python"
+    system_python.touch()
+
+    executable = expected_python
+    if wrong_executable:
+        executable = release.parent / "different-venv-python"
+        executable.touch()
+    base_executable = system_python
+    if wrong_base_interpreter:
+        base_executable = release.parent / "different-system-python"
+        base_executable.touch()
+
+    if expected_digest is None:
+        expected_digest = subprocess.run(
+            ["bash", str(LOCK_TOOL), str(release)],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    if expected_token is None and expected_digest != "0" * 64:
+        expected_token = subprocess.run(
+            [
+                "/usr/bin/python3",
+                "-I",
+                str(VERIFIER),
+                "capture",
+                str(release),
+                expected_digest,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    if expected_token is None:
+        expected_token = "0" * 64
+    installed_distributions = tuple(
+        _distribution(name, version) for name, version in installed
+    )
+    monkeypatch.setattr(
+        importlib.metadata,
+        "distributions",
+        lambda: installed_distributions,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(VERIFIER),
+            "verify",
+            str(release),
+            str(system_python),
+            expected_digest,
+            expected_token,
+        ],
+    )
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "_base_executable", str(base_executable))
+
+    capsys.readouterr()
+    returncode = 0
+    try:
+        runpy.run_path(str(VERIFIER), run_name="__main__")
+    except SystemExit as exc:
+        returncode = int(exc.code)
+    captured = capsys.readouterr()
+    return VerifierResult(returncode, captured.out, captured.err)
+
+
+def test_exact_installed_inventory_is_accepted_and_normalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release = _release(tmp_path)
+    expected = _expected_inventory()
+
+    result = _run_verifier(
+        release,
+        list(reversed(expected)),
+        monkeypatch,
+        capsys,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [
+        {"name": name, "version": version} for name, version in expected
+    ]
+    assert result.stderr == ""
+
+
+def test_unexpected_installed_distribution_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release = _release(tmp_path)
+
+    result = _run_verifier(
+        release,
+        _expected_inventory() + [("surprise", "9.9")],
+        monkeypatch,
+        capsys,
+    )
+
+    assert result.returncode == 1
+    assert "unexpected=surprise" in result.stderr
+    assert "missing=none" in result.stderr
+    assert result.stdout == ""
+
+
+def test_wrong_installed_version_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release = _release(tmp_path)
+    installed = dict(_expected_inventory())
+    installed["attrs"] = "0.0"
+
+    result = _run_verifier(
+        release,
+        sorted(installed.items()),
+        monkeypatch,
+        capsys,
+    )
+
+    assert result.returncode == 1
+    assert "wrong_version=attrs" in result.stderr
+    assert "unexpected=none" in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize(
+    ("wrong_executable", "wrong_base_interpreter", "expected_error"),
+    (
+        (True, False, "not running from the candidate virtual environment"),
+        (False, True, "was not created by the reviewed system Python"),
+    ),
+)
+def test_wrong_python_identity_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    wrong_executable: bool,
+    wrong_base_interpreter: bool,
+    expected_error: str,
+) -> None:
+    release = _release(tmp_path)
+
+    result = _run_verifier(
+        release,
+        _expected_inventory(),
+        monkeypatch,
+        capsys,
+        wrong_executable=wrong_executable,
+        wrong_base_interpreter=wrong_base_interpreter,
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+    assert result.stdout == ""
+
+
+def test_non_exact_lock_entry_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release = _release(
+        tmp_path,
+        runtime_lock=RUNTIME_LOCK.replace("attrs==26.1.0", "attrs>=26.1.0"),
+    )
+
+    result = _run_verifier(
+        release,
+        _expected_inventory(),
+        monkeypatch,
+        capsys,
+        expected_digest="0" * 64,
+    )
+
+    assert result.returncode == 1
+    assert "dependency is not one exact version pin" in result.stderr
+    assert result.stdout == ""
+
+
+def test_repeated_exact_lock_pin_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release = _release(
+        tmp_path,
+        runtime_lock=(
+            RUNTIME_LOCK
+            + "attrs==26.1.0 \\\n"
+            + "    --hash=sha256:"
+            + "a" * 64
+            + "\n"
+        ),
+    )
+
+    result = _run_verifier(
+        release,
+        _expected_inventory(),
+        monkeypatch,
+        capsys,
+        expected_digest="0" * 64,
+    )
+
+    assert result.returncode == 1
+    assert "lock contains a" in result.stderr
+    assert "dependency: attrs" in result.stderr
+    assert result.stdout == ""
+
+
+def test_restored_lock_bytes_do_not_hide_an_atomic_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release = _release(tmp_path)
+    digest = subprocess.run(
+        ["bash", str(LOCK_TOOL), str(release)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    token = subprocess.run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            str(VERIFIER),
+            "capture",
+            str(release),
+            digest,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    lock = release / "ops" / "ec2" / "requirements-validation.lock"
+    replacement = lock.with_name("replacement.lock")
+    replacement.write_bytes(lock.read_bytes())
+    replacement.chmod(0o644)
+    os.replace(replacement, lock)
+
+    result = _run_verifier(
+        release,
+        _expected_inventory(),
+        monkeypatch,
+        capsys,
+        expected_digest=digest,
+        expected_token=token,
+    )
+
+    assert result.returncode == 1
+    assert "paths changed since the sealed install snapshot" in result.stderr
+    assert result.stdout == ""

--- a/tests/test_ec2_preflight_and_evidence.py
+++ b/tests/test_ec2_preflight_and_evidence.py
@@ -71,6 +71,8 @@ def test_runbook_retains_reviewed_tools_and_uses_allowlisted_evidence() -> None:
     assert 'if versioned_launcher_raw != shared_launcher_raw:' in text
     assert 'state["validation_log_sha256"] != validation_log_sha256' in text
     assert 'validation_result_lines[-1] != state["validation_result"]' in text
+    assert 'state["dependency_tier"] != "runtime+validation-v1"' in text
+    assert 'state["dependency_lock_sha256"] != dependency_digest.hexdigest()' in text
     assert "flags |= os.O_NOFOLLOW" in text
     assert "opened = os.fstat(descriptor)" in text
     assert "visible = os.stat(path, follow_symlinks=False)" in text
@@ -91,6 +93,7 @@ def test_runbook_retains_reviewed_tools_and_uses_allowlisted_evidence() -> None:
     assert "PY_ROLLBACK_STATUS" in text
     assert '"to_launcher_sha256"' in text
     assert '"validation_log_sha256": state["validation_log_sha256"]' in text
+    assert '"dependency_lock_sha256": state["dependency_lock_sha256"]' in text
     assert 'evidence["running_commit"] != expected_commit' in text
 
 

--- a/tests/test_ec2_release_state_validator.py
+++ b/tests/test_ec2_release_state_validator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -12,6 +13,11 @@ VALIDATOR = ROOT / "ops" / "ec2" / "validate-release-state.sh"
 PREFLIGHT = ROOT / "ops" / "ec2" / "preflight-deploy.sh"
 DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
 ROLLBACK = ROOT / "ops" / "ec2" / "rollback-current.sh"
+DEPENDENCY_LOCK_TOOL = ROOT / "ops" / "ec2" / "dependency-lock-digest.sh"
+DEPENDENCY_LOCKS = (
+    ROOT / "ops" / "ec2" / "requirements-runtime.lock",
+    ROOT / "ops" / "ec2" / "requirements-validation.lock",
+)
 
 COMMIT = "b" * 40
 LAUNCHER_SHA256 = "c" * 64
@@ -40,14 +46,22 @@ def _write_state(path: Path, fields: list[tuple[str, str]]) -> None:
 
 
 def _production_fields(*, transitional: bool = False) -> list[tuple[str, str]]:
+    release_path = "/opt/hub-optimus/releases/20260803T120000Z.ABC123"
+    validation_command = "python -m pytest -q"
+    if not transitional:
+        validation_command = (
+            f"/usr/bin/env -i HOME={release_path} LANG=C.UTF-8 "
+            "PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 "
+            f"{release_path}/.venv/bin/python -m pytest -q"
+        )
     fields = [
         ("release", "20260803T120000Z.ABC123"),
         ("requested_ref", COMMIT),
         ("requested_ref_kind", "commit"),
         ("commit", COMMIT),
-        ("path", "/opt/hub-optimus/releases/20260803T120000Z.ABC123"),
+        ("path", release_path),
         ("validated_at_utc", "2026-08-03T12:00:00Z"),
-        ("validation_command", "python -m pytest -q"),
+        ("validation_command", validation_command),
         ("validation_exit_code", "0"),
         ("validation_result", VALIDATION_RESULT),
         (
@@ -58,10 +72,19 @@ def _production_fields(*, transitional: bool = False) -> list[tuple[str, str]]:
         ("validation_log_exit_code", "0"),
     ]
     if not transitional:
-        fields.append(
+        fields.extend(
             (
-                "validation_log_sha256",
-                hashlib.sha256(VALIDATION_LOG_RAW).hexdigest(),
+                (
+                    "validation_log_sha256",
+                    hashlib.sha256(VALIDATION_LOG_RAW).hexdigest(),
+                ),
+                ("dependency_tier", "runtime+validation-v1"),
+                (
+                    "dependency_lock",
+                    "/opt/hub-optimus/releases/20260803T120000Z.ABC123/"
+                    "ops/ec2/requirements-validation.lock",
+                ),
+                ("dependency_lock_sha256", "e" * 64),
             )
         )
     fields.extend(
@@ -95,9 +118,35 @@ def _production_fixture(
     validation_log.write_bytes(VALIDATION_LOG_RAW)
     validation_log.chmod(0o600)
     fields = _production_fields()
+    lock_dir = release / "ops" / "ec2"
+    lock_dir.mkdir(parents=True)
+    for source in DEPENDENCY_LOCKS:
+        target = lock_dir / source.name
+        shutil.copyfile(source, target)
+        target.chmod(0o644)
+    digest = subprocess.run(
+        ["bash", str(DEPENDENCY_LOCK_TOOL), str(release)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
     fields = _replace_field(fields, "release", release.name)
     fields = _replace_field(fields, "path", str(release))
+    fields = _replace_field(
+        fields,
+        "validation_command",
+        (
+            f"/usr/bin/env -i HOME={release} LANG=C.UTF-8 PATH=/usr/bin:/bin "
+            f"PYTHONNOUSERSITE=1 {release}/.venv/bin/python -m pytest -q"
+        ),
+    )
     fields = _replace_field(fields, "validation_log", str(validation_log))
+    fields = _replace_field(
+        fields,
+        "dependency_lock",
+        str(lock_dir / "requirements-validation.lock"),
+    )
+    fields = _replace_field(fields, "dependency_lock_sha256", digest)
     state = validation_log.parent / "RELEASE_STATE"
     _write_state(state, fields)
     return state, validation_log, fields

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -4,6 +4,8 @@ import hashlib
 import json
 import os
 import re
+import shlex
+import shutil
 import stat
 import subprocess
 import time
@@ -18,6 +20,10 @@ HUB_API = ROOT / "ops" / "ec2" / "hub-api.sh"
 HUB_OPS = ROOT / "ops" / "ec2" / "hub-ops.sh"
 DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
 ROLLBACK = ROOT / "ops" / "ec2" / "rollback-current.sh"
+DEPENDENCY_LOCKS = (
+    ROOT / "ops" / "ec2" / "requirements-runtime.lock",
+    ROOT / "ops" / "ec2" / "requirements-validation.lock",
+)
 RUN_ID_RE = re.compile(r"^\d{8}T\d{6}Z\.[A-Za-z0-9]{6}$")
 
 
@@ -477,6 +483,8 @@ def _source_repository(path: Path) -> tuple[str, str]:
 
     (path / "ops" / "ec2").mkdir(parents=True)
     (path / "requirements-dev.txt").write_text("pytest\n", encoding="utf-8")
+    for source in DEPENDENCY_LOCKS:
+        shutil.copyfile(source, path / "ops" / "ec2" / source.name)
     launcher = path / "ops" / "ec2" / "hub-api.sh"
     launcher.write_text("#!/usr/bin/env bash\necho api-v1\n", encoding="utf-8")
     launcher.chmod(0o755)
@@ -494,42 +502,189 @@ def _source_repository(path: Path) -> tuple[str, str]:
     return reviewed_commit, head_commit
 
 
-def _fake_deploy_python(path: Path) -> Path:
-    bin_dir = path / "deploy-bin"
-    bin_dir.mkdir()
-    python3 = bin_dir / "python3"
-    python3.write_text(
-        "#!/usr/bin/env bash\n"
+def _locked_dependency_inventory() -> str:
+    inventory: dict[str, str] = {}
+    for lock in DEPENDENCY_LOCKS:
+        for raw_line in lock.read_text(encoding="ascii").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith(("#", "-r ")) or "==" not in line:
+                continue
+            name, version = line.removesuffix("\\").strip().split("==", 1)
+            normalized_name = re.sub(r"[-_.]+", "-", name).lower()
+            inventory[normalized_name] = version
+    assert inventory
+    return json.dumps(
+        [
+            {"name": name, "version": inventory[name]}
+            for name in sorted(inventory)
+        ],
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _deploy_fixture(path: Path) -> tuple[Path, Path]:
+    fixture_root = path / "deploy-fixture"
+    fixture_ec2 = fixture_root / "ops" / "ec2"
+    shutil.copytree(ROOT / "ops" / "ec2", fixture_ec2)
+
+    controls = fixture_root / "controls"
+    controls.mkdir()
+    (controls / "inventory.output").write_text(
+        f"{_locked_dependency_inventory()}\n",
+        encoding="ascii",
+    )
+
+    fake_system_python = fixture_root / "fake-system-python"
+    fake_venv_python = fixture_root / "fake-venv-python"
+    quoted_controls = shlex.quote(str(controls))
+    quoted_system_python = shlex.quote(str(fake_system_python))
+    fake_venv_python.write_text(
+        "#!/bin/bash\n"
         "set -eu\n"
-        "test \"${1:-}\" = '-m'\n"
-        "test \"${2:-}\" = 'venv'\n"
-        "mkdir -p \"$3/bin\"\n"
-        "cat > \"$3/bin/activate\" <<'ACTIVATE'\n"
-        "python() {\n"
-        "  if [ \"${1:-}\" = '-m' ] && [ \"${2:-}\" = 'pytest' ]; then\n"
-        "    printf '%s\\n' \"${HUB_TEST_VALIDATION_OUTPUT:-17 passed in 0.01s}\"\n"
-        "    return \"${HUB_TEST_VALIDATION_EXIT:-0}\"\n"
+        f"CONTROL_DIR={quoted_controls}\n"
+        f"SYSTEM_PYTHON={quoted_system_python}\n"
+        "control_exit() {\n"
+        "  if [ -f \"$CONTROL_DIR/$1.exit\" ]; then\n"
+        "    /bin/cat \"$CONTROL_DIR/$1.exit\"\n"
+        "  else\n"
+        "    printf '%s\\n' \"$2\"\n"
         "  fi\n"
-        "  return 0\n"
         "}\n"
-        "deactivate() { :; }\n"
-        "ACTIVATE\n",
+        "swap_lock_hash_and_restore() {\n"
+        "  lock=$HOME/ops/ec2/requirements-validation.lock\n"
+        "  /bin/cp -- \"$lock\" \"$CONTROL_DIR/original.lock\"\n"
+        "  /bin/sed '0,/sha256:[0-9a-f]/s//sha256:0/' \\\n"
+        "    \"$CONTROL_DIR/original.lock\" > \"$CONTROL_DIR/replacement.lock\"\n"
+        "  /bin/mv -- \"$CONTROL_DIR/replacement.lock\" \"$lock\"\n"
+        "  /bin/cp -- \"$CONTROL_DIR/original.lock\" \\\n"
+        "    \"$CONTROL_DIR/restored.lock\"\n"
+        "  /bin/mv -- \"$CONTROL_DIR/restored.lock\" \"$lock\"\n"
+        "  : > \"$CONTROL_DIR/lock-was-swapped\"\n"
+        "}\n"
+        "isolated=0\n"
+        "if [ \"${1:-}\" = '-I' ]; then\n"
+        "  isolated=1\n"
+        "  shift\n"
+        "fi\n"
+        "if [ \"${1:-}\" = '-m' ]; then\n"
+        "  module=\"${2:-}\"\n"
+        "  action=\"${3:-}\"\n"
+        "  case \"$module:$action\" in\n"
+        "    pip:install)\n"
+        "      test \"$isolated\" -eq 1\n"
+        "      if [ -f \"$CONTROL_DIR/swap-lock-during-pip\" ]; then\n"
+        "        swap_lock_hash_and_restore\n"
+        "      fi\n"
+        "      exit \"$(control_exit pip-install 0)\"\n"
+        "      ;;\n"
+        "    pip:check)\n"
+        "      test \"$isolated\" -eq 1\n"
+        "      exit \"$(control_exit pip-check 0)\"\n"
+        "      ;;\n"
+        "    pip:uninstall)\n"
+        "      test \"$isolated\" -eq 1\n"
+        "      exit \"$(control_exit pip-uninstall 0)\"\n"
+        "      ;;\n"
+        "    pytest:*)\n"
+        "      test \"$isolated\" -eq 0\n"
+        "      if [ -f \"$CONTROL_DIR/swap-lock-during-pytest\" ]; then\n"
+        "        swap_lock_hash_and_restore\n"
+        "      fi\n"
+        "      if [ -f \"$CONTROL_DIR/pytest.output\" ]; then\n"
+        "        /bin/cat \"$CONTROL_DIR/pytest.output\"\n"
+        "      else\n"
+        "        printf '17 passed in 0.01s\\n'\n"
+        "      fi\n"
+        "      exit \"$(control_exit pytest 0)\"\n"
+        "      ;;\n"
+        "    *) exit 2 ;;\n"
+        "  esac\n"
+        "fi\n"
+        "tool=\"${1:-}\"\n"
+        "operation=\"${2:-}\"\n"
+        "release=\"${3:-}\"\n"
+        "system_python=\"${4:-}\"\n"
+        "digest=\"${5:-}\"\n"
+        "token=\"${6:-}\"\n"
+        "test \"$isolated\" -eq 1\n"
+        "test \"${tool##*/}\" = 'verify-installed-dependencies.py'\n"
+        "test \"$operation\" = 'verify'\n"
+        "test -d \"$release\"\n"
+        "test \"$system_python\" = \"$SYSTEM_PYTHON\"\n"
+        "test \"${#digest}\" -eq 64\n"
+        "test \"${#token}\" -eq 64\n"
+        "if [ -f \"$CONTROL_DIR/lock-was-swapped\" ]; then\n"
+        "  echo '[dependency-lock:error] dependency-lock paths changed since capture' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "/bin/cat \"$CONTROL_DIR/inventory.output\"\n"
+        "exit \"$(control_exit inventory 0)\"\n",
         encoding="utf-8",
     )
-    python3.chmod(0o755)
-    return bin_dir
+    fake_venv_python.chmod(0o755)
+
+    fake_system_python.write_text(
+        "#!/bin/bash\n"
+        "set -eu\n"
+        f"VENV_PYTHON={shlex.quote(str(fake_venv_python))}\n"
+        "if [ \"${1:-}\" = '-I' ] && [ \"${2:-}\" = '-' ]; then\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ \"${1:-}\" = '-I' ] \\\n"
+        "  && [ \"${2##*/}\" = 'verify-installed-dependencies.py' ]; then\n"
+        "  exec /usr/bin/python3 \"$@\"\n"
+        "fi\n"
+        "test \"${1:-}\" = '-I'\n"
+        "test \"${2:-}\" = '-m'\n"
+        "test \"${3:-}\" = 'venv'\n"
+        "test \"$#\" -eq 4\n"
+        "/bin/mkdir -p \"$4/bin\"\n"
+        "/bin/cp -- \"$VENV_PYTHON\" \"$4/bin/python\"\n"
+        "/bin/chmod 0755 \"$4/bin/python\"\n",
+        encoding="utf-8",
+    )
+    fake_system_python.chmod(0o755)
+
+    deploy = fixture_ec2 / "deploy-current.sh"
+    deploy_text = deploy.read_text(encoding="utf-8")
+    assignment = 'SYSTEM_PYTHON="/usr/bin/python3"'
+    assert deploy_text.count(assignment) == 1
+    assert '"$SYSTEM_PYTHON" -I -m venv' in deploy_text
+    assert '"$VENV_PYTHON" -m pytest -q' in deploy_text
+    assert '"$VENV_PYTHON" -I -m pytest -q' not in deploy_text
+    assert "HUB_OPTIMUS_TEST_MODE" not in deploy_text
+    assert "HUB_TEST_" not in deploy_text
+    deploy.write_text(
+        deploy_text.replace(
+            assignment,
+            f'SYSTEM_PYTHON="{fake_system_python}"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    return deploy, controls
 
 
 def _deploy_env(
     app_root: Path,
     source_repo: Path,
-    fake_bin: Path,
 ) -> dict[str, str]:
     env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith("PIP_"):
+            env.pop(name)
     env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
     env["HUB_OPTIMUS_REPO_URL"] = str(source_repo)
-    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     return env
+
+
+def _expected_validation_command(release: Path) -> str:
+    return (
+        f"/usr/bin/env -i HOME={release} LANG=C.UTF-8 PATH=/usr/bin:/bin "
+        f"PYTHONNOUSERSITE=1 {release}/.venv/bin/python -m pytest -q"
+    )
 
 
 def _operational_snapshot(app_root: Path) -> dict[str, object]:
@@ -557,11 +712,11 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, "reviewed-v1"], env=env)
+    first = _run([deploy, "reviewed-v1"], env=env)
     assert first.returncode == 0, first.stderr
     first_release = (app_root / "current").resolve()
     assert _git(first_release, "rev-parse", "HEAD") == reviewed_commit
@@ -569,7 +724,14 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     assert first_state["requested_ref"] == "reviewed-v1"
     assert first_state["requested_ref_kind"] == "tag"
     assert first_state["commit"] == reviewed_commit
-    assert first_state["validation_command"] == "python -m pytest -q"
+    assert first_state["validation_command"] == _expected_validation_command(
+        first_release
+    )
+    assert first_state["dependency_tier"] == "runtime+validation-v1"
+    assert first_state["dependency_lock"] == str(
+        first_release / "ops" / "ec2" / "requirements-validation.lock"
+    )
+    assert re.fullmatch(r"[0-9a-f]{64}", first_state["dependency_lock_sha256"])
     assert first_state["validation_exit_code"] == "0"
     assert first_state["validation_log_exit_code"] == "0"
     assert first_state["validation_result"] == "17 passed in 0.01s"
@@ -579,7 +741,7 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     ).hexdigest()
     assert "55 passed" not in (app_root / "shared" / "RELEASE_STATE").read_text()
 
-    second = _run([DEPLOY, head_commit], env=env)
+    second = _run([deploy, head_commit], env=env)
     assert second.returncode == 0, second.stderr
     second_release = (app_root / "current").resolve()
     assert second_release != first_release
@@ -622,16 +784,16 @@ def test_every_injected_post_switch_failure_restores_exact_state(
         case_root.mkdir()
         source_repo = case_root / "source"
         reviewed_commit, head_commit = _source_repository(source_repo)
-        fake_bin = _fake_deploy_python(case_root)
+        deploy, controls = _deploy_fixture(case_root)
         app_root = case_root / "app"
-        env = _deploy_env(app_root, source_repo, fake_bin)
+        env = _deploy_env(app_root, source_repo)
 
-        first = _run([DEPLOY, reviewed_commit], env=env)
+        first = _run([deploy, reviewed_commit], env=env)
         assert first.returncode == 0, first.stderr
         before = _operational_snapshot(app_root)
 
         env["HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION"] = stage
-        failed = _run([DEPLOY, head_commit], env=env)
+        failed = _run([deploy, head_commit], env=env)
 
         assert failed.returncode == 1
         assert f"injected test failure after mutation stage: {stage}" in failed.stderr
@@ -662,11 +824,11 @@ def test_deploy_recovery_runs_when_recovery_log_cannot_open(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, reviewed_commit], env=env)
+    first = _run([deploy, reviewed_commit], env=env)
     assert first.returncode == 0, first.stderr
     before = _operational_snapshot(app_root)
     unusable_log = tmp_path / "recovery-log-is-a-directory"
@@ -674,7 +836,7 @@ def test_deploy_recovery_runs_when_recovery_log_cannot_open(
     env["HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION"] = "current"
     env["HUB_OPTIMUS_TEST_RECOVERY_LOG_PATH"] = str(unusable_log)
 
-    failed = _run([DEPLOY, head_commit], env=env)
+    failed = _run([deploy, head_commit], env=env)
 
     assert failed.returncode == 1
     assert _operational_snapshot(app_root) == before
@@ -688,11 +850,11 @@ def test_injected_legacy_state_completion_is_recovered(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, reviewed_commit], env=env)
+    first = _run([deploy, reviewed_commit], env=env)
     assert first.returncode == 0, first.stderr
     current_release = (app_root / "current").resolve()
     legacy_state = current_release / ".hub-deployment" / "RELEASE_STATE"
@@ -700,7 +862,7 @@ def test_injected_legacy_state_completion_is_recovered(
     before = _operational_snapshot(app_root)
 
     env["HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION"] = "previous-release-state"
-    result = _run([DEPLOY, head_commit], env=env)
+    result = _run([deploy, head_commit], env=env)
 
     assert result.returncode == 1
     assert "injected test failure after mutation stage: previous-release-state" in result.stderr
@@ -714,14 +876,14 @@ def test_rollback_rejects_launcher_drift_before_switching(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, reviewed_commit], env=env)
+    first = _run([deploy, reviewed_commit], env=env)
     assert first.returncode == 0, first.stderr
     first_release = (app_root / "current").resolve()
-    second = _run([DEPLOY, head_commit], env=env)
+    second = _run([deploy, head_commit], env=env)
     assert second.returncode == 0, second.stderr
     before = _operational_snapshot(app_root)
     (first_release / "ops" / "ec2" / "hub-api.sh").write_text(
@@ -753,13 +915,13 @@ def test_every_injected_rollback_failure_restores_exact_state(
         case_root.mkdir()
         source_repo = case_root / "source"
         reviewed_commit, head_commit = _source_repository(source_repo)
-        fake_bin = _fake_deploy_python(case_root)
+        deploy, controls = _deploy_fixture(case_root)
         app_root = case_root / "app"
-        env = _deploy_env(app_root, source_repo, fake_bin)
+        env = _deploy_env(app_root, source_repo)
 
-        first = _run([DEPLOY, reviewed_commit], env=env)
+        first = _run([deploy, reviewed_commit], env=env)
         assert first.returncode == 0, first.stderr
-        second = _run([DEPLOY, head_commit], env=env)
+        second = _run([deploy, head_commit], env=env)
         assert second.returncode == 0, second.stderr
         before = _operational_snapshot(app_root)
         env["HUB_OPTIMUS_TEST_ROLLBACK_FAIL_AFTER_MUTATION"] = stage
@@ -786,12 +948,12 @@ def test_rollback_recovery_runs_when_recovery_log_cannot_open(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    assert _run([DEPLOY, reviewed_commit], env=env).returncode == 0
-    assert _run([DEPLOY, head_commit], env=env).returncode == 0
+    assert _run([deploy, reviewed_commit], env=env).returncode == 0
+    assert _run([deploy, head_commit], env=env).returncode == 0
     before = _operational_snapshot(app_root)
     unusable_log = tmp_path / "rollback-log-is-a-directory"
     unusable_log.mkdir()
@@ -815,13 +977,13 @@ def test_rollback_state_parser_rejects_duplicate_identity_keys(
         case_root.mkdir()
         source_repo = case_root / "source"
         reviewed_commit, head_commit = _source_repository(source_repo)
-        fake_bin = _fake_deploy_python(case_root)
+        deploy, controls = _deploy_fixture(case_root)
         app_root = case_root / "app"
-        env = _deploy_env(app_root, source_repo, fake_bin)
+        env = _deploy_env(app_root, source_repo)
 
-        assert _run([DEPLOY, reviewed_commit], env=env).returncode == 0
+        assert _run([deploy, reviewed_commit], env=env).returncode == 0
         first_release = (app_root / "current").resolve()
-        assert _run([DEPLOY, head_commit], env=env).returncode == 0
+        assert _run([deploy, head_commit], env=env).returncode == 0
         previous_state_path = (
             first_release / ".hub-deployment" / "RELEASE_STATE"
         )
@@ -848,13 +1010,13 @@ def test_rollback_rejects_malformed_managed_state_before_mutation(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    assert _run([DEPLOY, reviewed_commit], env=env).returncode == 0
+    assert _run([deploy, reviewed_commit], env=env).returncode == 0
     previous_release = (app_root / "current").resolve()
-    assert _run([DEPLOY, head_commit], env=env).returncode == 0
+    assert _run([deploy, head_commit], env=env).returncode == 0
     current_release = (app_root / "current").resolve()
     current_state = current_release / ".hub-deployment" / "RELEASE_STATE"
     shared_state = app_root / "shared" / "RELEASE_STATE"
@@ -884,11 +1046,11 @@ def test_invalid_rollback_target_state_fails_before_mutation(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, reviewed_commit], env=env)
+    first = _run([deploy, reviewed_commit], env=env)
     assert first.returncode == 0, first.stderr
     current_release = (app_root / "current").resolve()
     current_state_path = current_release / ".hub-deployment" / "RELEASE_STATE"
@@ -902,7 +1064,7 @@ def test_invalid_rollback_target_state_fails_before_mutation(
     )
     before = _operational_snapshot(app_root)
 
-    result = _run([DEPLOY, head_commit], env=env)
+    result = _run([deploy, head_commit], env=env)
 
     assert result.returncode == 1
     assert "requested commit differs from its resolved commit" in result.stderr
@@ -927,11 +1089,11 @@ def test_deploy_rejects_shared_only_state_drift_before_mutation(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, reviewed_commit], env=env)
+    first = _run([deploy, reviewed_commit], env=env)
     assert first.returncode == 0, first.stderr
     shared_state = app_root / "shared" / "RELEASE_STATE"
     if corruption == "malformed":
@@ -948,7 +1110,7 @@ def test_deploy_rejects_shared_only_state_drift_before_mutation(
         )
     before = _operational_snapshot(app_root)
 
-    result = _run([DEPLOY, head_commit], env=env)
+    result = _run([deploy, head_commit], env=env)
 
     assert result.returncode == 1
     assert expected_error in result.stderr
@@ -961,18 +1123,21 @@ def test_failed_validation_is_recorded_without_switching_current(
 ) -> None:
     source_repo = tmp_path / "source"
     reviewed_commit, head_commit = _source_repository(source_repo)
-    fake_bin = _fake_deploy_python(tmp_path)
+    deploy, controls = _deploy_fixture(tmp_path)
     app_root = tmp_path / "app"
-    env = _deploy_env(app_root, source_repo, fake_bin)
+    env = _deploy_env(app_root, source_repo)
 
-    first = _run([DEPLOY, reviewed_commit], env=env)
+    first = _run([deploy, reviewed_commit], env=env)
     assert first.returncode == 0, first.stderr
     before = _operational_snapshot(app_root)
 
-    env["HUB_TEST_VALIDATION_EXIT"] = "1"
-    env["HUB_TEST_VALIDATION_OUTPUT"] = "2 failed in 0.01s"
+    (controls / "pytest.exit").write_text("1\n", encoding="ascii")
+    (controls / "pytest.output").write_text(
+        "2 failed in 0.01s\n",
+        encoding="utf-8",
+    )
 
-    result = _run([DEPLOY, head_commit], env=env)
+    result = _run([deploy, head_commit], env=env)
 
     assert result.returncode == 1
     assert "validation failed (exit 1): 2 failed in 0.01s" in result.stderr
@@ -992,7 +1157,9 @@ def test_failed_validation_is_recorded_without_switching_current(
     )
     failed_state = _state(failed_state_path)
     assert failed_state["commit"] == head_commit
-    assert failed_state["validation_command"] == "python -m pytest -q"
+    assert failed_state["validation_command"] == _expected_validation_command(
+        failed_releases[0]
+    )
     assert failed_state["validation_exit_code"] == "1"
     assert failed_state["validation_result"] == "2 failed in 0.01s"
     failed_validation_log = (
@@ -1003,6 +1170,88 @@ def test_failed_validation_is_recorded_without_switching_current(
     ).hexdigest()
     assert failed_state["status"] == "validation-failed"
     assert (failed_releases[0] / ".hub-deployment" / "validation.log").is_file()
+
+
+@pytest.mark.parametrize(
+    "setting",
+    (
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_CONFIG_FILE",
+        "PIP_FIND_LINKS",
+        "PIP_TRUSTED_HOST",
+    ),
+)
+def test_ambient_pip_settings_fail_before_host_mutation(
+    tmp_path: Path,
+    setting: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, _ = _source_repository(source_repo)
+    deploy, controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+    env[setting] = "poisoned"
+
+    result = _run([deploy, reviewed_commit], env=env)
+
+    assert result.returncode == 1
+    assert f"ambient pip setting is not allowed: {setting}" in result.stderr
+    assert not app_root.exists()
+
+
+def test_dependency_install_failure_preserves_operational_state(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    first = _run([deploy, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    before = _operational_snapshot(app_root)
+    (controls / "pip-install.exit").write_text("23\n", encoding="ascii")
+
+    result = _run([deploy, head_commit], env=env)
+
+    assert result.returncode == 23
+    assert _operational_snapshot(app_root) == before
+    assert "Switching current symlink" not in result.stdout
+
+
+@pytest.mark.parametrize("stage", ("pip", "pytest"))
+def test_temporary_lock_replacement_cannot_publish_a_candidate(
+    tmp_path: Path,
+    stage: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    first = _run([deploy, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    before = _operational_snapshot(app_root)
+    (controls / f"swap-lock-during-{stage}").touch()
+
+    result = _run([deploy, head_commit], env=env)
+
+    assert result.returncode == 1
+    assert "lock" in result.stderr
+    assert "changed" in result.stderr
+    assert _operational_snapshot(app_root) == before
+    assert "Switching current symlink" not in result.stdout
+    published = [
+        path
+        for path in (app_root / "releases").iterdir()
+        if (path / ".hub-deployment" / "RELEASE_STATE").is_file()
+        and _state(path / ".hub-deployment" / "RELEASE_STATE").get("commit")
+        == head_commit
+    ]
+    assert published == []
 
 
 def test_deploy_requires_explicit_ref_and_hub_ops_forwards_it(

--- a/tests/test_ec2_runbook_attestation.py
+++ b/tests/test_ec2_runbook_attestation.py
@@ -13,6 +13,10 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNBOOK = ROOT / "ops" / "ec2" / "ISSUE_1831_RUNBOOK.md"
+DEPENDENCY_LOCKS = (
+    "ops/ec2/requirements-runtime.lock",
+    "ops/ec2/requirements-validation.lock",
+)
 
 
 def _heredoc(name: str) -> str:
@@ -68,6 +72,16 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
     validation_log = deployment_dir / "validation.log"
     validation_log_raw = b"collecting tests\n692 passed in 30.45s\n\n"
     _write_bytes(validation_log, validation_log_raw, 0o600)
+    dependency_digest = hashlib.sha256()
+    for relative in DEPENDENCY_LOCKS:
+        raw = (ROOT / relative).read_bytes()
+        _write_bytes(release / relative, raw, 0o644)
+        relative_raw = relative.encode("ascii")
+        dependency_digest.update(len(relative_raw).to_bytes(4, "big"))
+        dependency_digest.update(relative_raw)
+        dependency_digest.update(len(raw).to_bytes(8, "big"))
+        dependency_digest.update(raw)
+    dependency_lock = release / "ops" / "ec2" / "requirements-validation.lock"
     fields = {
         "release": release.name,
         "requested_ref": commit,
@@ -75,12 +89,18 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
         "commit": commit,
         "path": str(release),
         "validated_at_utc": "2026-08-02T12:00:00Z",
-        "validation_command": "python -m pytest -q",
+        "validation_command": (
+            f"/usr/bin/env -i HOME={release} LANG=C.UTF-8 PATH=/usr/bin:/bin "
+            f"PYTHONNOUSERSITE=1 {release}/.venv/bin/python -m pytest -q"
+        ),
         "validation_exit_code": "0",
         "validation_result": "692 passed in 30.45s",
         "validation_log": str(validation_log),
         "validation_log_exit_code": "0",
         "validation_log_sha256": hashlib.sha256(validation_log_raw).hexdigest(),
+        "dependency_tier": "runtime+validation-v1",
+        "dependency_lock": str(dependency_lock),
+        "dependency_lock_sha256": dependency_digest.hexdigest(),
         "launcher_sha256": launcher_sha256,
         "status": "production-candidate-core",
     }
@@ -125,6 +145,7 @@ def test_post_deploy_disk_attestation_accepts_exact_release(tmp_path: Path) -> N
     assert evidence["validation_log_sha256"] == hashlib.sha256(
         Path(fixture["validation_log"]).read_bytes()
     ).hexdigest()
+    assert re.fullmatch(r"[0-9a-f]{64}", evidence["dependency_lock_sha256"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Decision

Draft only. This PR addresses #1851 and is stacked on #1857 at `5a74928c1046a40fc54346add6d1ee8d4526b27a`.

It does **not** authorize merge, deployment, AWS mutation, DNS, TLS, OIDC, nginx, or service restart.

## Scope

- replace mutable EC2 requirements with explicit runtime and validation locks;
- pin the complete CPython 3.12/Linux x86_64 package graph and reviewed wheel hashes;
- reject ambient `PIP_*` overrides before host mutation;
- derive the digest, expected inventory, and pip requirements from one no-follow snapshot;
- feed pip through a mode-`0400` Linux memfd sealed against write/grow/shrink/resealing;
- retain a lock-path identity token across installation and post-pytest verification;
- remove bootstrap pip and reject missing, extra, duplicated, or wrong-version distributions;
- bind dependency tier, lock path, and digest into exact `RELEASE_STATE` validation;
- certify two offline sealed installs, corrupt-wheel rejection, identical inventories, and the full suite in CI.

## Adversarial coverage

- modified/missing hash and unexpected transitive dependency;
- poisoned pip index/config environment;
- wrong system or venv interpreter;
- extra or wrong-version installed distribution;
- symlink, hardlink, mode, and duplicate lock corruption;
- atomic lock replacement/restoration during pip and pytest;
- same package name/version with changed artifact hash;
- corrupt wheel in the offline wheelhouse.

## Validation

- sealed offline install from `/proc/self/fd/<n>`: PASS;
- exact inventory after pip removal: PASS;
- full locked-environment suite: **831 passed, 12 skipped**;
- final dependency/identity adversarial pack: **52 passed**;
- Markdown encoding: **292 files passed**;
- narrative consistency: **0 errors, 0 warnings**;
- benchmarks: **3/3 passed**;
- Bash, Python compilation, YAML, and `git diff --check`: PASS;
- three independent adversarial reviews: **PUBLISH**.

## Remaining blocks

#1831 and every AWS mutation remain blocked. The required stack continues with #1852, #1853, #1854, and #1855. This draft must not be merged or deployed independently.