### PR TITLE
fix(ec2): isolate reviewed release validation

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -122,7 +122,10 @@ Issue #1832 hardens that boundary before the blocked host operation in #1831:
 
 - the confirmed legacy current release has a separate, explicit adoption
   command bound to its real full commit; it validates repository/release/
-  symlink/launcher identity, preserves the original six-field state
+  symlink/launcher identity, captures reviewed source-tree and venv authority,
+  repeats HEAD/source/venv validation before mutation and after publication,
+  writes that incompatible exact schema as `adopted-legacy-current-v2`, and
+  preserves the original six-field state
   byte-for-byte as mode-`0400` evidence, records its hash without re-attesting
   the legacy test-count claim, postvalidates exact shared/per-release state,
   and recovers transactionally at every mutation failpoint;
@@ -141,7 +144,9 @@ Issue #1832 hardens that boundary before the blocked host operation in #1831:
   exact installed inventory is revalidated after tests, while the combined lock
   digest, tier, and path are recorded in production release state;
 - before mutation, deploy validates the managed rollback target's directory,
-  full commit, release/path state, launcher presence, and launcher SHA-256;
+  full commit and live HEAD, release/path state, launcher presence and SHA-256,
+  source-tree digest, and venv manifest, then repeats mutable authority checks
+  immediately before publication;
 - replacement launcher, release state, current marker, and rollback pointer are
   staged, while exact pre-deploy artifacts are snapshotted inside the persistent
   candidate release;
@@ -149,9 +154,14 @@ Issue #1832 hardens that boundary before the blocked host operation in #1831:
   records recovery, and retains the failed candidate without depending on a
   disposable reviewed-tools checkout; unavailable recovery logging never
   suppresses restoration or produces a success result;
-- rollback validates unique state identity keys and uses its own persistent
-  snapshot, staged artifacts, exit recovery, and injected-failure coverage for
-  the complete multi-file transition;
+- rollback validates unique state identity keys plus live HEAD/source/venv
+  authority for both current and previous releases, repeats those checks before
+  mutation, and uses its own persistent snapshot, staged artifacts, exit
+  recovery, and injected-failure coverage for the complete multi-file
+  transition;
+- the API/core launchers and systemd unit disable Python bytecode writes, and
+  `hub-core test` disables pytest cache generation, so normal `analyze` and test
+  use cannot silently invalidate reviewed source authority;
 - the API captures its full running commit and launcher SHA-256 at process
   start; `/status` exposes those immutable running values separately from the
   mutable configured-current symlink and commit;

--- a/ops/ec2/ISSUE_1831_RUNBOOK.md
+++ b/ops/ec2/ISSUE_1831_RUNBOOK.md
@@ -89,13 +89,22 @@ Adoption validates the managed symlink, exact repository origin, clean release
 checkout, full commit, marker, and byte-identical versioned/shared launcher. It
 does not re-assert the old `pytest 55 passed` claim. Instead it preserves the
 original legacy state byte-for-byte as mode-`0400` evidence, records its
-SHA-256 and short-commit prefix in a new full-SHA state, and postvalidates that
-the per-release and shared states are identical before committing success.
+SHA-256 and short-commit prefix in a new full-SHA v2 adoption state. That state
+also records the reviewed source-tree and venv digests. Adoption verifies HEAD,
+source, and venv at baseline, immediately before mutation, and after
+publication, then postvalidates that the per-release and shared states are
+identical before committing success.
 
 The command is idempotent only when that complete evidence bundle remains
 exact. A failure after mutation begins restores the pre-adoption state and
 retains its snapshot and recovery log under `shared/legacy-adoption.*`. Stop
 and inspect that evidence; do not repair or retry by hand.
+
+Normal API and core execution must not write caches into a release: the
+reviewed launchers and unit set `PYTHONDONTWRITEBYTECODE=1`, and `hub-core test`
+disables pytest's cache provider. Any pre-existing `__pycache__` or
+`.pytest_cache` is unexpected source drift and blocks adoption, deploy, and
+rollback.
 
 ## 3. Fail-closed host preflight
 
@@ -168,6 +177,18 @@ required_keys = {
     "validation_log",
     "validation_log_exit_code",
     "validation_log_sha256",
+    "validation_protocol",
+    "validation_collected",
+    "validation_terminal",
+    "validation_passed",
+    "validation_skipped",
+    "validation_failed",
+    "validation_pytest_exit_code",
+    "validation_nodeids_sha256",
+    "validation_descendants",
+    "validation_worker_uid",
+    "source_tree_sha256",
+    "venv_tree_sha256",
     "dependency_tier",
     "dependency_lock",
     "dependency_lock_sha256",
@@ -330,8 +351,9 @@ if not re.fullmatch(
 ):
     raise SystemExit("release-state validation timestamp is invalid")
 expected_validation_command = (
-    f"/usr/bin/env -i HOME={deployed} LANG=C.UTF-8 PATH=/usr/bin:/bin "
-    f"PYTHONNOUSERSITE=1 {deployed}/.venv/bin/python -m pytest -q"
+    "/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 PATH=/usr/bin:/bin "
+    f"/usr/bin/python3 -I {deployed}/ops/ec2/run-release-validation.py "
+    f"{deployed} {target} {deployed}/ops/ec2/verify-release-worktree.py"
 )
 if state["validation_command"] != expected_validation_command:
     raise SystemExit("release-state validation command differs")
@@ -356,6 +378,53 @@ if not validation_result_lines:
     raise SystemExit("validation log has no non-empty result line")
 if validation_result_lines[-1] != state["validation_result"]:
     raise SystemExit("validation result does not match the validation log")
+if state["validation_protocol"] != "isolated-pytest-v1":
+    raise SystemExit("release state has the wrong validation protocol")
+numeric_validation_fields = (
+    "validation_collected",
+    "validation_terminal",
+    "validation_passed",
+    "validation_skipped",
+    "validation_failed",
+    "validation_pytest_exit_code",
+    "validation_descendants",
+    "validation_worker_uid",
+)
+if any(not state[field].isdigit() for field in numeric_validation_fields):
+    raise SystemExit("release state has non-numeric validation evidence")
+collected = int(state["validation_collected"])
+terminal = int(state["validation_terminal"])
+passed = int(state["validation_passed"])
+skipped = int(state["validation_skipped"])
+failed = int(state["validation_failed"])
+if not (
+    collected > 0
+    and terminal == collected
+    and failed == 0
+    and state["validation_pytest_exit_code"] == "0"
+    and state["validation_descendants"] == "0"
+    and passed + skipped == terminal
+):
+    raise SystemExit("release state has incomplete validation evidence")
+for field in (
+    "validation_nodeids_sha256",
+    "source_tree_sha256",
+    "venv_tree_sha256",
+):
+    if not re.fullmatch(r"[0-9a-f]{64}", state[field]):
+        raise SystemExit(f"release state has invalid {field}")
+expected_validation_result = (
+    f"HUB_OPTIMUS_VALIDATION_V1 collected={collected} terminal={terminal} "
+    f"passed={passed} skipped={skipped} failed={failed} "
+    f"pytest_exit_code={state['validation_pytest_exit_code']} "
+    f"nodeids_sha256={state['validation_nodeids_sha256']} "
+    f"descendants={state['validation_descendants']} "
+    f"source_tree_sha256={state['source_tree_sha256']} "
+    f"venv_tree_sha256={state['venv_tree_sha256']} "
+    f"worker_uid={state['validation_worker_uid']} result=passed"
+)
+if state["validation_result"] != expected_validation_result:
+    raise SystemExit("validation result does not match structured evidence")
 if state["dependency_tier"] != "runtime+validation-v1":
     raise SystemExit("release state has the wrong dependency tier")
 expected_dependency_lock = deployed / "ops" / "ec2" / "requirements-validation.lock"
@@ -587,6 +656,8 @@ adopted_keys = {
     "validation_result",
     "validation_log",
     "validation_log_exit_code",
+    "source_tree_sha256",
+    "venv_tree_sha256",
     "launcher_sha256",
     "status",
     "provenance",
@@ -699,8 +770,12 @@ if release_state["validation_log_exit_code"] != "not-run":
     raise SystemExit("restored adoption log exit differs")
 if release_state["status"] != "adopted-legacy-current":
     raise SystemExit("restored adoption status differs")
-if release_state["provenance"] != "adopted-legacy-current-v1":
+if release_state["provenance"] != "adopted-legacy-current-v2":
     raise SystemExit("restored adoption provenance differs")
+if not re.fullmatch(r"[0-9a-f]{64}", release_state["source_tree_sha256"]):
+    raise SystemExit("restored source-tree authority is invalid")
+if not re.fullmatch(r"[0-9a-f]{64}", release_state["venv_tree_sha256"]):
+    raise SystemExit("restored venv authority is invalid")
 if not re.fullmatch(r"[0-9a-f]{64}", release_state["legacy_state_sha256"]):
     raise SystemExit("restored legacy-state identity is invalid")
 legacy_prefix = release_state["legacy_commit_prefix"]

--- a/ops/ec2/ISSUE_1831_RUNBOOK.md
+++ b/ops/ec2/ISSUE_1831_RUNBOOK.md
@@ -44,8 +44,14 @@ git -C "$TOOLS_ROOT" fetch --quiet --depth 1 origin "$TARGET_SHA"
 git -C "$TOOLS_ROOT" checkout --quiet --detach FETCH_HEAD
 test "$(git -C "$TOOLS_ROOT" rev-parse --verify HEAD)" = "$TARGET_SHA"
 
-bash -n "$TOOLS_ROOT"/ops/ec2/*.sh
-python3 -m py_compile "$TOOLS_ROOT/ops/ec2/intake-smoke-evidence.py"
+find "$TOOLS_ROOT/ops/ec2" -maxdepth 1 -type f -name '*.sh' \
+  ! -name 'hub-ops.sh' -exec bash -n '{}' +
+python3 -m py_compile \
+  "$TOOLS_ROOT/ops/ec2/hub-ops.sh" \
+  "$TOOLS_ROOT/ops/ec2/intake-smoke-evidence.py" \
+  "$TOOLS_ROOT/ops/ec2/run-reviewed-operation.py" \
+  "$TOOLS_ROOT/ops/ec2/run-release-validation.py" \
+  "$TOOLS_ROOT/ops/ec2/verify-release-worktree.py"
 ```
 
 Removal of this retained checkout is a separate post-operation cleanup choice;
@@ -59,10 +65,11 @@ file, the launcher, or a symlink by hand. The command is deliberately bound to
 the known full current commit rather than the legacy state's short SHA:
 
 ```bash
-HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
-HUB_OPTIMUS_REPO_URL="$REPO_URL" \
-  bash "$TOOLS_ROOT/ops/ec2/adopt-legacy-current.sh" \
-    "$LEGACY_CURRENT_SHA"
+/usr/bin/python3 -I \
+  "$TOOLS_ROOT/ops/ec2/run-reviewed-operation.py" \
+  --app-root "$APP_ROOT" \
+  --repo-url "$REPO_URL" \
+  adopt "$LEGACY_CURRENT_SHA"
 
 ADOPTED_CURRENT="$(readlink -f "$APP_ROOT/current")"
 ADOPTED_STATE="$ADOPTED_CURRENT/.hub-deployment/RELEASE_STATE"
@@ -95,11 +102,11 @@ and inspect that evidence; do not repair or retry by hand.
 Run the versioned preflight before deployment:
 
 ```bash
-HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
-HUB_OPTIMUS_REPO_URL="$REPO_URL" \
-  bash "$TOOLS_ROOT/ops/ec2/preflight-deploy.sh" \
-    "$TARGET_SHA" \
-    "$REFERENCE_URL"
+/usr/bin/python3 -I \
+  "$TOOLS_ROOT/ops/ec2/run-reviewed-operation.py" \
+  --app-root "$APP_ROOT" \
+  --repo-url "$REPO_URL" \
+  preflight "$TARGET_SHA" "$REFERENCE_URL"
 ```
 
 The preflight stops unless all of the following are true:
@@ -125,9 +132,11 @@ Do not override a failed threshold or identity check inside the same operation.
 ## 4. Exact-SHA deploy and review
 
 ```bash
-HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
-HUB_OPTIMUS_REPO_URL="$REPO_URL" \
-  bash "$TOOLS_ROOT/ops/ec2/deploy-current.sh" "$TARGET_SHA"
+/usr/bin/python3 -I \
+  "$TOOLS_ROOT/ops/ec2/run-reviewed-operation.py" \
+  --app-root "$APP_ROOT" \
+  --repo-url "$REPO_URL" \
+  deploy "$TARGET_SHA"
 
 DEPLOYED_RELEASE="$(readlink -f "$APP_ROOT/current")"
 test "$(git -C "$DEPLOYED_RELEASE" rev-parse --verify HEAD)" = "$TARGET_SHA"
@@ -532,8 +541,11 @@ deploy itself completed, retain the local response and use the rollback script
 from the persistent deployed release, not a temporary checkout:
 
 ```bash
-HUB_OPTIMUS_APP_ROOT="$APP_ROOT" \
-  bash "$DEPLOYED_RELEASE/ops/ec2/rollback-current.sh"
+/usr/bin/python3 -I \
+    "$DEPLOYED_RELEASE/ops/ec2/run-reviewed-operation.py" \
+    --app-root "$APP_ROOT" \
+    --repo-url "$REPO_URL" \
+    rollback
 
 ROLLED_BACK_RELEASE="$(readlink -f "$APP_ROOT/current")"
 RESTORED_COMMIT="$(git -C "$ROLLED_BACK_RELEASE" rev-parse --verify HEAD)"

--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -234,7 +234,11 @@ Manual installation targets:
 
 Run from the repository root:
 
-bash -n ops/ec2/*.sh
+```bash
+find ops/ec2 -maxdepth 1 -type f -name '*.sh' \
+  ! -name 'hub-ops.sh' -exec bash -n '{}' +
+python3 -m py_compile ops/ec2/hub-ops.sh ops/ec2/*.py
+```
 
 Runtime validation on EC2:
 

--- a/ops/ec2/README.md
+++ b/ops/ec2/README.md
@@ -99,9 +99,11 @@ after validation and recorded with the selected tier and lock path in
 they are not the EC2 deployment lock.
 
 The release state also records the SHA-256 of the selected `hub-api.sh`
-launcher. Before changing operational state, deployment validates that the
-current release is a managed, usable rollback target and stages all replacement
-artifacts. If any later step fails, an exit handler restores the exact previous
+launcher, the reviewed source-tree digest, and the complete venv-manifest
+digest. Before changing operational state, deployment validates that the
+current release is a managed, usable rollback target whose HEAD, source bytes,
+and venv still match that state, then stages all replacement artifacts. If any
+later step fails, an exit handler restores the exact previous
 `current` symlink, shared launcher, shared release state, current-release
 marker, previous-release pointer, and any transactionally completed legacy
 release state. The failed candidate retains its validation log,
@@ -115,9 +117,11 @@ prove that a commit or tag was reviewed or signed. GitHub review records and the
 human deploy decision remain the authority for that claim.
 
 Before switching, deployment preserves provenance for the current release.
-`rollback-current` rejects duplicate target-state identity keys, verifies the
-recorded commit, path, release, and launcher hash, then snapshots and stages its
-own complete transition. Any injected or ordinary failure after rollback
+`rollback-current` rejects duplicate target-state identity keys and verifies
+the recorded commit, path, release, launcher hash, source tree, and venv for
+both the current release and rollback target. It repeats mutable HEAD, source,
+and venv checks immediately before mutation, then snapshots and stages its own
+complete transition. Any injected or ordinary failure after rollback
 mutation begins restores the exact pre-rollback symlink, launcher, release
 state, rollback state, current marker, and prior transition marker. A successful
 rollback publishes a separate `ROLLBACK_STATE`. Deploy and rollback share a
@@ -126,6 +130,10 @@ non-blocking host lock so they cannot mutate release state concurrently.
 Neither operation silently restarts the running API service. After a deploy or
 rollback, an operator must review the recorded state and explicitly restart the
 service when the process should load the restored launcher.
+
+The API launcher, core launcher, and systemd unit disable Python bytecode writes
+inside a release. `hub-core test` also disables pytest's cache provider, so
+normal `analyze` and test operations do not invalidate source authority.
 
 At launcher start, the API captures the full commit of the resolved running
 release and the SHA-256 of the launcher that started it. `/status` reports those
@@ -144,9 +152,12 @@ the managed symlink, exact repository origin, clean checkout, marker, and
 byte-identical versioned/shared launcher. It does not trust the legacy short
 commit or validation-count claim as authority. The original six-field state is
 retained byte-for-byte as mode-`0400` `LEGACY_RELEASE_STATE`; its SHA-256 and
-short prefix are linked from the new full-SHA state. The shared/per-release
-states are postvalidated before success. Any post-mutation failure restores the
-exact snapshot, and an exact completed adoption can be rerun without change.
+short prefix are linked from the new full-SHA state. The v2 adoption state also
+records source-tree and venv authority captured with reviewed helpers. HEAD,
+source, and venv are checked at baseline, immediately before mutation, and
+after publication. The shared/per-release states are postvalidated before
+success. Any post-mutation failure restores the exact snapshot, and an exact
+completed adoption can be rerun without change.
 
 [`preflight-deploy.sh`](preflight-deploy.sh) is the read-only, fail-closed host
 gate for the exact-SHA localhost intake operation. It checks rollback release

--- a/ops/ec2/adopt-legacy-current.sh
+++ b/ops/ec2/adopt-legacy-current.sh
@@ -7,6 +7,8 @@ EXPECTED_COMMIT="${1:-}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 OPERATION_LOCK_TOOL="$SCRIPT_DIR/operation-lock.py"
 OPERATION_ENTRYPOINT="$SCRIPT_DIR/adopt-legacy-current.sh"
+SOURCE_TREE_TOOL="$SCRIPT_DIR/verify-release-worktree.py"
+VALIDATION_RUNNER="$SCRIPT_DIR/run-release-validation.py"
 
 usage() {
   cat <<USAGE
@@ -52,6 +54,98 @@ sha256_file() {
   digest="$(sha256sum -- "$path" | awk '{print $1}')"
   [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
     || fail "Could not calculate SHA-256 for $path"
+  printf '%s\n' "$digest"
+}
+
+verify_release_head() {
+  local release_path="$1"
+  local commit="$2"
+  local head_commit
+
+  head_commit="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 \
+      GIT_NO_REPLACE_OBJECTS=1 \
+      /usr/bin/git --no-replace-objects \
+        -C "$release_path" rev-parse --verify HEAD
+  )" || fail "Current release HEAD could not be resolved safely."
+  [[ "$head_commit" =~ ^[0-9a-f]{40}$ ]] \
+    && [ "$head_commit" = "$commit" ] \
+    || fail "Current release HEAD differs from its recorded commit."
+}
+
+release_source_evidence() {
+  local release_path="$1"
+  local commit="$2"
+  local evidence
+
+  verify_release_head "$release_path" "$commit"
+
+  [ -f "$SOURCE_TREE_TOOL" ] && [ ! -L "$SOURCE_TREE_TOOL" ] \
+    || fail "Source-tree verifier is not one regular file: $SOURCE_TREE_TOOL"
+  evidence="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      /usr/bin/python3 -I \
+        "$SOURCE_TREE_TOOL" \
+        "$release_path" \
+        "$commit" \
+        --allow-generated .venv \
+        --allow-generated .hub-deployment
+  )" || fail "Current source tree differs from its reviewed commit."
+  [ -n "$evidence" ] \
+    || fail "Source-tree verifier returned empty evidence."
+  verify_release_head "$release_path" "$commit"
+  printf '%s\n' "$evidence"
+}
+
+source_tree_digest() {
+  local evidence="$1"
+  local expected_commit="$2"
+
+  /usr/bin/python3 -I - "$expected_commit" "$evidence" <<'PY_SOURCE_EVIDENCE'
+import json
+import re
+import sys
+
+
+expected_commit, raw = sys.argv[1:]
+try:
+    evidence = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit(1)
+digest = evidence.get("source_tree_sha256")
+if evidence.get("commit") != expected_commit or not isinstance(digest, str):
+    raise SystemExit(1)
+if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+    raise SystemExit(1)
+print(digest)
+PY_SOURCE_EVIDENCE
+}
+
+current_venv_digest() {
+  local digest
+
+  [ -f "$VALIDATION_RUNNER" ] && [ ! -L "$VALIDATION_RUNNER" ] \
+    || fail "Validation supervisor is not one regular file: $VALIDATION_RUNNER"
+  digest="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      /usr/bin/python3 -I \
+        "$VALIDATION_RUNNER" \
+        manifest-venv \
+        "$CURRENT_RELEASE"
+  )" || fail "Current venv manifest verification failed."
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Validation supervisor returned an invalid venv digest."
   printf '%s\n' "$digest"
 }
 
@@ -270,12 +364,15 @@ validate_adopted_state() {
   local adopted_at
   local legacy_state_sha256
   local legacy_commit_prefix
+  local source_tree_sha256
+  local venv_tree_sha256
 
   validate_exact_state_keys \
     "$state_file" \
     release requested_ref requested_ref_kind commit path adopted_at_utc \
     validation_command validation_exit_code validation_result validation_log \
-    validation_log_exit_code launcher_sha256 status provenance \
+    validation_log_exit_code source_tree_sha256 venv_tree_sha256 \
+    launcher_sha256 status provenance \
     legacy_state_sha256 legacy_commit_prefix
 
   [ "$(required_state_value "$state_file" "release")" = "$CURRENT_RELEASE_ID" ] \
@@ -292,17 +389,25 @@ validate_adopted_state() {
     || fail "Adopted state launcher does not match current."
   [ "$(required_state_value "$state_file" "status")" = "adopted-legacy-current" ] \
     || fail "Adopted state status is invalid."
-  [ "$(required_state_value "$state_file" "provenance")" = "adopted-legacy-current-v1" ] \
+  [ "$(required_state_value "$state_file" "provenance")" = "adopted-legacy-current-v2" ] \
     || fail "Adopted state provenance is invalid."
   adopted_at="$(required_state_value "$state_file" "adopted_at_utc")"
   legacy_state_sha256="$(required_state_value "$state_file" "legacy_state_sha256")"
   legacy_commit_prefix="$(required_state_value "$state_file" "legacy_commit_prefix")"
+  source_tree_sha256="$(required_state_value "$state_file" source_tree_sha256)"
+  venv_tree_sha256="$(required_state_value "$state_file" venv_tree_sha256)"
   [[ "$adopted_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
     || fail "Adopted state timestamp is invalid."
   [[ "$legacy_state_sha256" =~ ^[0-9a-f]{64}$ ]] \
     || fail "Adopted state legacy-state SHA-256 is invalid."
   [[ "$legacy_commit_prefix" =~ ^[0-9a-f]{7,39}$ ]] \
     || fail "Adopted state legacy commit prefix is invalid."
+  [[ "$source_tree_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    && [ "$source_tree_sha256" = "$BASELINE_SOURCE_TREE_SHA256" ] \
+    || fail "Adopted state source-tree authority is invalid."
+  [[ "$venv_tree_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    && [ "$venv_tree_sha256" = "$BASELINE_VENV_TREE_SHA256" ] \
+    || fail "Adopted state venv authority is invalid."
   case "$ACTUAL_COMMIT" in
     "$legacy_commit_prefix"*) ;;
     *) fail "Adopted state legacy commit prefix does not match current." ;;
@@ -310,6 +415,8 @@ validate_adopted_state() {
 }
 
 validate_complete_adoption() {
+  local post_source_evidence
+  local post_venv_tree_sha256
   local recorded_legacy_sha256
 
   validate_adopted_state "$CURRENT_DEPLOYMENT_STATE"
@@ -334,6 +441,15 @@ validate_complete_adoption() {
       "$TRANSACTION_DIR/RELEASE_STATE.source" \
       || fail "Published adopted state differs from the staged state."
   fi
+  post_source_evidence="$(
+    release_source_evidence "$CURRENT_RELEASE" "$ACTUAL_COMMIT"
+  )"
+  [ "$post_source_evidence" = "$BASELINE_SOURCE_EVIDENCE" ] \
+    || fail "Current source evidence changed during legacy adoption."
+  post_venv_tree_sha256="$(current_venv_digest)"
+  [ "$post_venv_tree_sha256" = "$BASELINE_VENV_TREE_SHA256" ] \
+    || fail "Current venv evidence changed during legacy adoption."
+  verify_release_head "$CURRENT_RELEASE" "$ACTUAL_COMMIT"
 }
 
 MUTATION_STARTED=0
@@ -352,6 +468,9 @@ CURRENT_LEGACY_STATE=""
 CURRENT_LEGACY_STATE_NEW=""
 CURRENT_GIT_EXCLUDE=""
 DEPLOYMENT_DIR_EXISTED=0
+BASELINE_SOURCE_EVIDENCE=""
+BASELINE_SOURCE_TREE_SHA256=""
+BASELINE_VENV_TREE_SHA256=""
 trap on_exit EXIT
 
 case "$APP_ROOT" in
@@ -396,6 +515,15 @@ ACTUAL_COMMIT="$(git -C "$CURRENT_RELEASE" rev-parse --verify HEAD)"
   || fail "Current full commit does not match the explicit expected commit."
 [ -z "$(git -C "$CURRENT_RELEASE" status --porcelain --untracked-files=normal)" ] \
   || fail "Current release worktree is not clean."
+
+BASELINE_SOURCE_EVIDENCE="$(
+  release_source_evidence "$CURRENT_RELEASE" "$ACTUAL_COMMIT"
+)"
+BASELINE_SOURCE_TREE_SHA256="$(
+  source_tree_digest "$BASELINE_SOURCE_EVIDENCE" "$ACTUAL_COMMIT"
+)" || fail "Initial source-tree evidence is invalid."
+BASELINE_VENV_TREE_SHA256="$(current_venv_digest)"
+verify_release_head "$CURRENT_RELEASE" "$ACTUAL_COMMIT"
 
 CURRENT_LAUNCHER="$CURRENT_RELEASE/ops/ec2/hub-api.sh"
 SHARED_LAUNCHER="$APP_ROOT/shared/bin/hub-api"
@@ -468,9 +596,11 @@ validation_exit_code=not-run
 validation_result=legacy validation claim not re-attested; original state retained by SHA-256
 validation_log=not-applicable
 validation_log_exit_code=not-run
+source_tree_sha256=$BASELINE_SOURCE_TREE_SHA256
+venv_tree_sha256=$BASELINE_VENV_TREE_SHA256
 launcher_sha256=$CURRENT_LAUNCHER_SHA256
 status=adopted-legacy-current
-provenance=adopted-legacy-current-v1
+provenance=adopted-legacy-current-v2
 legacy_state_sha256=$LEGACY_STATE_SHA256
 legacy_commit_prefix=$LEGACY_COMMIT
 STATE
@@ -503,6 +633,22 @@ snapshot_item "$SHARED_STATE" "shared-release-state"
 snapshot_item "$CURRENT_DEPLOYMENT_STATE" "current-release-state"
 snapshot_item "$CURRENT_LEGACY_STATE" "legacy-release-state"
 snapshot_item "$CURRENT_GIT_EXCLUDE" "current-git-exclude"
+
+if [ -n "${HUB_OPTIMUS_TEST_LEGACY_ADOPTION_BEFORE_AUTHORITY_READY:-}" ]; then
+  touch "$HUB_OPTIMUS_TEST_LEGACY_ADOPTION_BEFORE_AUTHORITY_READY"
+  while [ ! -e "${HUB_OPTIMUS_TEST_LEGACY_ADOPTION_BEFORE_AUTHORITY_PROCEED:-}" ]; do
+    sleep 0.01
+  done
+fi
+PRE_MUTATION_SOURCE_EVIDENCE="$(
+  release_source_evidence "$CURRENT_RELEASE" "$ACTUAL_COMMIT"
+)"
+[ "$PRE_MUTATION_SOURCE_EVIDENCE" = "$BASELINE_SOURCE_EVIDENCE" ] \
+  || fail "Current source evidence changed before legacy adoption mutation."
+PRE_MUTATION_VENV_TREE_SHA256="$(current_venv_digest)"
+[ "$PRE_MUTATION_VENV_TREE_SHA256" = "$BASELINE_VENV_TREE_SHA256" ] \
+  || fail "Current venv evidence changed before legacy adoption mutation."
+verify_release_head "$CURRENT_RELEASE" "$ACTUAL_COMMIT"
 
 MUTATION_STARTED=1
 

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -10,6 +10,8 @@ DEPENDENCY_LOCK_TOOL="$SCRIPT_DIR/dependency-lock-digest.sh"
 DEPENDENCY_INVENTORY_TOOL="$SCRIPT_DIR/verify-installed-dependencies.py"
 OPERATION_LOCK_TOOL="$SCRIPT_DIR/operation-lock.py"
 OPERATION_ENTRYPOINT="$SCRIPT_DIR/deploy-current.sh"
+SOURCE_TREE_TOOL="$SCRIPT_DIR/verify-release-worktree.py"
+VALIDATION_RUNNER="$SCRIPT_DIR/run-release-validation.py"
 SYSTEM_PYTHON="/usr/bin/python3"
 
 usage() {
@@ -70,6 +72,113 @@ dependency_lock_digest() {
   [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
     || fail "Dependency-lock validator returned an invalid digest."
   printf '%s\n' "$digest"
+}
+
+verify_candidate_source() {
+  local release_path="$1"
+  local commit="$2"
+  local evidence
+
+  [ -f "$SOURCE_TREE_TOOL" ] && [ ! -L "$SOURCE_TREE_TOOL" ] \
+    || fail "Source-tree verifier is not one regular file: $SOURCE_TREE_TOOL"
+  evidence="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      /usr/bin/python3 -I \
+        "$SOURCE_TREE_TOOL" \
+        "$release_path" \
+        "$commit" \
+        --allow-generated .venv \
+        --allow-generated .hub-deployment
+  )" || fail "Candidate source tree differs from its reviewed commit."
+  [ -n "$evidence" ] \
+    || fail "Source-tree verifier returned empty evidence."
+  printf '%s\n' "$evidence"
+}
+
+candidate_venv_digest() {
+  local release_path="$1"
+  local runner="${2:-$VALIDATION_RUNNER}"
+  local digest
+
+  [ -f "$runner" ] && [ ! -L "$runner" ] \
+    || fail "Validation supervisor is not one regular file: $runner"
+  digest="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      /usr/bin/python3 -I \
+        "$runner" \
+        manifest-venv \
+        "$release_path"
+  )" || fail "Candidate venv manifest verification failed."
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Validation supervisor returned an invalid venv digest."
+  printf '%s\n' "$digest"
+}
+
+parse_validation_marker() {
+  local marker="$1"
+  local field
+  local key
+  local value
+
+  [[ "$marker" == HUB_OPTIMUS_VALIDATION_V1\ * ]] \
+    || fail "Validation supervisor returned no terminal evidence marker."
+  VALIDATION_COLLECTED=""
+  VALIDATION_TERMINAL=""
+  VALIDATION_PASSED=""
+  VALIDATION_SKIPPED=""
+  VALIDATION_FAILED=""
+  VALIDATION_PYTEST_EXIT_CODE=""
+  VALIDATION_NODEIDS_SHA256=""
+  VALIDATION_DESCENDANTS=""
+  SOURCE_TREE_SHA256=""
+  VENV_TREE_SHA256=""
+  VALIDATION_WORKER_UID=""
+  VALIDATION_BOUNDARY_RESULT=""
+  for field in ${marker#HUB_OPTIMUS_VALIDATION_V1 }; do
+    key="${field%%=*}"
+    value="${field#*=}"
+    case "$key" in
+      collected) VALIDATION_COLLECTED="$value" ;;
+      terminal) VALIDATION_TERMINAL="$value" ;;
+      passed) VALIDATION_PASSED="$value" ;;
+      skipped) VALIDATION_SKIPPED="$value" ;;
+      failed) VALIDATION_FAILED="$value" ;;
+      pytest_exit_code) VALIDATION_PYTEST_EXIT_CODE="$value" ;;
+      nodeids_sha256) VALIDATION_NODEIDS_SHA256="$value" ;;
+      descendants) VALIDATION_DESCENDANTS="$value" ;;
+      source_tree_sha256) SOURCE_TREE_SHA256="$value" ;;
+      venv_tree_sha256) VENV_TREE_SHA256="$value" ;;
+      worker_uid) VALIDATION_WORKER_UID="$value" ;;
+      result) VALIDATION_BOUNDARY_RESULT="$value" ;;
+      *) fail "Validation supervisor returned an unsupported evidence field: $key" ;;
+    esac
+  done
+  for value in \
+    "$VALIDATION_COLLECTED" \
+    "$VALIDATION_TERMINAL" \
+    "$VALIDATION_PASSED" \
+    "$VALIDATION_SKIPPED" \
+    "$VALIDATION_FAILED" \
+    "$VALIDATION_PYTEST_EXIT_CODE" \
+    "$VALIDATION_DESCENDANTS" \
+    "$VALIDATION_WORKER_UID"; do
+    [[ "$value" =~ ^[0-9]+$ ]] \
+      || fail "Validation supervisor returned non-numeric evidence."
+  done
+  [[ "$VALIDATION_NODEIDS_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+    && [[ "$SOURCE_TREE_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+    && [[ "$VENV_TREE_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Validation supervisor returned an invalid evidence digest."
+  case "$VALIDATION_BOUNDARY_RESULT" in
+    passed|failed) ;;
+    *) fail "Validation supervisor returned an invalid result." ;;
+  esac
 }
 
 validate_release_state_schema() {
@@ -408,6 +517,7 @@ echo "[deploy] Requested $REF_KIND: $DEPLOY_REF"
 
 mkdir -p "$APP_ROOT/releases" "$APP_ROOT/shared/logs" "$APP_ROOT/shared/bin"
 RELEASE_DIR="$(mktemp -d "$APP_ROOT/releases/$(date -u +%Y%m%dT%H%M%SZ).XXXXXX")"
+chmod 0755 "$RELEASE_DIR"
 RELEASE_ID="$(basename "$RELEASE_DIR")"
 DEPLOYMENT_DIR="$RELEASE_DIR/.hub-deployment"
 DEPLOYMENT_STATE="$DEPLOYMENT_DIR/RELEASE_STATE"
@@ -433,6 +543,25 @@ fi
 git -C "$RELEASE_DIR" checkout --quiet --detach "$RESOLVED_COMMIT"
 
 echo "[deploy] Resolved commit: $RESOLVED_COMMIT"
+echo "[deploy] Verifying the candidate directly against its commit tree"
+INITIAL_SOURCE_EVIDENCE="$(
+  verify_candidate_source "$RELEASE_DIR" "$RESOLVED_COMMIT"
+)"
+[ -n "$INITIAL_SOURCE_EVIDENCE" ] \
+  || fail "Initial source-tree evidence is empty."
+INITIAL_SOURCE_TREE_SHA256="$(
+  /usr/bin/python3 -I -c \
+    'import json,sys; print(json.loads(sys.argv[1])["source_tree_sha256"])' \
+    "$INITIAL_SOURCE_EVIDENCE"
+)" || fail "Initial source-tree evidence is invalid."
+[[ "$INITIAL_SOURCE_TREE_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+  || fail "Initial source-tree digest is invalid."
+CANDIDATE_SOURCE_TREE_TOOL="$RELEASE_DIR/ops/ec2/verify-release-worktree.py"
+CANDIDATE_VALIDATION_RUNNER="$RELEASE_DIR/ops/ec2/run-release-validation.py"
+[ -f "$CANDIDATE_SOURCE_TREE_TOOL" ] && [ ! -L "$CANDIDATE_SOURCE_TREE_TOOL" ] \
+  || fail "Candidate has no reviewed source-tree verifier."
+[ -f "$CANDIDATE_VALIDATION_RUNNER" ] && [ ! -L "$CANDIDATE_VALIDATION_RUNNER" ] \
+  || fail "Candidate has no reviewed validation supervisor."
 echo "[deploy] Verifying hub-api launcher source"
 if [ ! -f "$RELEASE_DIR/ops/ec2/hub-api.sh" ]; then
   fail "Missing hub-api launcher source: $RELEASE_DIR/ops/ec2/hub-api.sh"
@@ -457,9 +586,11 @@ VENV_PYTHON="$RELEASE_DIR/.venv/bin/python"
   || fail "Dependency-inventory verifier is not one regular file: $DEPENDENCY_INVENTORY_TOOL"
 
 printf -v VALIDATION_COMMAND_TEXT \
-  '/usr/bin/env -i HOME=%q LANG=C.UTF-8 PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 %q -m pytest -q' \
+  '/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 PATH=/usr/bin:/bin /usr/bin/python3 -I %q %q %q %q' \
+  "$CANDIDATE_VALIDATION_RUNNER" \
   "$RELEASE_DIR" \
-  "$VENV_PYTHON"
+  "$RESOLVED_COMMIT" \
+  "$CANDIDATE_SOURCE_TREE_TOOL"
 
 echo "[deploy] Installing from one sealed, hash-locked dependency snapshot"
 DEPENDENCY_CAPTURE_TOKEN="$(
@@ -484,11 +615,15 @@ chmod 0700 "$DEPLOYMENT_DIR"
 echo "[deploy] Running validation: $VALIDATION_COMMAND_TEXT"
 set +e
 /usr/bin/env -i \
-  HOME="$RELEASE_DIR" \
+  HOME=/nonexistent \
   LANG=C.UTF-8 \
   PATH=/usr/bin:/bin \
-  PYTHONNOUSERSITE=1 \
-  "$VENV_PYTHON" -m pytest -q 2>&1 | tee "$VALIDATION_LOG"
+  /usr/bin/python3 -I \
+    "$CANDIDATE_VALIDATION_RUNNER" \
+    "$RELEASE_DIR" \
+    "$RESOLVED_COMMIT" \
+    "$CANDIDATE_SOURCE_TREE_TOOL" \
+    2>&1 | tee "$VALIDATION_LOG"
 VALIDATION_PIPE_STATUS=("${PIPESTATUS[@]}")
 set -e
 VALIDATION_EXIT_CODE="${VALIDATION_PIPE_STATUS[0]}"
@@ -498,6 +633,9 @@ VALIDATION_RESULT="$(
   awk 'NF { result=$0 } END { print result == "" ? "no output" : result }' \
     "$VALIDATION_LOG"
 )"
+parse_validation_marker "$VALIDATION_RESULT"
+[ "$SOURCE_TREE_SHA256" = "$INITIAL_SOURCE_TREE_SHA256" ] \
+  || fail "Validation source-tree evidence differs from initial verification."
 VALIDATION_LOG_SHA256="$(sha256_file "$VALIDATION_LOG")"
 [ "$(dependency_lock_digest "$RELEASE_DIR")" = "$DEPENDENCY_LOCK_SHA256" ] \
   || fail "dependency locks changed during installation or validation."
@@ -519,7 +657,13 @@ DEPENDENCY_INVENTORY_AFTER="$(
   || fail "Installed dependency inventory evidence is empty."
 
 if [ "$VALIDATION_EXIT_CODE" -eq 0 ] \
-  && [ "$VALIDATION_LOG_EXIT_CODE" -eq 0 ]; then
+  && [ "$VALIDATION_LOG_EXIT_CODE" -eq 0 ] \
+  && [ "$VALIDATION_BOUNDARY_RESULT" = "passed" ] \
+  && [ "$VALIDATION_COLLECTED" -gt 0 ] \
+  && [ "$VALIDATION_TERMINAL" -eq "$VALIDATION_COLLECTED" ] \
+  && [ "$VALIDATION_FAILED" -eq 0 ] \
+  && [ "$VALIDATION_DESCENDANTS" -eq 0 ] \
+  && [ $((VALIDATION_PASSED + VALIDATION_SKIPPED)) -eq "$VALIDATION_TERMINAL" ]; then
   RELEASE_STATUS="production-candidate-core"
 else
   RELEASE_STATUS="validation-failed"
@@ -538,6 +682,18 @@ validation_result=$VALIDATION_RESULT
 validation_log=$VALIDATION_LOG
 validation_log_exit_code=$VALIDATION_LOG_EXIT_CODE
 validation_log_sha256=$VALIDATION_LOG_SHA256
+validation_protocol=isolated-pytest-v1
+validation_collected=$VALIDATION_COLLECTED
+validation_terminal=$VALIDATION_TERMINAL
+validation_passed=$VALIDATION_PASSED
+validation_skipped=$VALIDATION_SKIPPED
+validation_failed=$VALIDATION_FAILED
+validation_pytest_exit_code=$VALIDATION_PYTEST_EXIT_CODE
+validation_nodeids_sha256=$VALIDATION_NODEIDS_SHA256
+validation_descendants=$VALIDATION_DESCENDANTS
+validation_worker_uid=$VALIDATION_WORKER_UID
+source_tree_sha256=$SOURCE_TREE_SHA256
+venv_tree_sha256=$VENV_TREE_SHA256
 dependency_tier=runtime+validation-v1
 dependency_lock=$DEPENDENCY_LOCK_PATH
 dependency_lock_sha256=$DEPENDENCY_LOCK_SHA256
@@ -561,6 +717,17 @@ if [ "$VALIDATION_EXIT_CODE" -ne 0 ]; then
 fi
 
 validate_release_state_schema "$DEPLOYMENT_STATE"
+
+FINAL_SOURCE_EVIDENCE="$(
+  verify_candidate_source "$RELEASE_DIR" "$RESOLVED_COMMIT"
+)"
+[ "$FINAL_SOURCE_EVIDENCE" = "$INITIAL_SOURCE_EVIDENCE" ] \
+  || fail "Candidate source evidence changed before publication."
+FINAL_VENV_TREE_SHA256="$(
+  candidate_venv_digest "$RELEASE_DIR" "$CANDIDATE_VALIDATION_RUNNER"
+)"
+[ "$FINAL_VENV_TREE_SHA256" = "$VENV_TREE_SHA256" ] \
+  || fail "Candidate venv evidence changed before publication."
 
 PREVIOUS=""
 if [ -L "$APP_ROOT/current" ]; then
@@ -603,6 +770,17 @@ snapshot_item "$APP_ROOT/shared/previous_release" "previous-release-pointer"
 if [ -n "$PREVIOUS_STATE_PATH" ]; then
   snapshot_item "$PREVIOUS_STATE_PATH" "previous-release-state"
 fi
+
+PRE_SWITCH_SOURCE_EVIDENCE="$(
+  verify_candidate_source "$RELEASE_DIR" "$RESOLVED_COMMIT"
+)"
+[ "$PRE_SWITCH_SOURCE_EVIDENCE" = "$INITIAL_SOURCE_EVIDENCE" ] \
+  || fail "Candidate source evidence changed before the operational switch."
+PRE_SWITCH_VENV_TREE_SHA256="$(
+  candidate_venv_digest "$RELEASE_DIR" "$CANDIDATE_VALIDATION_RUNNER"
+)"
+[ "$PRE_SWITCH_VENV_TREE_SHA256" = "$VENV_TREE_SHA256" ] \
+  || fail "Candidate venv evidence changed before the operational switch."
 
 MUTATION_STARTED=1
 

--- a/ops/ec2/deploy-current.sh
+++ b/ops/ec2/deploy-current.sh
@@ -74,10 +74,33 @@ dependency_lock_digest() {
   printf '%s\n' "$digest"
 }
 
+verify_release_head() {
+  local release_path="$1"
+  local commit="$2"
+  local head_commit
+
+  head_commit="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 \
+      GIT_NO_REPLACE_OBJECTS=1 \
+      /usr/bin/git --no-replace-objects \
+        -C "$release_path" rev-parse --verify HEAD
+  )" || fail "Release HEAD could not be resolved safely: $release_path"
+  [[ "$head_commit" =~ ^[0-9a-f]{40}$ ]] \
+    && [ "$head_commit" = "$commit" ] \
+    || fail "Release HEAD differs from its recorded commit: $release_path"
+}
+
 verify_candidate_source() {
   local release_path="$1"
   local commit="$2"
   local evidence
+
+  verify_release_head "$release_path" "$commit"
 
   [ -f "$SOURCE_TREE_TOOL" ] && [ ! -L "$SOURCE_TREE_TOOL" ] \
     || fail "Source-tree verifier is not one regular file: $SOURCE_TREE_TOOL"
@@ -95,6 +118,7 @@ verify_candidate_source() {
   )" || fail "Candidate source tree differs from its reviewed commit."
   [ -n "$evidence" ] \
     || fail "Source-tree verifier returned empty evidence."
+  verify_release_head "$release_path" "$commit"
   printf '%s\n' "$evidence"
 }
 
@@ -118,6 +142,68 @@ candidate_venv_digest() {
   [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
     || fail "Validation supervisor returned an invalid venv digest."
   printf '%s\n' "$digest"
+}
+
+source_tree_digest() {
+  local evidence="$1"
+  local expected_commit="$2"
+
+  /usr/bin/python3 -I - "$expected_commit" "$evidence" <<'PY_SOURCE_EVIDENCE'
+import json
+import re
+import sys
+
+
+expected_commit, raw = sys.argv[1:]
+try:
+    evidence = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit(1)
+digest = evidence.get("source_tree_sha256")
+if evidence.get("commit") != expected_commit or not isinstance(digest, str):
+    raise SystemExit(1)
+if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+    raise SystemExit(1)
+print(digest)
+PY_SOURCE_EVIDENCE
+}
+
+verify_recorded_release_authority() {
+  local release_path="$1"
+  local state_file="$2"
+  local label="$3"
+  local commit
+  local evidence
+  local actual_source_tree_sha256
+  local actual_venv_tree_sha256
+  local recorded_source_tree_sha256
+  local recorded_venv_tree_sha256
+
+  commit="$(required_state_value "$state_file" commit)"
+  recorded_source_tree_sha256="$(
+    required_state_value "$state_file" source_tree_sha256
+  )"
+  recorded_venv_tree_sha256="$(
+    required_state_value "$state_file" venv_tree_sha256
+  )"
+  [[ "$recorded_source_tree_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$label RELEASE_STATE has no valid source-tree SHA-256."
+  [[ "$recorded_venv_tree_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$label RELEASE_STATE has no valid venv-tree SHA-256."
+
+  evidence="$(verify_candidate_source "$release_path" "$commit")"
+  actual_source_tree_sha256="$(source_tree_digest "$evidence" "$commit")" \
+    || fail "$label source-tree verifier returned invalid evidence."
+  [ "$actual_source_tree_sha256" = "$recorded_source_tree_sha256" ] \
+    || fail "$label source tree does not match RELEASE_STATE."
+
+  actual_venv_tree_sha256="$(
+    candidate_venv_digest "$release_path" "$VALIDATION_RUNNER"
+  )"
+  [ "$actual_venv_tree_sha256" = "$recorded_venv_tree_sha256" ] \
+    || fail "$label venv does not match RELEASE_STATE."
+  verify_release_head "$release_path" "$commit"
+  printf '%s:%s\n' "$actual_source_tree_sha256" "$actual_venv_tree_sha256"
 }
 
 parse_validation_marker() {
@@ -298,6 +384,14 @@ prepare_previous_release_state() {
     source_state="$shared_state"
   fi
 
+  PREVIOUS_AUTHORITY_STATE="$source_state"
+  PREVIOUS_AUTHORITY_COMMIT="$previous_commit"
+  verify_recorded_release_authority \
+    "$previous" \
+    "$PREVIOUS_AUTHORITY_STATE" \
+    "Rollback target" \
+    >/dev/null
+
   PREVIOUS_STATE_PATH="$previous_state"
   recorded_launcher_sha256="$(
     state_value "$source_state" "launcher_sha256"
@@ -457,6 +551,8 @@ inject_test_failure() {
 MUTATION_STARTED=0
 PREVIOUS_STATE_PATH=""
 PREVIOUS_STATE_INSTALL_SOURCE=""
+PREVIOUS_AUTHORITY_STATE=""
+PREVIOUS_AUTHORITY_COMMIT=""
 RECOVERY_DIR=""
 RECOVERY_LOG="/dev/null"
 RECOVERY_LOG_READY=0
@@ -636,6 +732,12 @@ VALIDATION_RESULT="$(
 parse_validation_marker "$VALIDATION_RESULT"
 [ "$SOURCE_TREE_SHA256" = "$INITIAL_SOURCE_TREE_SHA256" ] \
   || fail "Validation source-tree evidence differs from initial verification."
+OPERATIONAL_VENV_TREE_SHA256="$(
+  candidate_venv_digest "$RELEASE_DIR" "$VALIDATION_RUNNER"
+)"
+[ "$OPERATIONAL_VENV_TREE_SHA256" = "$VENV_TREE_SHA256" ] \
+  || fail "Validation venv evidence differs from the operational verifier."
+verify_release_head "$RELEASE_DIR" "$RESOLVED_COMMIT"
 VALIDATION_LOG_SHA256="$(sha256_file "$VALIDATION_LOG")"
 [ "$(dependency_lock_digest "$RELEASE_DIR")" = "$DEPENDENCY_LOCK_SHA256" ] \
   || fail "dependency locks changed during installation or validation."
@@ -724,10 +826,11 @@ FINAL_SOURCE_EVIDENCE="$(
 [ "$FINAL_SOURCE_EVIDENCE" = "$INITIAL_SOURCE_EVIDENCE" ] \
   || fail "Candidate source evidence changed before publication."
 FINAL_VENV_TREE_SHA256="$(
-  candidate_venv_digest "$RELEASE_DIR" "$CANDIDATE_VALIDATION_RUNNER"
+  candidate_venv_digest "$RELEASE_DIR" "$VALIDATION_RUNNER"
 )"
 [ "$FINAL_VENV_TREE_SHA256" = "$VENV_TREE_SHA256" ] \
   || fail "Candidate venv evidence changed before publication."
+verify_release_head "$RELEASE_DIR" "$RESOLVED_COMMIT"
 
 PREVIOUS=""
 if [ -L "$APP_ROOT/current" ]; then
@@ -771,16 +874,33 @@ if [ -n "$PREVIOUS_STATE_PATH" ]; then
   snapshot_item "$PREVIOUS_STATE_PATH" "previous-release-state"
 fi
 
+if [ -n "${HUB_OPTIMUS_TEST_DEPLOY_BEFORE_AUTHORITY_READY:-}" ]; then
+  touch "$HUB_OPTIMUS_TEST_DEPLOY_BEFORE_AUTHORITY_READY"
+  while [ ! -e "${HUB_OPTIMUS_TEST_DEPLOY_BEFORE_AUTHORITY_PROCEED:-}" ]; do
+    sleep 0.01
+  done
+fi
 PRE_SWITCH_SOURCE_EVIDENCE="$(
   verify_candidate_source "$RELEASE_DIR" "$RESOLVED_COMMIT"
 )"
 [ "$PRE_SWITCH_SOURCE_EVIDENCE" = "$INITIAL_SOURCE_EVIDENCE" ] \
   || fail "Candidate source evidence changed before the operational switch."
 PRE_SWITCH_VENV_TREE_SHA256="$(
-  candidate_venv_digest "$RELEASE_DIR" "$CANDIDATE_VALIDATION_RUNNER"
+  candidate_venv_digest "$RELEASE_DIR" "$VALIDATION_RUNNER"
 )"
 [ "$PRE_SWITCH_VENV_TREE_SHA256" = "$VENV_TREE_SHA256" ] \
   || fail "Candidate venv evidence changed before the operational switch."
+if [ -n "$PREVIOUS" ]; then
+  verify_recorded_release_authority \
+    "$PREVIOUS" \
+    "$PREVIOUS_AUTHORITY_STATE" \
+    "Rollback target" \
+    >/dev/null
+fi
+verify_release_head "$RELEASE_DIR" "$RESOLVED_COMMIT"
+if [ -n "$PREVIOUS" ]; then
+  verify_release_head "$PREVIOUS" "$PREVIOUS_AUTHORITY_COMMIT"
+fi
 
 MUTATION_STARTED=1
 

--- a/ops/ec2/hub-api.service
+++ b/ops/ec2/hub-api.service
@@ -7,6 +7,7 @@ Type=simple
 User=ubuntu
 WorkingDirectory=/opt/hub-optimus/current
 Environment=PATH=/opt/hub-optimus/shared/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=PYTHONDONTWRITEBYTECODE=1
 ExecStart=/opt/hub-optimus/shared/bin/hub-api
 Restart=on-failure
 RestartSec=3

--- a/ops/ec2/hub-api.sh
+++ b/ops/ec2/hub-api.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PYTHONDONTWRITEBYTECODE=1
+
 APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 API_DIR="$APP_ROOT/shared/api"
 API_FILE="$API_DIR/hub_api.py"

--- a/ops/ec2/hub-core.sh
+++ b/ops/ec2/hub-core.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PYTHONDONTWRITEBYTECODE=1
+
 APP_ROOT="${HUB_OPTIMUS_APP_ROOT:-/opt/hub-optimus}"
 RUN_ROOT="$APP_ROOT/shared/runs"
 RUN_ID_PREFIX="[hub-core:run-id]"
@@ -127,7 +129,7 @@ run_tests() {
   announce_run "$dir"
 
   echo "[hub-core:test] Output dir: $dir"
-  python -m pytest -q | tee "$dir/pytest.log"
+  python -m pytest -q -p no:cacheprovider | tee "$dir/pytest.log"
 
   deactivate
   echo "[hub-core:test] Done"

--- a/ops/ec2/hub-ops.sh
+++ b/ops/ec2/hub-ops.sh
@@ -1,126 +1,238 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/python3 -I
+"""Supported EC2 operator entrypoint with no ambient Bash boundary."""
 
-APP_ROOT="/opt/hub-optimus"
+from __future__ import annotations
 
-usage() {
-  cat <<USAGE
-HUB_Optimus EC2 ops
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+APP_ROOT = Path("/opt/hub-optimus")
+SYSTEM_PYTHON = "/usr/bin/python3"
+GIT = "/usr/bin/git"
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+DEFAULT_REPOSITORY = "https://github.com/Voxterrae/HUB_Optimus.git"
+MUTATING_OPERATIONS = frozenset({"adopt", "deploy", "preflight", "rollback"})
+
+
+def usage(stream=sys.stdout) -> None:
+    print(
+        """HUB_Optimus EC2 ops
 
 Usage:
   hub-ops status
   hub-ops validate
+  hub-ops preflight <full-commit-sha> <https-reference-url>
+  hub-ops adopt <full-current-commit-sha>
   hub-ops deploy <commit-sha-or-tag>
   hub-ops rollback
 
 Commands:
-  status    Show current release, previous release, state, commit, git status, releases and disk usage.
-  validate  Run pytest on current release and show commit/status.
+  status    Show current release, previous release, state, commit, source changes, releases and disk usage.
+  validate  Validate the current release through the isolated pytest supervisor.
+  preflight Run the reviewed read-only host preflight through a clean boundary.
+  adopt     Adopt one exact legacy current commit through a clean boundary.
   deploy    Deploy one explicit reviewed full commit SHA or tag.
-  rollback  Run rollback-current.
-USAGE
-}
+  rollback  Run rollback-current through a clean boundary.
+""",
+        file=stream,
+        end="",
+    )
 
-status_current() {
-  echo "[status] HUB_Optimus EC2"
-  echo
 
-  echo "[status] current:"
-  readlink -f "$APP_ROOT/current" 2>/dev/null || echo "none"
-  echo
+def fail(message: str) -> None:
+    print(f"[hub-ops:error] {message}", file=sys.stderr)
+    raise SystemExit(1)
 
-  echo "[status] previous:"
-  cat "$APP_ROOT/shared/previous_release" 2>/dev/null || echo "none"
-  echo
 
-  echo "[status] current_release:"
-  cat "$APP_ROOT/shared/current_release" 2>/dev/null || echo "none"
-  echo
+def clean_environment() -> dict[str, str]:
+    # Construct from nothing: neither Bash startup hooks/exported functions nor
+    # Python, pytest, Git, or pip caller configuration crosses this boundary.
+    return {
+        "HOME": "/nonexistent",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": "/usr/bin:/bin",
+    }
 
-  echo "[status] release_state:"
-  cat "$APP_ROOT/shared/RELEASE_STATE" 2>/dev/null || echo "none"
-  echo
 
-  echo "[status] last_rollback_from:"
-  cat "$APP_ROOT/shared/last_rollback_from" 2>/dev/null || echo "none"
-  echo
+def read_or_none(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").rstrip("\n") or "none"
+    except (OSError, UnicodeError):
+        return "none"
 
-  echo "[status] git commit:"
-  if [ -L "$APP_ROOT/current" ]; then
-    cd "$APP_ROOT/current"
-    git rev-parse --short HEAD
-  else
-    echo "none"
-  fi
-  echo
 
-  echo "[status] git status:"
-  if [ -L "$APP_ROOT/current" ]; then
-    cd "$APP_ROOT/current"
-    git status --short
-  else
-    echo "none"
-  fi
-  echo
+def current_release() -> Path | None:
+    current = APP_ROOT / "current"
+    if not current.is_symlink():
+        return None
+    try:
+        resolved = Path(os.path.realpath(current))
+        info = resolved.stat(follow_symlinks=False)
+    except OSError:
+        return None
+    return resolved if stat.S_ISDIR(info.st_mode) else None
 
-  echo "[status] releases:"
-  ls -1 "$APP_ROOT/releases" 2>/dev/null | sort || echo "none"
-  echo
 
-  echo "[status] disk:"
-  df -h "$APP_ROOT" | tail -n 1
-}
+def git(release: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [GIT, "-C", str(release), *arguments],
+        cwd="/",
+        env=clean_environment(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-validate_current() {
-  if [ ! -L "$APP_ROOT/current" ]; then
-    echo "[validate:error] current symlink does not exist."
-    exit 1
-  fi
 
-  cd "$APP_ROOT/current"
+def show_section(label: str, value: str) -> None:
+    print(f"[status] {label}:")
+    print(value or "none")
+    print()
 
-  if [ ! -d ".venv" ]; then
-    echo "[validate:error] .venv does not exist in current release."
-    exit 1
-  fi
 
-  source .venv/bin/activate
+def status_current() -> None:
+    print("[status] HUB_Optimus EC2\n")
+    release = current_release()
+    show_section("current", str(release) if release is not None else "none")
+    show_section("previous", read_or_none(APP_ROOT / "shared" / "previous_release"))
+    show_section("current_release", read_or_none(APP_ROOT / "shared" / "current_release"))
+    show_section("release_state", read_or_none(APP_ROOT / "shared" / "RELEASE_STATE"))
+    show_section("last_rollback_from", read_or_none(APP_ROOT / "shared" / "last_rollback_from"))
 
-  echo "[validate] Running pytest"
-  python -m pytest -q
+    if release is None:
+        show_section("git commit", "none")
+        show_section("git status", "none")
+    else:
+        commit = git(release, "rev-parse", "--verify", "HEAD^{commit}")
+        commit_value = commit.stdout.strip()
+        show_section(
+            "git commit",
+            commit_value if commit.returncode == 0 else "unavailable",
+        )
+        show_section(
+            "source status",
+            "not evaluated by read-only status; run hub-ops validate",
+        )
 
-  deactivate
+    releases = APP_ROOT / "releases"
+    try:
+        names = sorted(item.name for item in releases.iterdir())
+    except OSError:
+        names = []
+    show_section("releases", "\n".join(names) if names else "none")
+    try:
+        disk = os.statvfs(APP_ROOT)
+        available = disk.f_bavail * disk.f_frsize
+        total = disk.f_blocks * disk.f_frsize
+        disk_value = f"available_bytes={available} total_bytes={total}"
+    except OSError:
+        disk_value = "unavailable"
+    show_section("disk", disk_value)
 
-  echo "[validate] Git status"
-  git status --short
 
-  echo "[validate] Commit"
-  git rev-parse --short HEAD
+def operation_tools(release: Path | None = None) -> Path:
+    # A retained reviewed checkout keeps the complete toolset adjacent. An
+    # installed standalone hub-ops falls back to the active reviewed release.
+    if (SCRIPT_DIRECTORY / "run-reviewed-operation.py").is_file():
+        return SCRIPT_DIRECTORY
+    if release is None:
+        release = current_release()
+    if release is None:
+        fail("no reviewed operation toolset is available")
+    return release / "ops" / "ec2"
 
-  echo "[validate] Done"
-}
 
-case "${1:-}" in
-  status)
-    status_current
-    ;;
-  validate)
-    validate_current
-    ;;
-  deploy)
-    shift
-    exec "$APP_ROOT/shared/bin/deploy-current" "$@"
-    ;;
-  rollback)
-    exec "$APP_ROOT/shared/bin/rollback-current"
-    ;;
-  ""|-h|--help|help)
-    usage
-    ;;
-  *)
-    echo "[hub-ops:error] Unknown command: $1"
-    echo
-    usage
-    exit 1
-    ;;
-esac
+def validate_tool(path: Path, label: str) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        fail(f"cannot inspect {label}: {exc}")
+    if not stat.S_ISREG(info.st_mode) or path.is_symlink():
+        fail(f"{label} is not one regular file: {path}")
+    if info.st_uid != os.geteuid() or info.st_nlink != 1:
+        fail(f"{label} has unsafe identity: {path}")
+    if stat.S_IMODE(info.st_mode) & 0o022:
+        fail(f"{label} is group- or world-writable: {path}")
+
+
+def validate_current() -> None:
+    release = current_release()
+    if release is None:
+        fail("current symlink does not identify one release directory")
+    resolved = git(release, "rev-parse", "--verify", "HEAD^{commit}")
+    commit = resolved.stdout.strip()
+    if resolved.returncode != 0 or len(commit) != 40 or any(
+        character not in "0123456789abcdef" for character in commit
+    ):
+        fail("current release does not resolve to one full commit SHA")
+    tools = operation_tools(release)
+    runner = tools / "run-release-validation.py"
+    verifier = tools / "verify-release-worktree.py"
+    validate_tool(runner, "validation supervisor")
+    validate_tool(verifier, "source-tree verifier")
+    command = [
+        SYSTEM_PYTHON,
+        "-I",
+        str(runner),
+        str(release),
+        commit,
+        str(verifier),
+    ]
+    os.execve(command[0], command, clean_environment())
+
+
+def run_operation(operation: str, arguments: list[str]) -> None:
+    tools = operation_tools()
+    dispatcher = tools / "run-reviewed-operation.py"
+    validate_tool(dispatcher, "reviewed-operation dispatcher")
+    command = [
+        SYSTEM_PYTHON,
+        "-I",
+        str(dispatcher),
+        "--app-root",
+        str(APP_ROOT),
+        "--repo-url",
+        DEFAULT_REPOSITORY,
+        operation,
+        *arguments,
+    ]
+    os.execve(command[0], command, clean_environment())
+
+
+def main() -> None:
+    arguments = sys.argv[1:]
+    if not arguments or arguments[0] in {"-h", "--help", "help"}:
+        if len(arguments) > 1:
+            fail("help accepts no arguments")
+        usage()
+        return
+    command, *remaining = arguments
+    if command == "status":
+        if remaining:
+            fail("status accepts no arguments")
+        status_current()
+        return
+    if command == "validate":
+        if remaining:
+            fail("validate accepts no arguments")
+        validate_current()
+        return
+    if command in MUTATING_OPERATIONS:
+        run_operation(command, remaining)
+        return
+    usage(sys.stderr)
+    fail(f"unknown command: {command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/ec2/preflight-deploy.sh
+++ b/ops/ec2/preflight-deploy.sh
@@ -7,6 +7,7 @@ TARGET_SHA="${1:-}"
 REFERENCE_URL="${2:-}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"
+SOURCE_TREE_TOOL="$SCRIPT_DIR/verify-release-worktree.py"
 
 # Fail-closed floor for the reviewed t3.small deployment operation.
 MIN_DISK_KIB=3145728
@@ -66,8 +67,6 @@ inspect_release_directory() {
     || fail "Release is not the Git worktree root: $release_path"
   [ "$(git -C "$release_path" remote get-url origin)" = "$REPO_URL" ] \
     || fail "Release origin is not the reviewed repository: $release_path"
-  [ -z "$(git -C "$release_path" status --porcelain --untracked-files=normal)" ] \
-    || fail "Release worktree is not clean: $release_path"
   [ -f "$release_path/ops/ec2/hub-api.sh" ] \
     && [ ! -L "$release_path/ops/ec2/hub-api.sh" ] \
     && [ -x "$release_path/ops/ec2/hub-api.sh" ] \
@@ -76,6 +75,20 @@ inspect_release_directory() {
   actual_commit="$(git -C "$release_path" rev-parse --verify HEAD)"
   [[ "$actual_commit" =~ ^[0-9a-f]{40}$ ]] \
     || fail "Release does not resolve to one full commit SHA: $release_path"
+  [ -f "$SOURCE_TREE_TOOL" ] && [ ! -L "$SOURCE_TREE_TOOL" ] \
+    || fail "Source-tree verifier is not one regular file: $SOURCE_TREE_TOOL"
+  /usr/bin/env -i \
+    HOME=/nonexistent \
+    LANG=C.UTF-8 \
+    PATH=/usr/bin:/bin \
+    /usr/bin/python3 -I \
+      "$SOURCE_TREE_TOOL" \
+      "$release_path" \
+      "$actual_commit" \
+      --allow-generated .venv \
+      --allow-generated .hub-deployment \
+      >/dev/null \
+    || fail "Release source tree differs from its commit: $release_path"
   actual_launcher_sha256="$(sha256_file "$release_path/ops/ec2/hub-api.sh")"
 
   printf '%s\t%s\n' "$actual_commit" "$actual_launcher_sha256"

--- a/ops/ec2/rollback-current.sh
+++ b/ops/ec2/rollback-current.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 STATE_VALIDATOR="$SCRIPT_DIR/validate-release-state.sh"
 OPERATION_LOCK_TOOL="$SCRIPT_DIR/operation-lock.py"
 OPERATION_ENTRYPOINT="$SCRIPT_DIR/rollback-current.sh"
+SOURCE_TREE_TOOL="$SCRIPT_DIR/verify-release-worktree.py"
+VALIDATION_RUNNER="$SCRIPT_DIR/run-release-validation.py"
 
 fail() {
   echo "[rollback:error] $*" >&2
@@ -66,6 +68,135 @@ sha256_file() {
   [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
     || fail "Could not calculate launcher SHA-256: $path"
   printf '%s\n' "$digest"
+}
+
+verify_release_head() {
+  local release_path="$1"
+  local commit="$2"
+  local head_commit
+
+  head_commit="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 \
+      GIT_NO_REPLACE_OBJECTS=1 \
+      /usr/bin/git --no-replace-objects \
+        -C "$release_path" rev-parse --verify HEAD
+  )" || fail "Release HEAD could not be resolved safely: $release_path"
+  [[ "$head_commit" =~ ^[0-9a-f]{40}$ ]] \
+    && [ "$head_commit" = "$commit" ] \
+    || fail "Release HEAD differs from its recorded commit: $release_path"
+}
+
+release_source_evidence() {
+  local release_path="$1"
+  local commit="$2"
+  local evidence
+
+  verify_release_head "$release_path" "$commit"
+
+  [ -f "$SOURCE_TREE_TOOL" ] && [ ! -L "$SOURCE_TREE_TOOL" ] \
+    || fail "Source-tree verifier is not one regular file: $SOURCE_TREE_TOOL"
+  evidence="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      /usr/bin/python3 -I \
+        "$SOURCE_TREE_TOOL" \
+        "$release_path" \
+        "$commit" \
+        --allow-generated .venv \
+        --allow-generated .hub-deployment
+  )" || fail "Release source tree differs from its reviewed commit: $release_path"
+  [ -n "$evidence" ] \
+    || fail "Source-tree verifier returned empty evidence."
+  verify_release_head "$release_path" "$commit"
+  printf '%s\n' "$evidence"
+}
+
+source_tree_digest() {
+  local evidence="$1"
+  local expected_commit="$2"
+
+  /usr/bin/python3 -I - "$expected_commit" "$evidence" <<'PY_SOURCE_EVIDENCE'
+import json
+import re
+import sys
+
+
+expected_commit, raw = sys.argv[1:]
+try:
+    evidence = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit(1)
+digest = evidence.get("source_tree_sha256")
+if evidence.get("commit") != expected_commit or not isinstance(digest, str):
+    raise SystemExit(1)
+if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+    raise SystemExit(1)
+print(digest)
+PY_SOURCE_EVIDENCE
+}
+
+release_venv_digest() {
+  local release_path="$1"
+  local digest
+
+  [ -f "$VALIDATION_RUNNER" ] && [ ! -L "$VALIDATION_RUNNER" ] \
+    || fail "Venv-manifest supervisor is not one regular file: $VALIDATION_RUNNER"
+  digest="$(
+    /usr/bin/env -i \
+      HOME=/nonexistent \
+      LANG=C.UTF-8 \
+      PATH=/usr/bin:/bin \
+      /usr/bin/python3 -I \
+        "$VALIDATION_RUNNER" \
+        manifest-venv \
+        "$release_path"
+  )" || fail "Release venv manifest verification failed: $release_path"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "Venv-manifest supervisor returned an invalid digest."
+  printf '%s\n' "$digest"
+}
+
+verify_recorded_release_authority() {
+  local release_path="$1"
+  local state_file="$2"
+  local label="$3"
+  local commit
+  local evidence
+  local actual_source_tree_sha256
+  local actual_venv_tree_sha256
+  local recorded_source_tree_sha256
+  local recorded_venv_tree_sha256
+
+  commit="$(required_state_value "$state_file" commit)"
+  recorded_source_tree_sha256="$(
+    required_state_value "$state_file" source_tree_sha256
+  )"
+  recorded_venv_tree_sha256="$(
+    required_state_value "$state_file" venv_tree_sha256
+  )"
+  [[ "$recorded_source_tree_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$label RELEASE_STATE has no valid source-tree SHA-256."
+  [[ "$recorded_venv_tree_sha256" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$label RELEASE_STATE has no valid venv-tree SHA-256."
+
+  evidence="$(release_source_evidence "$release_path" "$commit")"
+  actual_source_tree_sha256="$(source_tree_digest "$evidence" "$commit")" \
+    || fail "$label source-tree verifier returned invalid evidence."
+  [ "$actual_source_tree_sha256" = "$recorded_source_tree_sha256" ] \
+    || fail "$label source tree does not match RELEASE_STATE."
+
+  actual_venv_tree_sha256="$(release_venv_digest "$release_path")"
+  [ "$actual_venv_tree_sha256" = "$recorded_venv_tree_sha256" ] \
+    || fail "$label venv does not match RELEASE_STATE."
+  verify_release_head "$release_path" "$commit"
+  printf '%s:%s\n' "$actual_source_tree_sha256" "$actual_venv_tree_sha256"
 }
 
 snapshot_item() {
@@ -258,6 +389,11 @@ CURRENT_COMMIT="$(git -C "$CURRENT" rev-parse --verify HEAD)"
 CURRENT_LAUNCHER_SHA256="$(sha256_file "$CURRENT/ops/ec2/hub-api.sh")"
 [ "$(required_state_value "$CURRENT_STATE" "launcher_sha256")" = "$CURRENT_LAUNCHER_SHA256" ] \
   || fail "Current release launcher does not match its deployment state."
+verify_recorded_release_authority \
+  "$CURRENT" \
+  "$CURRENT_STATE" \
+  "Current release" \
+  >/dev/null
 
 if [ "$CURRENT" = "$PREVIOUS" ]; then
   echo "[rollback] Current release already matches previous_release target:"
@@ -293,6 +429,11 @@ ACTUAL_COMMIT="$(git -C "$PREVIOUS" rev-parse --verify HEAD)"
 ACTUAL_LAUNCHER_SHA256="$(sha256_file "$PREVIOUS/ops/ec2/hub-api.sh")"
 [ "$RECORDED_LAUNCHER_SHA256" = "$ACTUAL_LAUNCHER_SHA256" ] \
   || fail "Previous release launcher does not match its deployment state."
+verify_recorded_release_authority \
+  "$PREVIOUS" \
+  "$PREVIOUS_STATE" \
+  "Previous release" \
+  >/dev/null
 
 CURRENT_RELEASE="$(basename "$CURRENT")"
 PREVIOUS_RELEASE="$(basename "$PREVIOUS")"
@@ -329,6 +470,25 @@ snapshot_item "$APP_ROOT/shared/RELEASE_STATE" "shared-release-state"
 snapshot_item "$APP_ROOT/shared/ROLLBACK_STATE" "rollback-state"
 snapshot_item "$APP_ROOT/shared/current_release" "current-release-marker"
 snapshot_item "$APP_ROOT/current" "current-symlink"
+
+if [ -n "${HUB_OPTIMUS_TEST_ROLLBACK_BEFORE_AUTHORITY_READY:-}" ]; then
+  touch "$HUB_OPTIMUS_TEST_ROLLBACK_BEFORE_AUTHORITY_READY"
+  while [ ! -e "${HUB_OPTIMUS_TEST_ROLLBACK_BEFORE_AUTHORITY_PROCEED:-}" ]; do
+    sleep 0.01
+  done
+fi
+verify_recorded_release_authority \
+  "$CURRENT" \
+  "$CURRENT_STATE" \
+  "Current release" \
+  >/dev/null
+verify_recorded_release_authority \
+  "$PREVIOUS" \
+  "$PREVIOUS_STATE" \
+  "Previous release" \
+  >/dev/null
+verify_release_head "$CURRENT" "$CURRENT_COMMIT"
+verify_release_head "$PREVIOUS" "$ACTUAL_COMMIT"
 
 MUTATION_STARTED=1
 

--- a/ops/ec2/run-release-validation.py
+++ b/ops/ec2/run-release-validation.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Run candidate pytest validation behind an isolated Linux supervisor."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import pwd
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+PR_SET_CHILD_SUBREAPER = 36
+PR_SET_NO_NEW_PRIVS = 38
+IDENTITY_FIELDS = (
+    "st_dev",
+    "st_ino",
+    "st_mode",
+    "st_nlink",
+    "st_uid",
+    "st_gid",
+    "st_size",
+    "st_mtime_ns",
+    "st_ctime_ns",
+)
+WORKER_SOURCE = r'''from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+import pytest
+
+
+class Evidence:
+    def __init__(self):
+        self.nodeids = []
+        self.outcomes = {}
+
+    def pytest_collection_finish(self, session):
+        self.nodeids = [item.nodeid for item in session.items]
+
+    def pytest_runtest_logreport(self, report):
+        terminal = report.when == "call" or (
+            report.when == "setup" and report.outcome in {"failed", "skipped"}
+        )
+        if terminal and report.nodeid not in self.outcomes:
+            self.outcomes[report.nodeid] = report.outcome
+
+
+def main():
+    release, result_path = sys.argv[1:]
+    plugin = Evidence()
+    # Import pytest before exposing the reviewed source tree on sys.path. This
+    # prevents a tracked top-level pytest.py from replacing the installed tool.
+    sys.path.insert(0, release)
+    exit_code = int(pytest.main([
+        "-q",
+        "-c", "/dev/null",
+        "-o", "addopts=",
+        "-p", "no:cacheprovider",
+        os.path.join(release, "tests"),
+    ], plugins=[plugin]))
+    nodeids = plugin.nodeids
+    outcomes = plugin.outcomes
+    terminal = len(outcomes)
+    passed = sum(value == "passed" for value in outcomes.values())
+    skipped = sum(value == "skipped" for value in outcomes.values())
+    failed = sum(value == "failed" for value in outcomes.values())
+    digest = hashlib.sha256()
+    for nodeid in nodeids:
+        raw = nodeid.encode("utf-8")
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+    evidence = {
+        "collected": len(nodeids),
+        "failed": failed,
+        "nodeids_sha256": digest.hexdigest(),
+        "passed": passed,
+        "pytest_exit_code": exit_code,
+        "skipped": skipped,
+        "terminal": terminal,
+    }
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(result_path, flags, 0o600)
+    try:
+        raw = (json.dumps(evidence, sort_keys=True, separators=(",", ":")) + "\n").encode("ascii")
+        view = memoryview(raw)
+        written = 0
+        while written < len(view):
+            written += os.write(descriptor, view[written:])
+    finally:
+        os.close(descriptor)
+    valid = (
+        exit_code == 0
+        and len(nodeids) > 0
+        and terminal == len(nodeids)
+        and failed == 0
+        and passed + skipped == terminal
+        and set(outcomes) == set(nodeids)
+    )
+    raise SystemExit(0 if valid else 1)
+
+
+main()
+'''
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return all(
+        getattr(left, field) == getattr(right, field)
+        for field in IDENTITY_FIELDS
+    )
+
+
+def canonical_directory(raw: str, label: str) -> Path:
+    if not os.path.isabs(raw) or os.path.abspath(raw) != raw:
+        fail(f"{label} must be one canonical absolute path")
+    path = Path(raw)
+    try:
+        visible = path.lstat()
+    except OSError as exc:
+        fail(f"cannot inspect {label}: {exc}")
+    if path.is_symlink() or not stat.S_ISDIR(visible.st_mode):
+        fail(f"{label} is not one real directory")
+    if stat.S_IMODE(visible.st_mode) & 0o022:
+        fail(f"{label} is group- or world-writable")
+    return path
+
+
+def open_regular(path: Path) -> tuple[bytes, os.stat_result]:
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK
+    if not hasattr(os, "O_NOFOLLOW"):
+        fail("O_NOFOLLOW is unavailable")
+    flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        fail(f"cannot safely open venv file {path}: {exc}")
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            fail(f"venv path is not one regular single-link file: {path}")
+        if stat.S_IMODE(before.st_mode) & 0o022:
+            fail(f"venv path is group- or world-writable: {path}")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    visible = path.stat(follow_symlinks=False)
+    if not same_identity(before, after) or not same_identity(after, visible):
+        fail(f"venv path changed while it was read: {path}")
+    return b"".join(chunks), after
+
+
+def venv_manifest(venv: Path, forbidden_owner: int | None) -> str:
+    root = canonical_directory(str(venv), "candidate venv")
+    digest = hashlib.sha256()
+    pending = [root]
+    records: list[tuple[str, bytes, os.stat_result]] = []
+    while pending:
+        directory = pending.pop()
+        info = directory.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(info.st_mode):
+            fail(f"venv directory changed type: {directory}")
+        if stat.S_IMODE(info.st_mode) & 0o022:
+            fail(f"venv directory is group- or world-writable: {directory}")
+        if forbidden_owner is not None and info.st_uid == forbidden_owner:
+            if stat.S_IMODE(info.st_mode) & 0o200:
+                fail(f"validation worker owns a writable venv directory: {directory}")
+        relative_directory = str(directory.relative_to(root)) or "."
+        records.append((relative_directory + "/", b"directory", info))
+        try:
+            entries = sorted(os.scandir(directory), key=lambda item: item.name)
+        except OSError as exc:
+            fail(f"cannot enumerate candidate venv {directory}: {exc}")
+        for entry in entries:
+            path = Path(entry.path)
+            entry_info = entry.stat(follow_symlinks=False)
+            relative = str(path.relative_to(root))
+            if stat.S_ISDIR(entry_info.st_mode):
+                pending.append(path)
+            elif stat.S_ISREG(entry_info.st_mode):
+                raw, stable = open_regular(path)
+                if forbidden_owner is not None and stable.st_uid == forbidden_owner:
+                    if stat.S_IMODE(stable.st_mode) & 0o200:
+                        fail(f"validation worker owns a writable venv file: {path}")
+                records.append((relative, raw, stable))
+            elif stat.S_ISLNK(entry_info.st_mode):
+                target = os.readlink(path)
+                second = path.stat(follow_symlinks=False)
+                if not same_identity(entry_info, second):
+                    fail(f"venv symlink changed while it was read: {path}")
+                records.append((relative, ("symlink:" + target).encode(), second))
+            else:
+                fail(f"unsupported special file in candidate venv: {path}")
+    for relative, raw, info in sorted(records, key=lambda record: record[0]):
+        encoded = relative.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+        for field in IDENTITY_FIELDS:
+            digest.update(int(getattr(info, field)).to_bytes(16, "big", signed=False))
+    return digest.hexdigest()
+
+
+def sealed_worker() -> int:
+    if not hasattr(os, "memfd_create"):
+        fail("memfd_create is unavailable")
+    flags = getattr(os, "MFD_CLOEXEC", 0x0001) | getattr(
+        os,
+        "MFD_ALLOW_SEALING",
+        0x0002,
+    )
+    descriptor = os.memfd_create("hub-optimus-validation-worker", flags)
+    raw = WORKER_SOURCE.encode("utf-8")
+    try:
+        view = memoryview(raw)
+        written = 0
+        while written < len(view):
+            written += os.write(descriptor, view[written:])
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.fchmod(descriptor, 0o400)
+        seals = (
+            getattr(fcntl, "F_SEAL_SEAL", 0x0001)
+            | getattr(fcntl, "F_SEAL_SHRINK", 0x0002)
+            | getattr(fcntl, "F_SEAL_GROW", 0x0004)
+            | getattr(fcntl, "F_SEAL_WRITE", 0x0008)
+        )
+        fcntl.fcntl(descriptor, getattr(fcntl, "F_ADD_SEALS", 1033), seals)
+        if fcntl.fcntl(descriptor, getattr(fcntl, "F_GET_SEALS", 1034)) != seals:
+            fail("validation worker memfd is not fully sealed")
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def set_subreaper() -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        fail(f"cannot enable child subreaper: {os.strerror(error)}")
+
+
+def no_new_privileges() -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+
+
+def direct_children() -> set[int]:
+    try:
+        tasks = list(Path("/proc/self/task").iterdir())
+    except OSError as exc:
+        fail(f"cannot enumerate supervisor tasks for descendant cleanup: {exc}")
+    if not tasks:
+        fail("cannot observe supervisor tasks for descendant cleanup")
+    children: set[int] = set()
+    for task in tasks:
+        path = task / "children"
+        try:
+            raw = path.read_text(encoding="ascii").strip()
+        except OSError as exc:
+            fail(f"cannot observe validation descendants through {path}: {exc}")
+        try:
+            children.update(int(value) for value in raw.split())
+        except ValueError:
+            fail(f"kernel returned invalid validation descendants through {path}")
+    return children
+
+
+def kill_and_reap_descendants() -> set[int]:
+    observed: set[int] = set()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        children = direct_children()
+        if not children:
+            break
+        observed.update(children)
+        for child in children:
+            try:
+                os.kill(child, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        while True:
+            try:
+                waited, _status = os.waitpid(-1, os.WNOHANG)
+            except ChildProcessError:
+                break
+            if waited == 0:
+                break
+        time.sleep(0.01)
+    if direct_children():
+        fail("could not reap all validation descendants")
+    return observed
+
+
+def clean_worker_environment(home: Path) -> dict[str, str]:
+    return {
+        "HOME": str(home),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": "/usr/bin:/bin",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "TMPDIR": str(home),
+    }
+
+
+def source_manifest(verifier: Path, release: Path, commit: str) -> bytes:
+    try:
+        visible = verifier.lstat()
+    except OSError as exc:
+        fail(f"cannot inspect source verifier: {exc}")
+    if verifier.is_symlink() or not stat.S_ISREG(visible.st_mode):
+        fail("source verifier is not one regular file")
+    result = subprocess.run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            str(verifier),
+            str(release),
+            commit,
+            "--allow-generated",
+            ".venv",
+            "--allow-generated",
+            ".hub-deployment",
+        ],
+        cwd="/",
+        env={"HOME": "/nonexistent", "LANG": "C.UTF-8", "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.buffer.write(result.stderr)
+        fail("candidate source tree verification failed")
+    try:
+        parsed = json.loads(result.stdout)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        fail("source verifier returned invalid evidence")
+    expected = (json.dumps(parsed, sort_keys=True, separators=(",", ":")) + "\n").encode("ascii")
+    if result.stdout != expected:
+        fail("source verifier evidence is not canonical")
+    if parsed.get("commit") != commit or not isinstance(
+        parsed.get("source_tree_sha256"),
+        str,
+    ):
+        fail("source verifier evidence is incomplete")
+    return result.stdout
+
+
+def worker_identity(release: Path, venv: Path) -> tuple[int, int]:
+    if os.geteuid() != 0:
+        return os.getegid(), os.geteuid()
+    try:
+        account = pwd.getpwnam("nobody")
+    except KeyError:
+        fail("the nobody validation account is unavailable")
+    if account.pw_uid == 0:
+        fail("the nobody validation account unexpectedly resolves to root")
+    for candidate in (release, venv):
+        info = candidate.stat(follow_symlinks=False)
+        if info.st_uid == account.pw_uid and stat.S_IMODE(info.st_mode) & 0o200:
+            fail(f"validation worker can write candidate path: {candidate}")
+    return account.pw_gid, account.pw_uid
+
+
+def make_preexec(gid: int, uid: int):
+    def prepare() -> None:
+        if os.geteuid() == 0:
+            os.setgroups([])
+            os.setgid(gid)
+            os.setuid(uid)
+        no_new_privileges()
+
+    return prepare
+
+
+def marker(evidence: dict[str, object]) -> str:
+    order = (
+        "collected",
+        "terminal",
+        "passed",
+        "skipped",
+        "failed",
+        "pytest_exit_code",
+        "nodeids_sha256",
+        "descendants",
+        "source_tree_sha256",
+        "venv_tree_sha256",
+        "worker_uid",
+        "result",
+    )
+    return "HUB_OPTIMUS_VALIDATION_V1 " + " ".join(
+        f"{name}={evidence[name]}" for name in order
+    )
+
+
+def run_validation(
+    release: Path,
+    commit: str,
+    verifier: Path,
+    timeout: int,
+) -> int:
+    venv = canonical_directory(str(release / ".venv"), "candidate venv")
+    venv_python = venv / "bin" / "python"
+    if not venv_python.is_file() or not os.access(venv_python, os.X_OK):
+        fail("candidate venv Python is not executable")
+    gid, uid = worker_identity(release, venv)
+    source_before = source_manifest(verifier, release, commit)
+    venv_before = venv_manifest(venv, uid if uid != os.geteuid() else None)
+
+    set_subreaper()
+    temporary = Path(tempfile.mkdtemp(prefix="hub-optimus-validation-", dir="/tmp"))
+    worker_descriptor = -1
+    process: subprocess.Popen[bytes] | None = None
+    observed_descendants: set[int] = set()
+    try:
+        if os.geteuid() == 0:
+            try:
+                os.chown(temporary, uid, gid)
+            except OSError as exc:
+                fail(f"cannot assign validation workspace to worker UID {uid}: {exc}")
+        temporary.chmod(0o700)
+        result_path = temporary / "evidence.json"
+        log_path = temporary / "pytest.log"
+        worker_descriptor = sealed_worker()
+        with log_path.open("wb") as log_stream:
+            process = subprocess.Popen(
+                [
+                    str(venv_python),
+                    "-I",
+                    "-B",
+                    f"/proc/self/fd/{worker_descriptor}",
+                    str(release),
+                    str(result_path),
+                ],
+                cwd=release,
+                env=clean_worker_environment(temporary),
+                pass_fds=(worker_descriptor,),
+                stdout=log_stream,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                preexec_fn=make_preexec(gid, uid),
+            )
+            try:
+                process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait(timeout=10)
+        # Give orphans one scheduler turn to reparent to this subreaper.
+        time.sleep(0.05)
+        observed_descendants = kill_and_reap_descendants()
+        raw_log = log_path.read_bytes()
+        sys.stdout.buffer.write(raw_log)
+        if raw_log and not raw_log.endswith(b"\n"):
+            sys.stdout.buffer.write(b"\n")
+        try:
+            raw_evidence = result_path.read_bytes()
+            evidence = json.loads(raw_evidence)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            fail("validation worker did not return canonical evidence")
+        canonical = (json.dumps(evidence, sort_keys=True, separators=(",", ":")) + "\n").encode("ascii")
+        if raw_evidence != canonical:
+            fail("validation worker evidence is not canonical")
+    finally:
+        if process is not None and process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait(timeout=10)
+        try:
+            observed_descendants.update(kill_and_reap_descendants())
+        finally:
+            if worker_descriptor >= 0:
+                os.close(worker_descriptor)
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    source_after = source_manifest(verifier, release, commit)
+    venv_after = venv_manifest(venv, uid if uid != os.geteuid() else None)
+    if source_after != source_before:
+        fail("candidate source tree changed during validation")
+    if venv_after != venv_before:
+        fail("candidate venv changed during validation")
+
+    evidence["descendants"] = len(observed_descendants)
+    evidence["source_tree_sha256"] = json.loads(source_before)["source_tree_sha256"]
+    evidence["venv_tree_sha256"] = venv_before
+    evidence["worker_uid"] = uid
+    success = (
+        process is not None
+        and process.returncode == 0
+        and evidence.get("collected", 0) > 0
+        and evidence.get("terminal") == evidence.get("collected")
+        and evidence.get("failed") == 0
+        and evidence.get("passed", 0) + evidence.get("skipped", 0)
+        == evidence.get("terminal")
+        and evidence["descendants"] == 0
+    )
+    evidence["result"] = "passed" if success else "failed"
+    print(marker(evidence), flush=True)
+    return 0 if success else 1
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    if len(sys.argv) == 3 and sys.argv[1] == "manifest-venv":
+        return argparse.Namespace(
+            operation="manifest-venv",
+            release=sys.argv[2],
+            commit=None,
+            source_verifier=None,
+            timeout=900,
+        )
+    parser.add_argument("release")
+    parser.add_argument("commit")
+    parser.add_argument("source_verifier")
+    parser.add_argument("--timeout", type=int, default=900)
+    arguments = parser.parse_args()
+    if not 1 <= arguments.timeout <= 3600:
+        parser.error("--timeout must be between 1 and 3600 seconds")
+    arguments.operation = "run"
+    return arguments
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    release = canonical_directory(arguments.release, "candidate release")
+    if arguments.operation == "manifest-venv":
+        venv = canonical_directory(str(release / ".venv"), "candidate venv")
+        _gid, uid = worker_identity(release, venv)
+        print(venv_manifest(venv, uid if uid != os.geteuid() else None))
+        return
+    if len(arguments.commit) != 40 or any(
+        character not in "0123456789abcdef" for character in arguments.commit
+    ):
+        fail("candidate commit must be one full lowercase SHA")
+    verifier = Path(arguments.source_verifier)
+    raise SystemExit(
+        run_validation(release, arguments.commit, verifier, arguments.timeout)
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ValidationError as exc:
+        print(f"[validation-boundary:error] {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ops/ec2/run-reviewed-operation.py
+++ b/ops/ec2/run-reviewed-operation.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Launch reviewed EC2 operations across a non-Bash environment boundary."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+DEFAULT_APP_ROOT = "/opt/hub-optimus"
+DEFAULT_REPOSITORY = "https://github.com/Voxterrae/HUB_Optimus.git"
+OPERATIONS = {
+    "adopt": ("adopt-legacy-current.sh", 1),
+    "deploy": ("deploy-current.sh", 1),
+    "preflight": ("preflight-deploy.sh", 2),
+    "rollback": ("rollback-current.sh", 0),
+}
+
+
+def fail(message: str) -> None:
+    print(f"[reviewed-operation:error] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def canonical_absolute(raw: str, label: str) -> str:
+    if not os.path.isabs(raw) or os.path.abspath(raw) != raw:
+        fail(f"{label} must be one canonical absolute path")
+    return raw
+
+
+def validate_script(path: Path) -> None:
+    try:
+        visible = path.lstat()
+    except OSError as exc:
+        fail(f"cannot inspect reviewed operation script {path}: {exc}")
+    if not stat.S_ISREG(visible.st_mode) or path.is_symlink():
+        fail(f"reviewed operation script is not one regular file: {path}")
+    if visible.st_uid != os.geteuid():
+        fail(f"reviewed operation script has an unexpected owner: {path}")
+    if visible.st_nlink != 1:
+        fail(f"reviewed operation script has more than one link: {path}")
+    if stat.S_IMODE(visible.st_mode) & 0o022:
+        fail(f"reviewed operation script is group- or world-writable: {path}")
+
+
+def clean_environment(app_root: str, repository: str) -> dict[str, str]:
+    # This is intentionally constructed from nothing. In particular, Bash never
+    # observes BASH_ENV/exported functions and Python/pytest/git/pip receive no
+    # ambient configuration from the caller.
+    return {
+        "HOME": "/nonexistent",
+        "HUB_OPTIMUS_APP_ROOT": app_root,
+        "HUB_OPTIMUS_REPO_URL": repository,
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": "/usr/bin:/bin",
+    }
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run one reviewed HUB_Optimus EC2 operation",
+    )
+    parser.add_argument("--app-root", default=DEFAULT_APP_ROOT)
+    parser.add_argument("--repo-url", default=DEFAULT_REPOSITORY)
+    parser.add_argument("operation", choices=sorted(OPERATIONS))
+    parser.add_argument("operation_arguments", nargs="*")
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    app_root = canonical_absolute(arguments.app_root, "APP_ROOT")
+    repository = arguments.repo_url
+    if not repository.startswith("https://"):
+        canonical_absolute(repository, "local repository path")
+
+    script_name, required_arguments = OPERATIONS[arguments.operation]
+    if len(arguments.operation_arguments) != required_arguments:
+        fail(
+            f"{arguments.operation} requires exactly "
+            f"{required_arguments} operation argument(s)"
+        )
+
+    script_directory = Path(__file__).resolve().parent
+    script = script_directory / script_name
+    validate_script(script)
+    environment = clean_environment(app_root, repository)
+    command = [
+        "/bin/bash",
+        "--noprofile",
+        "--norc",
+        str(script),
+        *arguments.operation_arguments,
+    ]
+    os.execve(command[0], command, environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/ec2/validate-release-state.sh
+++ b/ops/ec2/validate-release-state.sh
@@ -383,7 +383,8 @@ validate_adopted_legacy() {
   require_exact_keys \
     release requested_ref requested_ref_kind commit path adopted_at_utc \
     validation_command validation_exit_code validation_result validation_log \
-    validation_log_exit_code launcher_sha256 status provenance \
+    validation_log_exit_code source_tree_sha256 venv_tree_sha256 \
+    launcher_sha256 status provenance \
     legacy_state_sha256 legacy_commit_prefix
   require_common_identity
   commit="$(state_value commit)"
@@ -401,10 +402,13 @@ validate_adopted_legacy() {
     && [ "$(state_value validation_log_exit_code)" = "not-run" ] \
     || fail "$STATE_FILE has invalid legacy-adoption validation metadata."
   [ "$(state_value status)" = "adopted-legacy-current" ] \
-    && [ "$(state_value provenance)" = "adopted-legacy-current-v1" ] \
+    && [ "$(state_value provenance)" = "adopted-legacy-current-v2" ] \
     || fail "$STATE_FILE has invalid legacy-adoption provenance."
   [[ "$(state_value launcher_sha256)" =~ ^[0-9a-f]{64}$ ]] \
     || fail "$STATE_FILE has no valid launcher SHA-256."
+  [[ "$(state_value source_tree_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+    && [[ "$(state_value venv_tree_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "$STATE_FILE has invalid adopted source/venv authority."
   [[ "$(state_value legacy_state_sha256)" =~ ^[0-9a-f]{64}$ ]] \
     || fail "$STATE_FILE has an invalid legacy-state SHA-256."
   [[ "$prefix" =~ ^[0-9a-f]{7,39}$ ]] \

--- a/ops/ec2/validate-release-state.sh
+++ b/ops/ec2/validate-release-state.sh
@@ -108,13 +108,32 @@ validate_production() {
   local requested_ref_kind
   local digest_bound="no"
   local dependency_bound="no"
+  local isolated_bound="no"
   local validation_log
   local validation_log_sha256
   local dependency_lock_sha256
   local expected_validation_command
+  local validation_collected
+  local validation_terminal
+  local validation_passed
+  local validation_skipped
+  local validation_failed
 
   if [ "$transitional" = "yes" ]; then
-    if [[ -n "${SEEN_STATE_KEYS[dependency_lock_sha256]+present}" ]]; then
+    if [[ -n "${SEEN_STATE_KEYS[validation_protocol]+present}" ]]; then
+      require_exact_keys \
+        release requested_ref requested_ref_kind commit path validated_at_utc \
+        validation_command validation_exit_code validation_result validation_log \
+        validation_log_exit_code validation_log_sha256 validation_protocol \
+        validation_collected validation_terminal validation_passed \
+        validation_skipped validation_failed validation_pytest_exit_code \
+        validation_nodeids_sha256 validation_descendants validation_worker_uid \
+        source_tree_sha256 venv_tree_sha256 dependency_tier dependency_lock \
+        dependency_lock_sha256 launcher_sha256 status provenance
+      digest_bound="yes"
+      dependency_bound="yes"
+      isolated_bound="yes"
+    elif [[ -n "${SEEN_STATE_KEYS[dependency_lock_sha256]+present}" ]]; then
       require_exact_keys \
         release requested_ref requested_ref_kind commit path validated_at_utc \
         validation_command validation_exit_code validation_result validation_log \
@@ -142,11 +161,16 @@ validate_production() {
     require_exact_keys \
       release requested_ref requested_ref_kind commit path validated_at_utc \
       validation_command validation_exit_code validation_result validation_log \
-      validation_log_exit_code validation_log_sha256 dependency_tier \
-      dependency_lock dependency_lock_sha256 launcher_sha256 status
+      validation_log_exit_code validation_log_sha256 validation_protocol \
+      validation_collected validation_terminal validation_passed \
+      validation_skipped validation_failed validation_pytest_exit_code \
+      validation_nodeids_sha256 validation_descendants validation_worker_uid \
+      source_tree_sha256 venv_tree_sha256 dependency_tier dependency_lock \
+      dependency_lock_sha256 launcher_sha256 status
     schema="production"
     digest_bound="yes"
     dependency_bound="yes"
+    isolated_bound="yes"
   fi
 
   require_common_identity
@@ -172,7 +196,14 @@ validate_production() {
   esac
   [[ "$(state_value validated_at_utc)" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
     || fail "$STATE_FILE has an invalid validation timestamp."
-  if [ "$dependency_bound" = "yes" ]; then
+  if [ "$isolated_bound" = "yes" ]; then
+    printf -v expected_validation_command \
+      '/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 PATH=/usr/bin:/bin /usr/bin/python3 -I %q %q %q %q' \
+      "$(state_value path)/ops/ec2/run-release-validation.py" \
+      "$(state_value path)" \
+      "$commit" \
+      "$(state_value path)/ops/ec2/verify-release-worktree.py"
+  elif [ "$dependency_bound" = "yes" ]; then
     printf -v expected_validation_command \
       '/usr/bin/env -i HOME=%q LANG=C.UTF-8 PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 %q -m pytest -q' \
       "$(state_value path)" \
@@ -188,6 +219,42 @@ validate_production() {
   [ -n "$(state_value validation_result)" ] \
     && [ -n "$(state_value validation_log)" ] \
     || fail "$STATE_FILE has incomplete validation evidence."
+
+  if [ "$isolated_bound" = "yes" ]; then
+    [ "$(state_value validation_protocol)" = "isolated-pytest-v1" ] \
+      || fail "$STATE_FILE has an unsupported validation protocol."
+    validation_collected="$(state_value validation_collected)"
+    validation_terminal="$(state_value validation_terminal)"
+    validation_passed="$(state_value validation_passed)"
+    validation_skipped="$(state_value validation_skipped)"
+    validation_failed="$(state_value validation_failed)"
+    for value in \
+      "$validation_collected" \
+      "$validation_terminal" \
+      "$validation_passed" \
+      "$validation_skipped" \
+      "$validation_failed" \
+      "$(state_value validation_pytest_exit_code)" \
+      "$(state_value validation_descendants)" \
+      "$(state_value validation_worker_uid)"; do
+      [[ "$value" =~ ^[0-9]+$ ]] \
+        || fail "$STATE_FILE has non-numeric validation evidence."
+    done
+    [ "$validation_collected" -gt 0 ] \
+      && [ "$validation_terminal" -eq "$validation_collected" ] \
+      && [ "$validation_failed" -eq 0 ] \
+      && [ "$(state_value validation_pytest_exit_code)" -eq 0 ] \
+      && [ "$(state_value validation_descendants)" -eq 0 ] \
+      && [ $((validation_passed + validation_skipped)) -eq "$validation_terminal" ] \
+      || fail "$STATE_FILE does not attest one completed pytest execution."
+    [[ "$(state_value validation_nodeids_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+      && [[ "$(state_value source_tree_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+      && [[ "$(state_value venv_tree_sha256)" =~ ^[0-9a-f]{64}$ ]] \
+      || fail "$STATE_FILE has invalid validation-tree evidence."
+    [ "$(state_value validation_result)" = \
+      "HUB_OPTIMUS_VALIDATION_V1 collected=$validation_collected terminal=$validation_terminal passed=$validation_passed skipped=$validation_skipped failed=$validation_failed pytest_exit_code=$(state_value validation_pytest_exit_code) nodeids_sha256=$(state_value validation_nodeids_sha256) descendants=$(state_value validation_descendants) source_tree_sha256=$(state_value source_tree_sha256) venv_tree_sha256=$(state_value venv_tree_sha256) worker_uid=$(state_value validation_worker_uid) result=passed" ] \
+      || fail "Validation result does not match its structured evidence: $STATE_FILE"
+  fi
 
   if [ "$digest_bound" = "yes" ]; then
     validation_log="$(state_value validation_log)"

--- a/ops/ec2/verify-release-worktree.py
+++ b/ops/ec2/verify-release-worktree.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python3
+"""Verify release source bytes directly against one immutable Git commit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+GIT = "/usr/bin/git"
+ALLOWED_GENERATED = frozenset({b".venv", b".hub-deployment"})
+GIT_MODE_PERMISSIONS = {b"100644": 0o644, b"100755": 0o755}
+GIT_TREE_MODE = b"40000"
+FULL_SHA_RE = re.compile(rb"[0-9a-f]{40}")
+IDENTITY_FIELDS = (
+    "st_dev",
+    "st_ino",
+    "st_mode",
+    "st_nlink",
+    "st_size",
+    "st_mtime_ns",
+    "st_ctime_ns",
+)
+READ_FLAGS = os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK
+DIRECTORY_FLAGS = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY
+GIT_ENVIRONMENT = {
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_NO_LAZY_FETCH": "1",
+    "GIT_NO_REPLACE_OBJECTS": "1",
+    "GIT_OPTIONAL_LOCKS": "0",
+    "GIT_TERMINAL_PROMPT": "0",
+    "HOME": "/nonexistent",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PATH": "/usr/bin:/bin",
+    "XDG_CONFIG_HOME": "/nonexistent",
+}
+
+
+@dataclass(frozen=True)
+class ExpectedFile:
+    git_mode: bytes
+    object_id: bytes
+    content: bytes
+
+
+@dataclass(frozen=True)
+class ActualFile:
+    permissions: int
+    content: bytes
+
+
+@dataclass(frozen=True)
+class WorktreeSnapshot:
+    root_permissions: int
+    directories: dict[bytes, int]
+    files: dict[bytes, ActualFile]
+
+
+def fail(message: str) -> None:
+    print(f"[release-worktree:error] {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def display_path(path: bytes) -> str:
+    return ascii(os.fsdecode(path))
+
+
+def same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return all(
+        getattr(left, field) == getattr(right, field)
+        for field in IDENTITY_FIELDS
+    )
+
+
+def require_safe_directory(info: os.stat_result, label: str) -> None:
+    if not stat.S_ISDIR(info.st_mode):
+        fail(f"{label} is not one real directory")
+    if stat.S_IMODE(info.st_mode) & 0o022:
+        fail(f"{label} is group- or world-writable")
+
+
+def open_directory_at(
+    parent_descriptor: int,
+    name: bytes,
+    label: str,
+) -> tuple[int, os.stat_result]:
+    try:
+        visible = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        fail(f"cannot inspect {label}: {exc.strerror or 'operating-system error'}")
+    require_safe_directory(visible, label)
+    try:
+        descriptor = os.open(
+            name,
+            DIRECTORY_FLAGS | os.O_NOFOLLOW,
+            dir_fd=parent_descriptor,
+        )
+    except OSError as exc:
+        fail(
+            f"cannot open {label} without following links: "
+            f"{exc.strerror or 'operating-system error'}"
+        )
+    opened = os.fstat(descriptor)
+    if not same_identity(visible, opened):
+        os.close(descriptor)
+        fail(f"{label} changed while it was opened")
+    require_safe_directory(opened, label)
+    return descriptor, opened
+
+
+def require_visible_identity(
+    parent_descriptor: int,
+    name: bytes,
+    original: os.stat_result,
+    label: str,
+) -> None:
+    try:
+        visible = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        fail(f"{label} changed during inspection: {exc.strerror or 'missing'}")
+    if not same_identity(original, visible):
+        fail(f"{label} changed during inspection")
+
+
+def open_release(raw_release: str) -> tuple[bytes, int, os.stat_result]:
+    release = os.fsencode(raw_release)
+    if (
+        not os.path.isabs(release)
+        or os.path.abspath(release) != release
+        or os.path.realpath(release) != release
+        or b"\n" in release
+        or b"\r" in release
+    ):
+        fail("release must be one canonical absolute physical path")
+    try:
+        visible = os.stat(release, follow_symlinks=False)
+    except OSError as exc:
+        fail(f"cannot inspect release directory: {exc.strerror or 'missing'}")
+    require_safe_directory(visible, "release directory")
+    try:
+        descriptor = os.open(
+            release,
+            DIRECTORY_FLAGS | os.O_NOFOLLOW,
+        )
+    except OSError as exc:
+        fail(
+            "cannot open release directory without following links: "
+            f"{exc.strerror or 'operating-system error'}"
+        )
+    opened = os.fstat(descriptor)
+    if not same_identity(visible, opened):
+        os.close(descriptor)
+        fail("release directory changed while it was opened")
+    require_safe_directory(opened, "release directory")
+    return release, descriptor, opened
+
+
+def git_command(
+    root_descriptor: int,
+    git_descriptor: int,
+    arguments: list[str],
+    label: str,
+    *,
+    input_bytes: bytes | None = None,
+) -> bytes:
+    command = [
+        GIT,
+        "--no-replace-objects",
+        f"--git-dir=/proc/self/fd/{git_descriptor}",
+        f"--work-tree=/proc/self/fd/{root_descriptor}",
+        *arguments,
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=f"/proc/self/fd/{root_descriptor}",
+            input=input_bytes,
+            stdin=subprocess.DEVNULL if input_bytes is None else None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=GIT_ENVIRONMENT,
+            pass_fds=(root_descriptor, git_descriptor),
+            check=False,
+        )
+    except OSError as exc:
+        fail(f"cannot execute reviewed Git for {label}: {exc.strerror or 'error'}")
+    if completed.returncode != 0:
+        fail(f"reviewed Git {label} failed")
+    return completed.stdout
+
+
+def resolve_commit(
+    root_descriptor: int,
+    git_descriptor: int,
+    requested: str,
+) -> bytes:
+    requested_bytes = requested.encode("ascii", errors="strict")
+    if requested_bytes != b"HEAD" and FULL_SHA_RE.fullmatch(requested_bytes) is None:
+        fail("commit must be HEAD or one full lowercase SHA-1")
+    resolved = git_command(
+        root_descriptor,
+        git_descriptor,
+        ["rev-parse", "--verify", "--end-of-options", requested],
+        "commit resolution",
+    ).strip()
+    if FULL_SHA_RE.fullmatch(resolved) is None:
+        fail("reviewed Git did not resolve one full commit SHA")
+    if requested_bytes != b"HEAD" and resolved != requested_bytes:
+        fail("explicit commit does not identify that commit directly")
+    return resolved
+
+
+def validate_git_worktree(
+    release: bytes,
+    root_descriptor: int,
+    git_descriptor: int,
+) -> None:
+    inside = git_command(
+        root_descriptor,
+        git_descriptor,
+        ["rev-parse", "--is-inside-work-tree"],
+        "worktree inspection",
+    )
+    if inside != b"true\n":
+        fail("release is not one Git worktree")
+    top_level = git_command(
+        root_descriptor,
+        git_descriptor,
+        ["rev-parse", "--show-toplevel"],
+        "worktree-root inspection",
+    )
+    if top_level != release + b"\n":
+        fail("release is not the Git worktree root")
+
+
+def path_is_reserved(path: bytes) -> bool:
+    first = path.split(b"/", 1)[0]
+    return first == b".git" or first in ALLOWED_GENERATED
+
+
+def read_verified_git_object(
+    root_descriptor: int,
+    git_descriptor: int,
+    object_id: bytes,
+    expected_type: bytes,
+) -> bytes:
+    """Read one object, then independently authenticate its canonical Git OID."""
+
+    if FULL_SHA_RE.fullmatch(object_id) is None:
+        fail("reviewed commit references an invalid object identity")
+    output = git_command(
+        root_descriptor,
+        git_descriptor,
+        ["cat-file", "--batch"],
+        f"{expected_type.decode('ascii')} object read",
+        input_bytes=object_id + b"\n",
+    )
+    newline = output.find(b"\n")
+    if newline < 0:
+        fail("reviewed Git returned a truncated object header")
+    header = output[:newline].split(b" ")
+    if len(header) != 3 or header[0] != object_id or header[1] != expected_type:
+        fail("reviewed Git returned a mismatched object header")
+    size_bytes = header[2]
+    if not size_bytes.isdigit():
+        fail("reviewed Git returned an invalid object size")
+    size = int(size_bytes)
+    if str(size).encode("ascii") != size_bytes:
+        fail("reviewed Git returned a non-canonical object size")
+    start = newline + 1
+    end = start + size
+    if end + 1 != len(output) or output[end:] != b"\n":
+        fail("reviewed Git returned truncated or trailing object bytes")
+    payload = output[start:end]
+    canonical = expected_type + b" " + size_bytes + b"\0" + payload
+    actual_id = hashlib.sha1(canonical).hexdigest().encode("ascii")
+    if actual_id != object_id:
+        fail(
+            "reviewed Git object bytes do not match their cryptographic identity"
+        )
+    return payload
+
+
+def commit_tree_identity(commit_payload: bytes) -> bytes:
+    """Extract exactly one canonical leading tree header from a commit object."""
+
+    header_end = commit_payload.find(b"\n\n")
+    if header_end < 0:
+        fail("reviewed commit object has no canonical header terminator")
+    header_lines = commit_payload[:header_end].split(b"\n")
+    if not header_lines or not header_lines[0].startswith(b"tree "):
+        fail("reviewed commit object has no leading tree identity")
+    first = header_lines[0]
+    if len(first) != 45 or FULL_SHA_RE.fullmatch(first[5:]) is None:
+        fail("reviewed commit object has an invalid tree identity")
+    if any(line.startswith(b"tree ") for line in header_lines[1:]):
+        fail("reviewed commit object has duplicate tree identities")
+    return first[5:]
+
+
+@dataclass(frozen=True)
+class TreeEntry:
+    git_mode: bytes
+    name: bytes
+    object_id: bytes
+
+
+def tree_entry_sort_key(entry: TreeEntry) -> bytes:
+    suffix = b"/" if entry.git_mode == GIT_TREE_MODE else b"\0"
+    return entry.name + suffix
+
+
+def parse_binary_tree(tree_payload: bytes) -> list[TreeEntry]:
+    """Parse Git's binary tree format without trusting porcelain output."""
+
+    entries: list[TreeEntry] = []
+    offset = 0
+    prior_key: bytes | None = None
+    while offset < len(tree_payload):
+        mode_end = tree_payload.find(b" ", offset)
+        if mode_end < 0:
+            fail("reviewed tree object has a truncated mode")
+        git_mode = tree_payload[offset:mode_end]
+        name_end = tree_payload.find(b"\0", mode_end + 1)
+        if name_end < 0:
+            fail("reviewed tree object has a truncated path")
+        name = tree_payload[mode_end + 1 : name_end]
+        identity_end = name_end + 21
+        if identity_end > len(tree_payload):
+            fail("reviewed tree object has a truncated object identity")
+        object_id = tree_payload[name_end + 1 : identity_end].hex().encode("ascii")
+        offset = identity_end
+        if (
+            not name
+            or name in {b".", b".."}
+            or b"/" in name
+            or b"\n" in name
+            or b"\r" in name
+        ):
+            fail("reviewed commit contains an unsafe tree path")
+        if git_mode not in {*GIT_MODE_PERMISSIONS, GIT_TREE_MODE}:
+            fail(
+                "reviewed commit contains a non-regular source entry at "
+                f"{display_path(name)}"
+            )
+        entry = TreeEntry(git_mode, name, object_id)
+        sort_key = tree_entry_sort_key(entry)
+        if prior_key is not None and sort_key <= prior_key:
+            fail("reviewed tree object entries are duplicate or non-canonical")
+        prior_key = sort_key
+        entries.append(entry)
+    return entries
+
+
+def load_expected_tree(
+    root_descriptor: int,
+    git_descriptor: int,
+    commit: bytes,
+) -> tuple[dict[bytes, ExpectedFile], set[bytes]]:
+    commit_payload = read_verified_git_object(
+        root_descriptor,
+        git_descriptor,
+        commit,
+        b"commit",
+    )
+    root_tree = commit_tree_identity(commit_payload)
+    files: dict[bytes, ExpectedFile] = {}
+    directories: set[bytes] = set()
+    active_trees: set[bytes] = set()
+
+    def visit(tree_id: bytes, prefix: bytes) -> None:
+        if tree_id in active_trees:
+            fail("reviewed commit contains a recursive tree graph")
+        active_trees.add(tree_id)
+        try:
+            payload = read_verified_git_object(
+                root_descriptor,
+                git_descriptor,
+                tree_id,
+                b"tree",
+            )
+            for entry in parse_binary_tree(payload):
+                path = entry.name if not prefix else prefix + b"/" + entry.name
+                if entry.git_mode == GIT_TREE_MODE:
+                    if path in directories:
+                        fail(
+                            "reviewed commit contains duplicate directory "
+                            f"{display_path(path)}"
+                        )
+                    directories.add(path)
+                    visit(entry.object_id, path)
+                    if path_is_reserved(path):
+                        fail(
+                            "reviewed commit tracks reserved local path "
+                            f"{display_path(path)}"
+                        )
+                    continue
+                if path_is_reserved(path):
+                    fail(
+                        "reviewed commit tracks reserved local path "
+                        f"{display_path(path)}"
+                    )
+                if path in files:
+                    fail(
+                        "reviewed commit contains duplicate path "
+                        f"{display_path(path)}"
+                    )
+                content = read_verified_git_object(
+                    root_descriptor,
+                    git_descriptor,
+                    entry.object_id,
+                    b"blob",
+                )
+                files[path] = ExpectedFile(
+                    entry.git_mode,
+                    entry.object_id,
+                    content,
+                )
+        finally:
+            active_trees.remove(tree_id)
+
+    visit(root_tree, b"")
+    return files, directories
+
+
+def read_expected_file(
+    parent_descriptor: int,
+    name: bytes,
+    path: bytes,
+    expected: ExpectedFile,
+) -> ActualFile:
+    label = f"source file {display_path(path)}"
+    try:
+        visible = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        fail(f"cannot inspect {label}: {exc.strerror or 'missing'}")
+    if not stat.S_ISREG(visible.st_mode):
+        fail(f"{label} is not one regular file")
+    if visible.st_nlink != 1:
+        fail(f"{label} is not one single-link file")
+    permissions = stat.S_IMODE(visible.st_mode)
+    if permissions & 0o022:
+        fail(f"{label} is group- or world-writable")
+    expected_permissions = GIT_MODE_PERMISSIONS[expected.git_mode]
+    if permissions != expected_permissions:
+        fail(
+            f"{label} mode differs from Git "
+            f"({permissions:04o} != {expected_permissions:04o})"
+        )
+    try:
+        descriptor = os.open(
+            name,
+            READ_FLAGS | os.O_NOFOLLOW,
+            dir_fd=parent_descriptor,
+        )
+    except OSError as exc:
+        fail(
+            f"cannot open {label} without following links: "
+            f"{exc.strerror or 'operating-system error'}"
+        )
+    try:
+        opened = os.fstat(descriptor)
+        if not same_identity(visible, opened):
+            fail(f"{label} changed while it was opened")
+        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+            fail(f"{label} is not one regular single-link file")
+        chunks: list[bytes] = []
+        total = 0
+        expected_size = len(expected.content)
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > expected_size:
+                break
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if not same_identity(opened, after):
+        fail(f"{label} changed while it was read")
+    require_visible_identity(parent_descriptor, name, after, label)
+    content = b"".join(chunks)
+    if content != expected.content:
+        fail(f"{label} bytes differ from the reviewed commit")
+    return ActualFile(permissions, content)
+
+
+def list_directory(descriptor: int, label: str) -> list[bytes]:
+    try:
+        return sorted(os.fsencode(name) for name in os.listdir(descriptor))
+    except OSError as exc:
+        fail(f"cannot list {label}: {exc.strerror or 'operating-system error'}")
+
+
+def walk_source_directory(
+    descriptor: int,
+    relative: bytes,
+    opened_identity: os.stat_result,
+    expected_files: dict[bytes, ExpectedFile],
+    expected_dirs: set[bytes],
+    actual_files: dict[bytes, ActualFile],
+    actual_dirs: dict[bytes, int],
+) -> None:
+    label = (
+        "release directory"
+        if not relative
+        else f"source directory {display_path(relative)}"
+    )
+    initial_names = list_directory(descriptor, label)
+    for name in initial_names:
+        path = name if not relative else relative + b"/" + name
+        try:
+            visible = os.stat(
+                name,
+                dir_fd=descriptor,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            fail(f"cannot inspect {display_path(path)}: {exc.strerror or 'missing'}")
+        if stat.S_ISDIR(visible.st_mode):
+            if path not in expected_dirs:
+                fail(f"unexpected source directory {display_path(path)}")
+            child, child_identity = open_directory_at(
+                descriptor,
+                name,
+                f"source directory {display_path(path)}",
+            )
+            actual_dirs[path] = stat.S_IMODE(child_identity.st_mode)
+            try:
+                walk_source_directory(
+                    child,
+                    path,
+                    child_identity,
+                    expected_files,
+                    expected_dirs,
+                    actual_files,
+                    actual_dirs,
+                )
+                require_visible_identity(
+                    descriptor,
+                    name,
+                    child_identity,
+                    f"source directory {display_path(path)}",
+                )
+            finally:
+                os.close(child)
+        elif stat.S_ISREG(visible.st_mode):
+            expected = expected_files.get(path)
+            if expected is None:
+                fail(f"unexpected source file {display_path(path)}")
+            actual_files[path] = read_expected_file(
+                descriptor,
+                name,
+                path,
+                expected,
+            )
+        else:
+            fail(f"unexpected non-regular source entry {display_path(path)}")
+    if list_directory(descriptor, label) != initial_names:
+        fail(f"{label} entries changed during inspection")
+    after = os.fstat(descriptor)
+    if not same_identity(opened_identity, after):
+        fail(f"{label} changed during inspection")
+
+
+def snapshot_worktree(
+    root_descriptor: int,
+    root_identity: os.stat_result,
+    git_descriptor: int,
+    git_identity: os.stat_result,
+    expected_files: dict[bytes, ExpectedFile],
+    expected_dirs: set[bytes],
+    allowed_generated: set[bytes],
+) -> WorktreeSnapshot:
+    actual_files: dict[bytes, ActualFile] = {}
+    actual_dirs: dict[bytes, int] = {}
+    generated: list[tuple[bytes, int, os.stat_result]] = []
+    initial_names = list_directory(root_descriptor, "release directory")
+    try:
+        if b".git" not in initial_names:
+            fail("release has no root .git directory")
+        for name in initial_names:
+            if name == b".git":
+                require_visible_identity(
+                    root_descriptor,
+                    name,
+                    git_identity,
+                    "root .git directory",
+                )
+                continue
+            if name in ALLOWED_GENERATED:
+                if name not in allowed_generated:
+                    fail(
+                        "generated directory requires an explicit allowlist flag: "
+                        f"{display_path(name)}"
+                    )
+                child, child_identity = open_directory_at(
+                    root_descriptor,
+                    name,
+                    f"generated directory {display_path(name)}",
+                )
+                generated.append((name, child, child_identity))
+                continue
+            path = name
+            try:
+                visible = os.stat(
+                    name,
+                    dir_fd=root_descriptor,
+                    follow_symlinks=False,
+                )
+            except OSError as exc:
+                fail(
+                    f"cannot inspect {display_path(path)}: "
+                    f"{exc.strerror or 'missing'}"
+                )
+            if stat.S_ISDIR(visible.st_mode):
+                if path not in expected_dirs:
+                    fail(f"unexpected source directory {display_path(path)}")
+                child, child_identity = open_directory_at(
+                    root_descriptor,
+                    name,
+                    f"source directory {display_path(path)}",
+                )
+                actual_dirs[path] = stat.S_IMODE(child_identity.st_mode)
+                try:
+                    walk_source_directory(
+                        child,
+                        path,
+                        child_identity,
+                        expected_files,
+                        expected_dirs,
+                        actual_files,
+                        actual_dirs,
+                    )
+                    require_visible_identity(
+                        root_descriptor,
+                        name,
+                        child_identity,
+                        f"source directory {display_path(path)}",
+                    )
+                finally:
+                    os.close(child)
+            elif stat.S_ISREG(visible.st_mode):
+                expected = expected_files.get(path)
+                if expected is None:
+                    fail(f"unexpected source file {display_path(path)}")
+                actual_files[path] = read_expected_file(
+                    root_descriptor,
+                    name,
+                    path,
+                    expected,
+                )
+            else:
+                fail(f"unexpected non-regular source entry {display_path(path)}")
+
+        missing_files = sorted(set(expected_files) - set(actual_files))
+        if missing_files:
+            fail(f"missing source file {display_path(missing_files[0])}")
+        missing_dirs = sorted(expected_dirs - set(actual_dirs))
+        if missing_dirs:
+            fail(f"missing source directory {display_path(missing_dirs[0])}")
+        for name, child, identity in generated:
+            if not same_identity(identity, os.fstat(child)):
+                fail(
+                    f"generated directory {display_path(name)} "
+                    "changed during inspection"
+                )
+            require_visible_identity(
+                root_descriptor,
+                name,
+                identity,
+                f"generated directory {display_path(name)}",
+            )
+        require_visible_identity(
+            root_descriptor,
+            b".git",
+            git_identity,
+            "root .git directory",
+        )
+        if list_directory(root_descriptor, "release directory") != initial_names:
+            fail("release directory entries changed during inspection")
+        if not same_identity(root_identity, os.fstat(root_descriptor)):
+            fail("release directory changed during inspection")
+    finally:
+        for _, descriptor, _ in generated:
+            os.close(descriptor)
+    return WorktreeSnapshot(
+        root_permissions=stat.S_IMODE(root_identity.st_mode),
+        directories=actual_dirs,
+        files=actual_files,
+    )
+
+
+def update_field(digest: Any, value: bytes) -> None:
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def source_tree_digest(commit: bytes, snapshot: WorktreeSnapshot) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"hub-optimus-release-source-tree-v1\0")
+    update_field(digest, commit)
+    digest.update(snapshot.root_permissions.to_bytes(4, "big"))
+    for path in sorted(snapshot.directories):
+        digest.update(b"D")
+        update_field(digest, path)
+        digest.update(snapshot.directories[path].to_bytes(4, "big"))
+    for path in sorted(snapshot.files):
+        actual = snapshot.files[path]
+        digest.update(b"F")
+        update_field(digest, path)
+        digest.update(actual.permissions.to_bytes(4, "big"))
+        update_field(digest, actual.content)
+    return digest.hexdigest()
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify direct release source bytes against one Git commit",
+    )
+    parser.add_argument("release")
+    parser.add_argument("commit")
+    parser.add_argument(
+        "--allow-generated",
+        action="append",
+        default=[],
+        choices=sorted(os.fsdecode(path) for path in ALLOWED_GENERATED),
+        metavar="DIRECTORY",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    if not hasattr(os, "O_NOFOLLOW") or not os.path.isdir("/proc/self/fd"):
+        fail("Linux no-follow descriptor traversal is unavailable")
+    arguments = parse_arguments()
+    allowed_list = [os.fsencode(item) for item in arguments.allow_generated]
+    if len(allowed_list) != len(set(allowed_list)):
+        fail("generated-directory allowlist contains a duplicate")
+    release, root_descriptor, root_identity = open_release(arguments.release)
+    git_descriptor = -1
+    try:
+        git_descriptor, git_identity = open_directory_at(
+            root_descriptor,
+            b".git",
+            "root .git directory",
+        )
+        validate_git_worktree(
+            release,
+            root_descriptor,
+            git_descriptor,
+        )
+        commit = resolve_commit(
+            root_descriptor,
+            git_descriptor,
+            arguments.commit,
+        )
+        expected, expected_dirs = load_expected_tree(
+            root_descriptor,
+            git_descriptor,
+            commit,
+        )
+        snapshot = snapshot_worktree(
+            root_descriptor,
+            root_identity,
+            git_descriptor,
+            git_identity,
+            expected,
+            expected_dirs,
+            set(allowed_list),
+        )
+        try:
+            visible_root = os.stat(release, follow_symlinks=False)
+        except OSError as exc:
+            fail(
+                "release path changed during inspection: "
+                f"{exc.strerror or 'missing'}"
+            )
+        if not same_identity(root_identity, visible_root):
+            fail("release path changed during inspection")
+        result = {
+            "commit": commit.decode("ascii"),
+            "source_file_count": len(expected),
+            "source_tree_sha256": source_tree_digest(commit, snapshot),
+        }
+        print(
+            json.dumps(
+                result,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    finally:
+        if git_descriptor >= 0:
+            os.close(git_descriptor)
+        os.close(root_descriptor)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except UnicodeEncodeError:
+        fail("commit must be HEAD or one full lowercase SHA-1")
+    except OSError as exc:
+        fail(f"worktree inspection failed: {exc.strerror or 'operating-system error'}")

--- a/tests/test_ec2_deploy_hub_api_sync.py
+++ b/tests/test_ec2_deploy_hub_api_sync.py
@@ -4,6 +4,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOY = ROOT / "ops" / "ec2" / "deploy-current.sh"
 SERVICE = ROOT / "ops" / "ec2" / "hub-api.service"
+API = ROOT / "ops" / "ec2" / "hub-api.sh"
+CORE = ROOT / "ops" / "ec2" / "hub-core.sh"
 
 
 def test_deploy_syncs_hub_api_launcher_into_shared_bin():
@@ -36,3 +38,14 @@ def test_systemd_execstart_uses_synced_shared_launcher():
     text = SERVICE.read_text(encoding="utf-8")
 
     assert "ExecStart=/opt/hub-optimus/shared/bin/hub-api" in text
+
+
+def test_runtime_launchers_do_not_write_caches_into_release_source():
+    api = API.read_text(encoding="utf-8")
+    core = CORE.read_text(encoding="utf-8")
+    service = SERVICE.read_text(encoding="utf-8")
+
+    assert "export PYTHONDONTWRITEBYTECODE=1" in api
+    assert "export PYTHONDONTWRITEBYTECODE=1" in core
+    assert "Environment=PYTHONDONTWRITEBYTECODE=1" in service
+    assert "python -m pytest -q -p no:cacheprovider" in core

--- a/tests/test_ec2_legacy_adoption.py
+++ b/tests/test_ec2_legacy_adoption.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import stat
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,15 @@ def _legacy_environment(
     clone = _run(["git", "clone", "-q", "--no-hardlinks", source, release])
     assert clone.returncode == 0, clone.stderr
     _git(release, "checkout", "-q", "--detach", commit)
+    venv = release / ".venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").write_bytes(b"fixture-python\n")
+    (venv / "bin" / "python").chmod(0o755)
+    with (release / ".git" / "info" / "exclude").open(
+        "a",
+        encoding="utf-8",
+    ) as handle:
+        handle.write(".venv/\n")
 
     shared = app_root / "shared"
     shared_launcher = shared / "bin" / "hub-api"
@@ -156,6 +166,61 @@ def _write_executable(path: Path, text: str) -> None:
     path.chmod(0o755)
 
 
+def _wait_for_barrier(ready: Path, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 30
+    while not ready.exists() and process.poll() is None:
+        if time.monotonic() >= deadline:
+            process.terminate()
+            _stdout, stderr = process.communicate(timeout=5)
+            raise AssertionError(f"adoption did not reach authority barrier: {stderr}")
+        time.sleep(0.01)
+    if not ready.exists():
+        _stdout, stderr = process.communicate(timeout=5)
+        raise AssertionError(f"adoption exited before authority barrier: {stderr}")
+
+
+def _install_manifest_barrier(
+    runner: Path,
+    target: Path,
+    ready: Path,
+    proceed: Path,
+    counter: Path,
+    trigger_call: int,
+) -> None:
+    original = runner.with_name("run-release-validation.original.py")
+    runner.replace(original)
+    runner.write_text(
+        "import os\n"
+        "import sys\n"
+        "import time\n"
+        "from pathlib import Path\n"
+        f"target = {str(target)!r}\n"
+        f"ready = Path({str(ready)!r})\n"
+        f"proceed = Path({str(proceed)!r})\n"
+        f"counter = Path({str(counter)!r})\n"
+        f"trigger_call = {trigger_call}\n"
+        f"original = {str(original)!r}\n"
+        "if (\n"
+        "    len(sys.argv) == 3\n"
+        "    and sys.argv[1] == 'manifest-venv'\n"
+        "    and os.path.realpath(sys.argv[2]) == target\n"
+        "):\n"
+        "    calls = int(counter.read_text()) + 1 if counter.exists() else 1\n"
+        "    counter.write_text(str(calls))\n"
+        "    if calls == trigger_call:\n"
+        "        ready.touch(exist_ok=False)\n"
+        "        deadline = time.monotonic() + 30\n"
+        "        while not proceed.exists():\n"
+        "            if time.monotonic() >= deadline:\n"
+        "                raise SystemExit('manifest barrier timed out')\n"
+        "            time.sleep(0.01)\n"
+        "os.execv('/usr/bin/python3', [\n"
+        "    '/usr/bin/python3', '-I', original, *sys.argv[1:]\n"
+        "])\n",
+        encoding="utf-8",
+    )
+
+
 def test_adopts_9d677_format_and_is_idempotent(tmp_path: Path) -> None:
     fixture = LEGACY_FIXTURE.read_text(encoding="utf-8")
     assert "commit=9d67719\n" in fixture
@@ -186,10 +251,12 @@ def test_adopts_9d677_format_and_is_idempotent(tmp_path: Path) -> None:
     assert state["requested_ref"] == commit
     assert state["requested_ref_kind"] == "legacy-host-adoption"
     assert state["launcher_sha256"] == LEGACY_LAUNCHER_SHA256
-    assert state["provenance"] == "adopted-legacy-current-v1"
+    assert state["provenance"] == "adopted-legacy-current-v2"
     assert state["legacy_state_sha256"] == legacy_state_sha256
     assert state["legacy_commit_prefix"] == commit[:7]
     assert state["validation_command"] == "not-run-during-legacy-adoption"
+    assert len(state["source_tree_sha256"]) == 64
+    assert len(state["venv_tree_sha256"]) == 64
     assert legacy_evidence.read_bytes() == rendered_fixture.encode()
     assert stat.S_IMODE(legacy_evidence.stat().st_mode) == 0o400
     assert (shared / "RELEASE_STATE").read_bytes() == release_state_path.read_bytes()
@@ -218,6 +285,102 @@ def test_success_is_postvalidated_before_transaction_closes() -> None:
     assert publish < postvalidate < close
     assert 'LEGACY_RELEASE_STATE"' in text
     assert "install -m 0400" in text
+    assert text.count("release_source_evidence") >= 4
+    baseline = text.index('BASELINE_SOURCE_EVIDENCE="$(')
+    pre_mutation = text.index('PRE_MUTATION_SOURCE_EVIDENCE="$(')
+    mutation = text.index("MUTATION_STARTED=1", pre_mutation)
+    postvalidation = text.index("validate_complete_adoption", mutation)
+
+    assert baseline < pre_mutation < mutation < postvalidation
+
+
+def test_adoption_rejects_head_change_after_baseline_before_mutation(
+    tmp_path: Path,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    before = _snapshot(app_root, release)
+    ready = tmp_path / "adoption-authority-ready"
+    proceed = tmp_path / "adoption-authority-proceed"
+    env["HUB_OPTIMUS_TEST_LEGACY_ADOPTION_BEFORE_AUTHORITY_READY"] = str(ready)
+    env["HUB_OPTIMUS_TEST_LEGACY_ADOPTION_BEFORE_AUTHORITY_PROCEED"] = str(
+        proceed
+    )
+    process = subprocess.Popen(
+        [str(ADOPT), commit],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    _wait_for_barrier(ready, process)
+    _git(
+        release,
+        "-c",
+        "user.email=tests@example.invalid",
+        "-c",
+        "user.name=HUB tests",
+        "commit",
+        "--allow-empty",
+        "-qm",
+        "external HEAD drift",
+    )
+    assert _git(release, "rev-parse", "HEAD") != commit
+    proceed.touch()
+    _stdout, stderr = process.communicate(timeout=30)
+
+    assert process.returncode == 1
+    assert "Current release HEAD differs from its recorded commit" in stderr
+    assert _snapshot(app_root, release) == before
+    assert not (release / ".hub-deployment" / "RELEASE_STATE").exists()
+
+
+def test_adoption_rejects_head_change_during_postvalidation_venv_hash(
+    tmp_path: Path,
+) -> None:
+    app_root, release, commit, env = _legacy_environment(tmp_path)
+    before = _snapshot(app_root, release)
+    tools = tmp_path / "reviewed-tools"
+    shutil.copytree(ROOT / "ops" / "ec2", tools)
+    adopt = tools / "adopt-legacy-current.sh"
+    ready = tmp_path / "adoption-post-venv-ready"
+    proceed = tmp_path / "adoption-post-venv-proceed"
+    counter = tmp_path / "adoption-manifest-calls"
+    _install_manifest_barrier(
+        tools / "run-release-validation.py",
+        release,
+        ready,
+        proceed,
+        counter,
+        3,
+    )
+    process = subprocess.Popen(
+        [str(adopt), commit],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    _wait_for_barrier(ready, process)
+    _git(
+        release,
+        "-c",
+        "user.email=tests@example.invalid",
+        "-c",
+        "user.name=HUB tests",
+        "commit",
+        "--allow-empty",
+        "-qm",
+        "external postvalidation HEAD drift",
+    )
+    assert _git(release, "rev-parse", "HEAD") != commit
+    proceed.touch()
+    _stdout, stderr = process.communicate(timeout=30)
+
+    assert process.returncode == 1
+    assert "Current release HEAD differs from its recorded commit" in stderr
+    assert "Pre-adoption state restored" in stderr
+    assert _snapshot(app_root, release) == before
+    assert not (release / ".hub-deployment" / "RELEASE_STATE").exists()
 
 
 def test_preflight_inventories_unattested_historical_pointer(
@@ -419,6 +582,7 @@ def test_adoption_still_restores_when_recovery_log_cannot_open(
         ("symlink", "outside the managed releases directory"),
         ("shared-launcher", "does not exactly match"),
         ("dirty-launcher", "worktree is not clean"),
+        ("hidden-tracked-drift", "source tree differs"),
     ),
 )
 def test_adoption_rejects_unattested_identity_before_mutation(
@@ -446,6 +610,10 @@ def test_adoption_rejects_unattested_identity_before_mutation(
             "#!/usr/bin/env bash\necho dirty\n",
             encoding="utf-8",
         )
+    elif invalid_case == "hidden-tracked-drift":
+        tracked = release / "tracked.txt"
+        _git(release, "update-index", "--assume-unchanged", "tracked.txt")
+        tracked.write_text("hidden drift\n", encoding="utf-8")
     before = _snapshot(app_root, release)
 
     failed = _run([ADOPT, expected_commit], env=env)

--- a/tests/test_ec2_preflight_and_evidence.py
+++ b/tests/test_ec2_preflight_and_evidence.py
@@ -54,9 +54,12 @@ def test_runbook_retains_reviewed_tools_and_uses_allowlisted_evidence() -> None:
     assert "9d6771994095e4fc04e8fdbf2caa644ccb002ab1" in text
     assert "shared/reviewed-tools/$TARGET_SHA" in text
     assert "Do not put it behind an" in text
-    assert "preflight-deploy.sh" in text
-    assert "adopt-legacy-current.sh" in text
-    assert text.index("adopt-legacy-current.sh") < text.index("preflight-deploy.sh")
+    assert "run-reviewed-operation.py" in text
+    assert "  preflight \"$TARGET_SHA\" \"$REFERENCE_URL\"" in text
+    assert "  adopt \"$LEGACY_CURRENT_SHA\"" in text
+    assert text.index('  adopt "$LEGACY_CURRENT_SHA"') < text.index(
+        '  preflight "$TARGET_SHA"'
+    )
     assert "LEGACY_RELEASE_STATE" in text
     assert "legacy_state_sha256=" in text
     assert "legacy-unattested-not-deploy-rollback-target" in text

--- a/tests/test_ec2_release_state_validator.py
+++ b/tests/test_ec2_release_state_validator.py
@@ -22,8 +22,17 @@ DEPENDENCY_LOCKS = (
 COMMIT = "b" * 40
 LAUNCHER_SHA256 = "c" * 64
 LEGACY_SHA256 = "d" * 64
-VALIDATION_RESULT = "719 passed in 30.45s"
-VALIDATION_LOG_RAW = f"collecting tests\n{VALIDATION_RESULT}\n\n".encode()
+NODEIDS_SHA256 = "1" * 64
+SOURCE_TREE_SHA256 = "2" * 64
+VENV_TREE_SHA256 = "3" * 64
+VALIDATION_RESULT = (
+    "HUB_OPTIMUS_VALIDATION_V1 collected=719 terminal=719 passed=700 "
+    "skipped=19 failed=0 pytest_exit_code=0 "
+    f"nodeids_sha256={NODEIDS_SHA256} descendants=0 "
+    f"source_tree_sha256={SOURCE_TREE_SHA256} "
+    f"venv_tree_sha256={VENV_TREE_SHA256} worker_uid=65534 result=passed"
+)
+VALIDATION_LOG_RAW = f"collecting tests\n719 passed in 30.45s\n{VALIDATION_RESULT}\n".encode()
 ADOPTION_RESULT = (
     "legacy validation claim not re-attested; original state retained by SHA-256"
 )
@@ -50,9 +59,11 @@ def _production_fields(*, transitional: bool = False) -> list[tuple[str, str]]:
     validation_command = "python -m pytest -q"
     if not transitional:
         validation_command = (
-            f"/usr/bin/env -i HOME={release_path} LANG=C.UTF-8 "
-            "PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 "
-            f"{release_path}/.venv/bin/python -m pytest -q"
+            "/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 "
+            "PATH=/usr/bin:/bin /usr/bin/python3 -I "
+            f"{release_path}/ops/ec2/run-release-validation.py "
+            f"{release_path} {COMMIT} "
+            f"{release_path}/ops/ec2/verify-release-worktree.py"
         )
     fields = [
         ("release", "20260803T120000Z.ABC123"),
@@ -78,6 +89,18 @@ def _production_fields(*, transitional: bool = False) -> list[tuple[str, str]]:
                     "validation_log_sha256",
                     hashlib.sha256(VALIDATION_LOG_RAW).hexdigest(),
                 ),
+                ("validation_protocol", "isolated-pytest-v1"),
+                ("validation_collected", "719"),
+                ("validation_terminal", "719"),
+                ("validation_passed", "700"),
+                ("validation_skipped", "19"),
+                ("validation_failed", "0"),
+                ("validation_pytest_exit_code", "0"),
+                ("validation_nodeids_sha256", NODEIDS_SHA256),
+                ("validation_descendants", "0"),
+                ("validation_worker_uid", "65534"),
+                ("source_tree_sha256", SOURCE_TREE_SHA256),
+                ("venv_tree_sha256", VENV_TREE_SHA256),
                 ("dependency_tier", "runtime+validation-v1"),
                 (
                     "dependency_lock",
@@ -136,8 +159,10 @@ def _production_fixture(
         fields,
         "validation_command",
         (
-            f"/usr/bin/env -i HOME={release} LANG=C.UTF-8 PATH=/usr/bin:/bin "
-            f"PYTHONNOUSERSITE=1 {release}/.venv/bin/python -m pytest -q"
+            "/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 "
+            "PATH=/usr/bin:/bin /usr/bin/python3 -I "
+            f"{release}/ops/ec2/run-release-validation.py "
+            f"{release} {COMMIT} {release}/ops/ec2/verify-release-worktree.py"
         ),
     )
     fields = _replace_field(fields, "validation_log", str(validation_log))
@@ -510,6 +535,6 @@ def test_attestation_scope_excludes_operational_hardening() -> None:
     )
 
     assert "validation_log_sha256" in sources
-    assert "validate-release-worktree" not in sources
+    assert "verify-release-worktree.py" in sources
     assert "recovery-snapshot" not in sources
     assert "PYTEST_ADDOPTS" not in sources

--- a/tests/test_ec2_release_state_validator.py
+++ b/tests/test_ec2_release_state_validator.py
@@ -190,9 +190,11 @@ def _adopted_fields() -> list[tuple[str, str]]:
         ("validation_result", ADOPTION_RESULT),
         ("validation_log", "not-applicable"),
         ("validation_log_exit_code", "not-run"),
+        ("source_tree_sha256", SOURCE_TREE_SHA256),
+        ("venv_tree_sha256", VENV_TREE_SHA256),
         ("launcher_sha256", LAUNCHER_SHA256),
         ("status", "adopted-legacy-current"),
-        ("provenance", "adopted-legacy-current-v1"),
+        ("provenance", "adopted-legacy-current-v2"),
         ("legacy_state_sha256", LEGACY_SHA256),
         ("legacy_commit_prefix", COMMIT[:7]),
     ]
@@ -250,6 +252,23 @@ def test_validator_accepts_an_exact_tag_state(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert "PASS production" in result.stdout
+
+
+def test_validator_rejects_superseded_legacy_adoption_v1(
+    tmp_path: Path,
+) -> None:
+    state = tmp_path / "adopted-v1"
+    fields = _replace_field(
+        _adopted_fields(),
+        "provenance",
+        "adopted-legacy-current-v1",
+    )
+    _write_state(state, fields)
+
+    result = _run(state)
+
+    assert result.returncode == 1
+    assert "invalid legacy-adoption provenance" in result.stderr
 
 
 def test_validator_accepts_digest_bound_transitional_state(tmp_path: Path) -> None:

--- a/tests/test_ec2_release_worktree_verifier.py
+++ b/tests/test_ec2_release_worktree_verifier.py
@@ -60,7 +60,15 @@ def _replace_loose_object(
         + b"\0"
         + payload
     )
-    object_path.write_bytes(zlib.compress(canonical))
+    # Git deliberately stores loose objects read-only.  Root can overwrite
+    # those files directly, which hid this portability bug in the local
+    # adversarial run; hosted runners execute as an unprivileged owner.  Model
+    # an attacker replacing the directory entry instead, preserving the
+    # read-only mode of a normal loose object.
+    replacement = object_path.with_name(f".{object_path.name}.replacement")
+    replacement.write_bytes(zlib.compress(canonical))
+    replacement.chmod(0o444)
+    os.replace(replacement, object_path)
 
 
 def _repository(tmp_path: Path) -> tuple[Path, str]:

--- a/tests/test_ec2_release_worktree_verifier.py
+++ b/tests/test_ec2_release_worktree_verifier.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "ops" / "ec2" / "verify-release-worktree.py"
+PYTHON = Path("/usr/bin/python3")
+GIT = Path("/usr/bin/git")
+
+
+@dataclass(frozen=True)
+class Verification:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        [str(GIT), "-C", str(repository), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout.strip()
+
+
+def _git_object_payload(repository: Path, object_type: str, object_id: str) -> bytes:
+    completed = subprocess.run(
+        [str(GIT), "-C", str(repository), "cat-file", object_type, object_id],
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr.decode("utf-8", "replace")
+    return completed.stdout
+
+
+def _replace_loose_object(
+    repository: Path,
+    object_id: str,
+    object_type: str,
+    payload: bytes,
+) -> None:
+    object_path = repository / ".git" / "objects" / object_id[:2] / object_id[2:]
+    assert object_path.is_file(), f"expected one loose test object at {object_path}"
+    canonical = (
+        object_type.encode("ascii")
+        + b" "
+        + str(len(payload)).encode("ascii")
+        + b"\0"
+        + payload
+    )
+    object_path.write_bytes(zlib.compress(canonical))
+
+
+def _repository(tmp_path: Path) -> tuple[Path, str]:
+    repository = tmp_path / "release"
+    repository.mkdir()
+    _git(repository, "init", "--quiet")
+    _git(repository, "config", "user.name", "Release Verifier Test")
+    _git(repository, "config", "user.email", "release-verifier@example.invalid")
+    (repository / ".gitignore").write_bytes(b"ignored/\n")
+    (repository / "README.md").write_bytes(b"reviewed source\n")
+    executable_directory = repository / "bin"
+    executable_directory.mkdir()
+    executable = executable_directory / "tool.sh"
+    executable.write_bytes(b"#!/usr/bin/env bash\nprintf 'reviewed\\n'\n")
+    executable.chmod(0o755)
+    _git(repository, "add", "--all")
+    _git(repository, "commit", "--quiet", "-m", "reviewed source")
+    return repository, _git(repository, "rev-parse", "HEAD")
+
+
+def _verify(
+    repository: Path,
+    commit: str,
+    *arguments: str,
+    env: dict[str, str] | None = None,
+) -> Verification:
+    completed = subprocess.run(
+        [
+            str(PYTHON),
+            "-I",
+            str(VERIFIER),
+            str(repository),
+            commit,
+            *arguments,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return Verification(
+        completed.returncode,
+        completed.stdout,
+        completed.stderr,
+    )
+
+
+def test_exact_tree_emits_one_deterministic_canonical_identity(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+
+    first = _verify(repository, commit)
+    second = _verify(repository, "HEAD")
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert first.stdout == second.stdout
+    assert first.stderr == second.stderr == ""
+    identity = json.loads(first.stdout)
+    assert identity == {
+        "commit": commit,
+        "source_file_count": 3,
+        "source_tree_sha256": identity["source_tree_sha256"],
+    }
+    assert len(identity["source_tree_sha256"]) == 64
+    assert first.stdout == (
+        json.dumps(identity, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+        + "\n"
+    )
+
+
+def test_git_metadata_and_explicit_generated_roots_do_not_change_source_identity(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    before = _verify(repository, commit)
+    assert before.returncode == 0, before.stderr
+
+    (repository / ".git" / "local-verifier-sentinel").write_bytes(b"metadata\n")
+    venv_bin = repository / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python3").symlink_to("/usr/bin/python3")
+    deployment = repository / ".hub-deployment"
+    deployment.mkdir(mode=0o700)
+    (deployment / "validation.log").write_bytes(b"3 passed\n")
+
+    after = _verify(
+        repository,
+        commit,
+        "--allow-generated",
+        ".venv",
+        "--allow-generated",
+        ".hub-deployment",
+    )
+
+    assert after.returncode == 0, after.stderr
+    assert after.stdout == before.stdout
+    assert after.stderr == ""
+
+
+@pytest.mark.parametrize("generated", (".venv", ".hub-deployment"))
+def test_generated_root_requires_its_literal_allowlist_flag(
+    tmp_path: Path,
+    generated: str,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    (repository / generated).mkdir()
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "requires an explicit allowlist flag" in result.stderr
+    assert generated in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("kind", ("file", "symlink", "writable-directory"))
+def test_allowlisted_generated_root_must_still_be_one_safe_real_directory(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    generated = repository / ".venv"
+    if kind == "file":
+        generated.write_bytes(b"not a directory\n")
+    elif kind == "symlink":
+        target = tmp_path / "external-venv"
+        target.mkdir()
+        generated.symlink_to(target, target_is_directory=True)
+    else:
+        generated.mkdir()
+        generated.chmod(0o777)
+
+    result = _verify(
+        repository,
+        commit,
+        "--allow-generated",
+        ".venv",
+    )
+
+    assert result.returncode == 1
+    if kind == "writable-directory":
+        assert "group- or world-writable" in result.stderr
+    else:
+        assert "not one real directory" in result.stderr
+    assert result.stdout == ""
+
+
+def test_allowlist_rejects_unknown_or_duplicate_generated_roots(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+
+    unknown = _verify(
+        repository,
+        commit,
+        "--allow-generated",
+        "ignored",
+    )
+    duplicate = _verify(
+        repository,
+        commit,
+        "--allow-generated",
+        ".venv",
+        "--allow-generated",
+        ".venv",
+    )
+
+    assert unknown.returncode == 2
+    assert "invalid choice" in unknown.stderr
+    assert unknown.stdout == ""
+    assert duplicate.returncode == 1
+    assert "allowlist contains a duplicate" in duplicate.stderr
+    assert duplicate.stdout == ""
+
+
+@pytest.mark.parametrize("index_flag", ("--assume-unchanged", "--skip-worktree"))
+def test_index_flags_cannot_hide_modified_tracked_bytes(
+    tmp_path: Path,
+    index_flag: str,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    _git(repository, "update-index", index_flag, "README.md")
+    (repository / "README.md").write_bytes(b"hidden drift\n")
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "bytes differ from the reviewed commit" in result.stderr
+    assert result.stdout == ""
+
+
+def test_ambient_git_index_config_and_object_paths_are_ignored(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    hostile_config = tmp_path / "hostile.gitconfig"
+    hostile_config.write_text("[core]\n\tbare = true\n", encoding="ascii")
+    hostile_environment = os.environ.copy()
+    hostile_environment.update(
+        {
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(tmp_path / "alternates"),
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_GLOBAL": str(hostile_config),
+            "GIT_CONFIG_KEY_0": "core.repositoryformatversion",
+            "GIT_CONFIG_SYSTEM": str(hostile_config),
+            "GIT_CONFIG_VALUE_0": "999",
+            "GIT_DIR": str(tmp_path / "other-git-dir"),
+            "GIT_INDEX_FILE": str(tmp_path / "substituted-index"),
+            "GIT_OBJECT_DIRECTORY": str(tmp_path / "objects"),
+            "GIT_WORK_TREE": str(tmp_path / "other-worktree"),
+            "HOME": str(tmp_path),
+            "PATH": str(tmp_path),
+        }
+    )
+
+    result = _verify(repository, commit, env=hostile_environment)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["commit"] == commit
+    assert result.stderr == ""
+
+
+def test_git_replace_cannot_substitute_the_reviewed_commit_tree(
+    tmp_path: Path,
+) -> None:
+    repository, reviewed_commit = _repository(tmp_path)
+    (repository / "README.md").write_bytes(b"replacement source\n")
+    _git(repository, "add", "README.md")
+    _git(repository, "commit", "--quiet", "-m", "replacement source")
+    replacement_commit = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "replace", reviewed_commit, replacement_commit)
+
+    result = _verify(repository, reviewed_commit)
+
+    assert result.returncode == 1
+    assert "bytes differ from the reviewed commit" in result.stderr
+    assert result.stdout == ""
+
+
+def test_loose_blob_bytes_must_cryptographically_match_the_referenced_oid(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    blob_id = _git(repository, "rev-parse", f"{commit}:README.md")
+    poisoned = b"same worktree bytes supplied by a corrupted loose blob\n"
+    (repository / "README.md").write_bytes(poisoned)
+    _replace_loose_object(repository, blob_id, "blob", poisoned)
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "object bytes do not match their cryptographic identity" in result.stderr
+    assert result.stdout == ""
+
+
+def test_loose_tree_bytes_must_cryptographically_match_the_commit_tree_oid(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    original_tree = _git(repository, "rev-parse", f"{commit}^{{tree}}")
+    poisoned = b"same worktree bytes supplied by a corrupted loose tree\n"
+    (repository / "README.md").write_bytes(poisoned)
+    _git(repository, "add", "README.md")
+    replacement_tree = _git(repository, "write-tree")
+    replacement_payload = _git_object_payload(
+        repository,
+        "tree",
+        replacement_tree,
+    )
+    _replace_loose_object(repository, original_tree, "tree", replacement_payload)
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "object bytes do not match their cryptographic identity" in result.stderr
+    assert result.stdout == ""
+
+
+def test_loose_commit_bytes_must_cryptographically_match_the_requested_oid(
+    tmp_path: Path,
+) -> None:
+    repository, reviewed_commit = _repository(tmp_path)
+    poisoned = b"same worktree bytes supplied by a corrupted loose commit\n"
+    (repository / "README.md").write_bytes(poisoned)
+    _git(repository, "add", "README.md")
+    _git(repository, "commit", "--quiet", "-m", "unreviewed source")
+    replacement_commit = _git(repository, "rev-parse", "HEAD")
+    replacement_payload = _git_object_payload(
+        repository,
+        "commit",
+        replacement_commit,
+    )
+    _replace_loose_object(
+        repository,
+        reviewed_commit,
+        "commit",
+        replacement_payload,
+    )
+
+    result = _verify(repository, reviewed_commit)
+
+    assert result.returncode == 1
+    assert "object bytes do not match their cryptographic identity" in result.stderr
+    assert result.stdout == ""
+
+
+def test_ignored_descendant_and_untracked_empty_directory_are_rejected(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    ignored = repository / "ignored" / "nested"
+    ignored.mkdir(parents=True)
+    (ignored / "payload.txt").write_bytes(b"ignored but present\n")
+
+    ignored_result = _verify(repository, commit)
+    assert ignored_result.returncode == 1
+    assert "unexpected source directory" in ignored_result.stderr
+    assert "ignored" in ignored_result.stderr
+
+    for path in sorted((repository / "ignored").rglob("*"), reverse=True):
+        if path.is_file():
+            path.unlink()
+        else:
+            path.rmdir()
+    (repository / "ignored").rmdir()
+    (repository / "empty-untracked").mkdir()
+
+    empty_result = _verify(repository, commit)
+    assert empty_result.returncode == 1
+    assert "unexpected source directory" in empty_result.stderr
+    assert "empty-untracked" in empty_result.stderr
+
+
+def test_missing_tracked_file_is_rejected(tmp_path: Path) -> None:
+    repository, commit = _repository(tmp_path)
+    (repository / "README.md").unlink()
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "missing source file" in result.stderr
+    assert "README.md" in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize(
+    ("relative", "permissions"),
+    (("README.md", 0o600), ("bin/tool.sh", 0o744)),
+)
+def test_tracked_file_mode_must_match_the_git_mode_exactly(
+    tmp_path: Path,
+    relative: str,
+    permissions: int,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    (repository / relative).chmod(permissions)
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "mode differs from Git" in result.stderr
+    assert result.stdout == ""
+
+
+def test_group_or_world_writable_source_file_and_directory_are_rejected(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    readme = repository / "README.md"
+    readme.chmod(0o666)
+
+    file_result = _verify(repository, commit)
+    assert file_result.returncode == 1
+    assert "source file 'README.md' is group- or world-writable" in file_result.stderr
+
+    readme.chmod(0o644)
+    source_directory = repository / "bin"
+    source_directory.chmod(0o777)
+
+    directory_result = _verify(repository, commit)
+    assert directory_result.returncode == 1
+    assert "source directory 'bin' is group- or world-writable" in (
+        directory_result.stderr
+    )
+
+
+def test_hardlink_symlink_and_fifo_cannot_replace_a_tracked_file(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    readme = repository / "README.md"
+    reviewed_bytes = readme.read_bytes()
+    readme.unlink()
+    hardlink_source = tmp_path / "hardlink-source"
+    hardlink_source.write_bytes(reviewed_bytes)
+    os.link(hardlink_source, readme)
+
+    hardlink_result = _verify(repository, commit)
+    assert hardlink_result.returncode == 1
+    assert "not one single-link file" in hardlink_result.stderr
+
+    readme.unlink()
+    hardlink_source.unlink()
+    symlink_source = tmp_path / "symlink-source"
+    symlink_source.write_bytes(reviewed_bytes)
+    readme.symlink_to(symlink_source)
+
+    symlink_result = _verify(repository, commit)
+    assert symlink_result.returncode == 1
+    assert "unexpected non-regular source entry" in symlink_result.stderr
+
+    readme.unlink()
+    os.mkfifo(readme, 0o644)
+
+    fifo_result = _verify(repository, commit)
+    assert fifo_result.returncode == 1
+    assert "unexpected non-regular source entry" in fifo_result.stderr
+
+
+def test_commit_cannot_track_a_reserved_generated_root(tmp_path: Path) -> None:
+    repository, _ = _repository(tmp_path)
+    tracked_generated = repository / ".venv"
+    tracked_generated.mkdir()
+    (tracked_generated / "payload").write_bytes(b"tracked generated path\n")
+    _git(repository, "add", ".venv/payload")
+    _git(repository, "commit", "--quiet", "-m", "track reserved path")
+    commit = _git(repository, "rev-parse", "HEAD")
+
+    result = _verify(
+        repository,
+        commit,
+        "--allow-generated",
+        ".venv",
+    )
+
+    assert result.returncode == 1
+    assert "tracks reserved local path" in result.stderr
+    assert ".venv/payload" in result.stderr
+    assert result.stdout == ""
+
+
+def test_commit_with_a_tracked_symlink_is_rejected(tmp_path: Path) -> None:
+    repository, _ = _repository(tmp_path)
+    (repository / "tracked-link").symlink_to("README.md")
+    _git(repository, "add", "tracked-link")
+    _git(repository, "commit", "--quiet", "-m", "track symlink")
+    commit = _git(repository, "rev-parse", "HEAD")
+
+    result = _verify(repository, commit)
+
+    assert result.returncode == 1
+    assert "non-regular source entry" in result.stderr
+    assert "tracked-link" in result.stderr
+    assert result.stdout == ""
+
+
+def test_release_root_must_be_a_safe_canonical_physical_directory(
+    tmp_path: Path,
+) -> None:
+    repository, commit = _repository(tmp_path)
+    repository.chmod(0o777)
+
+    writable = _verify(repository, commit)
+
+    assert writable.returncode == 1
+    assert "release directory is group- or world-writable" in writable.stderr
+    assert writable.stdout == ""

--- a/tests/test_ec2_reviewed_operation_dispatcher.py
+++ b/tests/test_ec2_reviewed_operation_dispatcher.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DISPATCHER = ROOT / "ops" / "ec2" / "run-reviewed-operation.py"
+HUB_OPS = ROOT / "ops" / "ec2" / "hub-ops.sh"
+POISONED_NAMES = (
+    "BASH_ENV",
+    "BASH_FUNC_git%%",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_DIR",
+    "PIP_CONFIG_FILE",
+    "PYTHONPATH",
+    "PYTEST_ADDOPTS",
+    "PYTEST_PLUGINS",
+    "HUB_OPTIMUS_TEST_FAIL_AFTER_MUTATION",
+)
+
+
+def _run(
+    arguments: list[str | Path],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(argument) for argument in arguments],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+    ops = tmp_path / "ops"
+    ops.mkdir()
+    dispatcher = ops / DISPATCHER.name
+    shutil.copy2(DISPATCHER, dispatcher)
+    probe = ops / "deploy-current.sh"
+    probe.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "/usr/bin/python3 -I - \"$1\" <<'PY'\n"
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "with open(sys.argv[1], 'w', encoding='utf-8') as stream:\n"
+        "    json.dump(dict(os.environ), stream, sort_keys=True)\n"
+        "PY\n",
+        encoding="utf-8",
+    )
+    probe.chmod(0o755)
+    return dispatcher, probe
+
+
+def _operational_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
+    records: list[tuple[object, ...]] = []
+    for path in sorted((root, *root.rglob("*")), key=lambda item: str(item)):
+        info = path.lstat()
+        relative = "." if path == root else str(path.relative_to(root))
+        if path.is_symlink():
+            payload: object = ("symlink", os.readlink(path))
+        elif path.is_file():
+            payload = ("file", path.read_bytes())
+        else:
+            payload = ("directory",)
+        records.append(
+            (
+                relative,
+                info.st_mode,
+                info.st_uid,
+                info.st_gid,
+                info.st_nlink,
+                payload,
+            )
+        )
+    return tuple(records)
+
+
+def _hub_ops_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    dispatcher, _probe = _fixture(tmp_path)
+    ops = dispatcher.parent
+    hub_ops = ops / HUB_OPS.name
+    source = HUB_OPS.read_text(encoding="utf-8")
+    app_root = tmp_path / "app-root"
+    source = source.replace(
+        'APP_ROOT = Path("/opt/hub-optimus")',
+        f"APP_ROOT = Path({str(app_root)!r})",
+        1,
+    )
+    hub_ops.write_text(source, encoding="utf-8")
+    hub_ops.chmod(0o755)
+    (app_root / "shared").mkdir(parents=True)
+    (app_root / "releases").mkdir()
+    (app_root / "shared" / "RELEASE_STATE").write_text(
+        "status=stable\n",
+        encoding="ascii",
+    )
+    return hub_ops, app_root, ops
+
+
+def test_dispatcher_prevents_bash_env_and_ambient_tool_poisoning(
+    tmp_path: Path,
+) -> None:
+    dispatcher, probe = _fixture(tmp_path)
+    sentinel = tmp_path / "bash-env-ran"
+    bash_env = tmp_path / "bash-env.sh"
+    bash_env.write_text(
+        f"printf poison > {sentinel}\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "environment.json"
+    app_root = tmp_path / "app"
+    repository = tmp_path / "repo"
+    env = os.environ.copy()
+    for name in POISONED_NAMES:
+        env[name] = str(bash_env) if name == "BASH_ENV" else "poison"
+
+    poisoned_direct = _run(["/bin/bash", probe, tmp_path / "direct.json"], env=env)
+    assert poisoned_direct.returncode == 0, poisoned_direct.stderr
+    assert sentinel.read_bytes() == b"poison"
+    sentinel.unlink()
+
+    result = _run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            dispatcher,
+            "--app-root",
+            app_root,
+            "--repo-url",
+            repository,
+            "deploy",
+            output,
+        ],
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not sentinel.exists()
+    observed = json.loads(output.read_text(encoding="utf-8"))
+    assert all(name not in observed for name in POISONED_NAMES)
+    assert observed["HUB_OPTIMUS_APP_ROOT"] == str(app_root)
+    assert observed["HUB_OPTIMUS_REPO_URL"] == str(repository)
+    assert observed["PATH"] == "/usr/bin:/bin"
+
+
+@pytest.mark.parametrize("unsafe", ("symlink", "hardlink", "writable"))
+def test_dispatcher_rejects_unsafe_operation_script(
+    tmp_path: Path,
+    unsafe: str,
+) -> None:
+    dispatcher, probe = _fixture(tmp_path)
+    if unsafe == "symlink":
+        target = tmp_path / "target.sh"
+        probe.replace(target)
+        probe.symlink_to(target)
+    elif unsafe == "hardlink":
+        os.link(probe, tmp_path / "second-link.sh")
+    else:
+        probe.chmod(0o777)
+
+    result = _run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            dispatcher,
+            "--app-root",
+            tmp_path / "app",
+            "--repo-url",
+            tmp_path / "repo",
+            "deploy",
+            tmp_path / "unused",
+        ]
+    )
+
+    assert result.returncode == 1
+    assert "reviewed-operation:error" in result.stderr
+
+
+def test_dispatcher_rejects_wrong_operation_arity(tmp_path: Path) -> None:
+    dispatcher, _probe = _fixture(tmp_path)
+    result = _run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            dispatcher,
+            "--app-root",
+            tmp_path / "app",
+            "--repo-url",
+            tmp_path / "repo",
+            "rollback",
+            "unexpected",
+        ]
+    )
+    assert result.returncode == 1
+    assert "rollback requires exactly 0" in result.stderr
+
+
+def test_supported_hub_ops_entrypoint_never_exposes_bash_startup_poison(
+    tmp_path: Path,
+) -> None:
+    hub_ops, app_root, _ops = _hub_ops_fixture(tmp_path)
+    marker = app_root / "bash-env-ran"
+    bash_env = tmp_path / "bash-env.sh"
+    bash_env.write_text(
+        f"printf poison > {marker}\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "environment.json"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "BASH_ENV": str(bash_env),
+            "BASH_FUNC_git%%": "() { printf function-poison; }",
+            "PYTHONPATH": str(tmp_path / "python-poison"),
+            "PYTEST_ADDOPTS": "--collect-only",
+            "GIT_DIR": str(tmp_path / "git-poison"),
+        }
+    )
+    before = _operational_snapshot(app_root)
+
+    result = _run([hub_ops, "deploy", output], env=environment)
+
+    assert result.returncode == 0, result.stderr
+    assert not marker.exists()
+    assert _operational_snapshot(app_root) == before
+    observed = json.loads(output.read_text(encoding="utf-8"))
+    assert "BASH_ENV" not in observed
+    assert "BASH_FUNC_git%%" not in observed
+    assert "PYTHONPATH" not in observed
+    assert "PYTEST_ADDOPTS" not in observed
+    assert "GIT_DIR" not in observed
+    assert HUB_OPS.read_text(encoding="utf-8").startswith("#!/usr/bin/python3 -I\n")

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -485,6 +485,64 @@ def _source_repository(path: Path) -> tuple[str, str]:
     (path / "requirements-dev.txt").write_text("pytest\n", encoding="utf-8")
     for source in DEPENDENCY_LOCKS:
         shutil.copyfile(source, path / "ops" / "ec2" / source.name)
+    shutil.copyfile(
+        ROOT / "ops" / "ec2" / "verify-release-worktree.py",
+        path / "ops" / "ec2" / "verify-release-worktree.py",
+    )
+    validation_runner = path / "ops" / "ec2" / "run-release-validation.py"
+    validation_runner.write_text(
+        "import hashlib\n"
+        "import json\n"
+        "import os\n"
+        "import subprocess\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "def controls(release):\n"
+        "    return Path((release / '.hub-deployment' / 'test-controls').read_text().strip())\n"
+        "def venv_digest(release):\n"
+        "    digest = hashlib.sha256()\n"
+        "    for item in sorted((release / '.venv').rglob('*')):\n"
+        "        relative = str(item.relative_to(release / '.venv')).encode()\n"
+        "        digest.update(len(relative).to_bytes(8, 'big')); digest.update(relative)\n"
+        "        if item.is_file(): digest.update(item.read_bytes())\n"
+        "    return digest.hexdigest()\n"
+        "if sys.argv[1] == 'manifest-venv':\n"
+        "    print(venv_digest(Path(sys.argv[2])))\n"
+        "    raise SystemExit(0)\n"
+        "release = Path(sys.argv[1]); commit = sys.argv[2]; control = controls(release)\n"
+        "if (control / 'swap-lock-during-pytest').exists():\n"
+        "    lock = release / 'ops/ec2/requirements-validation.lock'\n"
+        "    original = lock.read_bytes(); lock.write_bytes(original + b'# changed\\n'); lock.write_bytes(original)\n"
+        "    (control / 'lock-was-swapped').touch()\n"
+        "source = subprocess.run([\n"
+        "    '/usr/bin/python3', '-I', str(Path(__file__).with_name('verify-release-worktree.py')),\n"
+        "    str(release), commit, '--allow-generated', '.venv',\n"
+        "    '--allow-generated', '.hub-deployment',\n"
+        "], env={'HOME':'/nonexistent','LANG':'C.UTF-8','PATH':'/usr/bin:/bin'},\n"
+        "capture_output=True, text=True, check=False)\n"
+        "if source.returncode != 0:\n"
+        "    sys.stderr.write(source.stderr); raise SystemExit(1)\n"
+        "source_digest = json.loads(source.stdout)['source_tree_sha256']\n"
+        "exit_path = control / 'pytest.exit'\n"
+        "exit_code = int(exit_path.read_text()) if exit_path.exists() else 0\n"
+        "output_path = control / 'pytest.output'\n"
+        "if output_path.exists(): print(output_path.read_text(), end='')\n"
+        "else: print('17 passed in 0.01s')\n"
+        "collected = 17 if exit_code == 0 else 2\n"
+        "passed = collected if exit_code == 0 else 0\n"
+        "failed = 0 if exit_code == 0 else collected\n"
+        "result = 'passed' if exit_code == 0 else 'failed'\n"
+        "nodeids = 'd' * 64\n"
+        "print(\n"
+        "    'HUB_OPTIMUS_VALIDATION_V1 '\n"
+        "    f'collected={collected} terminal={collected} passed={passed} skipped=0 '\n"
+        "    f'failed={failed} pytest_exit_code={exit_code} nodeids_sha256={nodeids} '\n"
+        "    f'descendants=0 source_tree_sha256={source_digest} '\n"
+        "    f'venv_tree_sha256={venv_digest(release)} worker_uid=65534 result={result}'\n"
+        ")\n"
+        "raise SystemExit(exit_code)\n",
+        encoding="utf-8",
+    )
     launcher = path / "ops" / "ec2" / "hub-api.sh"
     launcher.write_text("#!/usr/bin/env bash\necho api-v1\n", encoding="utf-8")
     launcher.chmod(0o755)
@@ -652,10 +710,19 @@ def _deploy_fixture(path: Path) -> tuple[Path, Path]:
     assignment = 'SYSTEM_PYTHON="/usr/bin/python3"'
     assert deploy_text.count(assignment) == 1
     assert '"$SYSTEM_PYTHON" -I -m venv' in deploy_text
-    assert '"$VENV_PYTHON" -m pytest -q' in deploy_text
-    assert '"$VENV_PYTHON" -I -m pytest -q' not in deploy_text
+    assert '"$CANDIDATE_VALIDATION_RUNNER" \\\n' in deploy_text
+    assert '"$VENV_PYTHON" -m pytest' not in deploy_text
     assert "HUB_OPTIMUS_TEST_MODE" not in deploy_text
     assert "HUB_TEST_" not in deploy_text
+    deployment_marker = 'chmod 0700 "$DEPLOYMENT_DIR"\n'
+    assert deploy_text.count(deployment_marker) == 1
+    deploy_text = deploy_text.replace(
+        deployment_marker,
+        deployment_marker
+        + f"printf '%s\\n' {quoted_controls} > "
+        + '"$DEPLOYMENT_DIR/test-controls"\n',
+        1,
+    )
     deploy.write_text(
         deploy_text.replace(
             assignment,
@@ -689,9 +756,11 @@ def _deploy_env(
 
 
 def _expected_validation_command(release: Path) -> str:
+    commit = _git(release, "rev-parse", "HEAD")
     return (
-        f"/usr/bin/env -i HOME={release} LANG=C.UTF-8 PATH=/usr/bin:/bin "
-        f"PYTHONNOUSERSITE=1 {release}/.venv/bin/python -m pytest -q"
+        "/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 PATH=/usr/bin:/bin "
+        f"/usr/bin/python3 -I {release}/ops/ec2/run-release-validation.py "
+        f"{release} {commit} {release}/ops/ec2/verify-release-worktree.py"
     )
 
 
@@ -742,7 +811,18 @@ def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     assert re.fullmatch(r"[0-9a-f]{64}", first_state["dependency_lock_sha256"])
     assert first_state["validation_exit_code"] == "0"
     assert first_state["validation_log_exit_code"] == "0"
-    assert first_state["validation_result"] == "17 passed in 0.01s"
+    assert first_state["validation_protocol"] == "isolated-pytest-v1"
+    assert first_state["validation_collected"] == "17"
+    assert first_state["validation_terminal"] == "17"
+    assert first_state["validation_passed"] == "17"
+    assert first_state["validation_skipped"] == "0"
+    assert first_state["validation_failed"] == "0"
+    assert first_state["validation_descendants"] == "0"
+    assert first_state["validation_result"].startswith(
+        "HUB_OPTIMUS_VALIDATION_V1 collected=17 terminal=17 passed=17 "
+    )
+    assert re.fullmatch(r"[0-9a-f]{64}", first_state["source_tree_sha256"])
+    assert re.fullmatch(r"[0-9a-f]{64}", first_state["venv_tree_sha256"])
     first_validation_log = first_release / ".hub-deployment" / "validation.log"
     assert first_state["validation_log_sha256"] == hashlib.sha256(
         first_validation_log.read_bytes()
@@ -1148,7 +1228,7 @@ def test_failed_validation_is_recorded_without_switching_current(
     result = _run([deploy, head_commit], env=env)
 
     assert result.returncode == 1
-    assert "validation failed (exit 1): 2 failed in 0.01s" in result.stderr
+    assert "validation failed (exit 1): HUB_OPTIMUS_VALIDATION_V1" in result.stderr
     assert _operational_snapshot(app_root) == before
     failed_releases = [
         release
@@ -1169,7 +1249,10 @@ def test_failed_validation_is_recorded_without_switching_current(
         failed_releases[0]
     )
     assert failed_state["validation_exit_code"] == "1"
-    assert failed_state["validation_result"] == "2 failed in 0.01s"
+    assert failed_state["validation_result"].startswith(
+        "HUB_OPTIMUS_VALIDATION_V1 collected=2 terminal=2 passed=0 "
+    )
+    assert failed_state["validation_failed"] == "2"
     failed_validation_log = (
         failed_releases[0] / ".hub-deployment" / "validation.log"
     )
@@ -1278,5 +1361,7 @@ def test_deploy_requires_explicit_ref_and_hub_ops_forwards_it(
     assert result.returncode == 2
     assert not (app_root / "current").exists()
     hub_ops = HUB_OPS.read_text(encoding="utf-8")
-    assert "  deploy)\n    shift\n" in hub_ops
-    assert 'deploy-current" "$@"' in hub_ops
+    assert hub_ops.startswith("#!/usr/bin/python3 -I\n")
+    assert 'MUTATING_OPERATIONS = frozenset({"adopt", "deploy", "preflight", "rollback"})' in hub_ops
+    assert 'dispatcher = tools / "run-reviewed-operation.py"' in hub_ops
+    assert "run_operation(command, remaining)" in hub_ops

--- a/tests/test_ec2_run_identity_and_provenance.py
+++ b/tests/test_ec2_run_identity_and_provenance.py
@@ -149,6 +149,79 @@ def test_same_second_hub_core_runs_get_exclusive_ids(tmp_path: Path) -> None:
         assert run_state["commit"] == commit
 
 
+def test_hub_core_test_and_analyze_preserve_release_source_authority(
+    tmp_path: Path,
+) -> None:
+    app_root = tmp_path / "app"
+    release = app_root / "releases" / "current-release"
+    commit = _init_git_repo(release)
+    activate = release / ".venv" / "bin" / "activate"
+    activate.parent.mkdir(parents=True)
+    activate.write_text("deactivate() { :; }\n", encoding="utf-8")
+    (app_root / "shared").mkdir(parents=True)
+    (app_root / "current").symlink_to(release, target_is_directory=True)
+
+    fake_bin = tmp_path / "runtime-bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        "if [ -z \"${PYTHONDONTWRITEBYTECODE:-}\" ]; then\n"
+        "  mkdir -p semantic_engine/__pycache__\n"
+        "  printf poison > semantic_engine/__pycache__/runtime.pyc\n"
+        "fi\n"
+        "case \" $* \" in\n"
+        "  *' -m pytest '*)\n"
+        "    case \" $* \" in\n"
+        "      *' -p no:cacheprovider '*) ;;\n"
+        "      *) mkdir -p .pytest_cache; printf poison > .pytest_cache/CACHEDIR.TAG ;;\n"
+        "    esac\n"
+        "    printf '1 passed in 0.01s\\n'\n"
+        "    ;;\n"
+        "  *)\n"
+        "    previous=''\n"
+        "    for argument in \"$@\"; do\n"
+        "      if [ \"$previous\" = '--output' ]; then\n"
+        "        printf '{\"status\":\"draft\"}\\n' > \"$argument\"\n"
+        "      fi\n"
+        "      previous=\"$argument\"\n"
+        "    done\n"
+        "    ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    case_path = tmp_path / "case.json"
+    case_path.write_text("{}\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.pop("PYTHONDONTWRITEBYTECODE", None)
+    env["HUB_OPTIMUS_APP_ROOT"] = str(app_root)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    tested = _run(["bash", HUB_CORE, "test"], env=env)
+    analyzed = _run(["bash", HUB_CORE, "analyze", case_path], env=env)
+
+    assert tested.returncode == 0, tested.stderr
+    assert analyzed.returncode == 0, analyzed.stderr
+    assert not (release / "semantic_engine" / "__pycache__").exists()
+    assert not (release / ".pytest_cache").exists()
+    verified = _run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            ROOT / "ops" / "ec2" / "verify-release-worktree.py",
+            release,
+            commit,
+            "--allow-generated",
+            ".venv",
+            "--allow-generated",
+            ".hub-deployment",
+        ],
+    )
+    assert verified.returncode == 0, verified.stderr
+
+
 def test_hub_core_pins_one_release_for_the_complete_run(
     tmp_path: Path,
 ) -> None:
@@ -494,17 +567,32 @@ def _source_repository(path: Path) -> tuple[str, str]:
         "import hashlib\n"
         "import json\n"
         "import os\n"
+        "import stat\n"
         "import subprocess\n"
         "import sys\n"
         "from pathlib import Path\n"
         "def controls(release):\n"
         "    return Path((release / '.hub-deployment' / 'test-controls').read_text().strip())\n"
+        "IDENTITY_FIELDS = ('st_dev','st_ino','st_mode','st_nlink','st_uid','st_gid','st_size','st_mtime_ns','st_ctime_ns')\n"
         "def venv_digest(release):\n"
-        "    digest = hashlib.sha256()\n"
-        "    for item in sorted((release / '.venv').rglob('*')):\n"
-        "        relative = str(item.relative_to(release / '.venv')).encode()\n"
-        "        digest.update(len(relative).to_bytes(8, 'big')); digest.update(relative)\n"
-        "        if item.is_file(): digest.update(item.read_bytes())\n"
+        "    root = (release / '.venv').resolve()\n"
+        "    digest = hashlib.sha256(); pending = [root]; records = []\n"
+        "    while pending:\n"
+        "        directory = pending.pop(); info = directory.stat(follow_symlinks=False)\n"
+        "        relative = str(directory.relative_to(root)) or '.'\n"
+        "        records.append((relative + '/', b'directory', info))\n"
+        "        for item in sorted(os.scandir(directory), key=lambda entry: entry.name):\n"
+        "            path = Path(item.path); entry_info = item.stat(follow_symlinks=False)\n"
+        "            item_relative = str(path.relative_to(root))\n"
+        "            if stat.S_ISDIR(entry_info.st_mode): pending.append(path)\n"
+        "            elif stat.S_ISREG(entry_info.st_mode): records.append((item_relative, path.read_bytes(), path.stat(follow_symlinks=False)))\n"
+        "            elif stat.S_ISLNK(entry_info.st_mode): records.append((item_relative, ('symlink:' + os.readlink(path)).encode(), path.stat(follow_symlinks=False)))\n"
+        "            else: raise SystemExit('unsupported fake venv entry')\n"
+        "    for relative, raw, info in sorted(records, key=lambda record: record[0]):\n"
+        "        encoded = relative.encode('utf-8')\n"
+        "        digest.update(len(encoded).to_bytes(8, 'big')); digest.update(encoded)\n"
+        "        digest.update(len(raw).to_bytes(8, 'big')); digest.update(raw)\n"
+        "        for field in IDENTITY_FIELDS: digest.update(int(getattr(info, field)).to_bytes(16, 'big'))\n"
         "    return digest.hexdigest()\n"
         "if sys.argv[1] == 'manifest-venv':\n"
         "    print(venv_digest(Path(sys.argv[2])))\n"
@@ -784,6 +872,76 @@ def _operational_snapshot(app_root: Path) -> dict[str, object]:
     return snapshot
 
 
+def _wait_for_operation_barrier(
+    ready: Path,
+    process: subprocess.Popen[str],
+) -> None:
+    deadline = time.monotonic() + 30
+    while not ready.exists() and process.poll() is None:
+        if time.monotonic() >= deadline:
+            process.terminate()
+            _stdout, stderr = process.communicate(timeout=5)
+            raise AssertionError(
+                f"operation did not reach test barrier {ready}: {stderr}"
+            )
+        time.sleep(0.01)
+    if not ready.exists():
+        _stdout, stderr = process.communicate(timeout=5)
+        raise AssertionError(
+            f"operation exited before test barrier {ready}: {stderr}"
+        )
+
+
+def _advance_head_without_tree_change(release: Path) -> str:
+    _git(
+        release,
+        "-c",
+        "user.email=tests@example.invalid",
+        "-c",
+        "user.name=HUB tests",
+        "commit",
+        "--allow-empty",
+        "-qm",
+        "external HEAD drift",
+    )
+    return _git(release, "rev-parse", "HEAD")
+
+
+def _install_manifest_barrier(
+    runner: Path,
+    target: Path,
+    ready: Path,
+    proceed: Path,
+) -> None:
+    original = runner.with_name("run-release-validation.original.py")
+    runner.replace(original)
+    runner.write_text(
+        "import os\n"
+        "import sys\n"
+        "import time\n"
+        "from pathlib import Path\n"
+        f"target = {str(target)!r}\n"
+        f"ready = Path({str(ready)!r})\n"
+        f"proceed = Path({str(proceed)!r})\n"
+        f"original = {str(original)!r}\n"
+        "if (\n"
+        "    len(sys.argv) == 3\n"
+        "    and sys.argv[1] == 'manifest-venv'\n"
+        "    and os.path.realpath(sys.argv[2]) == target\n"
+        "):\n"
+        "    ready.touch(exist_ok=False)\n"
+        "    deadline = time.monotonic() + 30\n"
+        "    while not proceed.exists():\n"
+        "        if time.monotonic() >= deadline:\n"
+        "            raise SystemExit('manifest barrier timed out')\n"
+        "        time.sleep(0.01)\n"
+        "os.execv('/usr/bin/python3', [\n"
+        "    '/usr/bin/python3', '-I', original, *sys.argv[1:]\n"
+        "])\n",
+        encoding="utf-8",
+    )
+
+
 def test_deploy_is_ref_bound_records_validation_and_rolls_back(
     tmp_path: Path,
 ) -> None:
@@ -959,6 +1117,127 @@ def test_injected_legacy_state_completion_is_recovered(
     assert not legacy_state.exists()
 
 
+@pytest.mark.parametrize("drift", ("source", "venv"))
+def test_deploy_rejects_rollback_target_authority_drift_before_mutation(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    first = _run([deploy, reviewed_commit], env=env)
+    assert first.returncode == 0, first.stderr
+    rollback_target = (app_root / "current").resolve()
+    if drift == "source":
+        _git(rollback_target, "update-index", "--assume-unchanged", "version.txt")
+        (rollback_target / "version.txt").write_text(
+            "hidden rollback-target drift\n",
+            encoding="utf-8",
+        )
+    else:
+        with (rollback_target / ".venv" / "bin" / "python").open(
+            "ab",
+        ) as handle:
+            handle.write(b"# rollback-target drift\n")
+    before = _operational_snapshot(app_root)
+
+    failed = _run([deploy, head_commit], env=env)
+
+    assert failed.returncode == 1
+    if drift == "source":
+        assert "source tree differs from its reviewed commit" in failed.stderr
+    else:
+        assert "Rollback target venv does not match RELEASE_STATE" in failed.stderr
+    assert _operational_snapshot(app_root) == before
+    assert "Restoring exact pre-deploy" not in failed.stderr
+
+
+def test_deploy_rejects_rollback_target_head_change_at_authority_barrier(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, _controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    assert _run([deploy, reviewed_commit], env=env).returncode == 0
+    previous = (app_root / "current").resolve()
+    before = _operational_snapshot(app_root)
+    ready = tmp_path / "deploy-authority-ready"
+    proceed = tmp_path / "deploy-authority-proceed"
+    env["HUB_OPTIMUS_TEST_DEPLOY_BEFORE_AUTHORITY_READY"] = str(ready)
+    env["HUB_OPTIMUS_TEST_DEPLOY_BEFORE_AUTHORITY_PROCEED"] = str(proceed)
+    process = subprocess.Popen(
+        [str(deploy), head_commit],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    _wait_for_operation_barrier(ready, process)
+    assert _advance_head_without_tree_change(previous) != reviewed_commit
+    proceed.touch()
+    _stdout, stderr = process.communicate(timeout=30)
+
+    assert process.returncode == 1
+    assert "Release HEAD differs from its recorded commit" in stderr
+    assert _operational_snapshot(app_root) == before
+    assert "Restoring exact pre-deploy" not in stderr
+
+
+@pytest.mark.parametrize("operation", ("deploy", "rollback"))
+def test_operation_rejects_head_change_during_venv_authority_hash(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, _controls = _deploy_fixture(tmp_path)
+    rollback = deploy.parent / "rollback-current.sh"
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    assert _run([deploy, reviewed_commit], env=env).returncode == 0
+    target = (app_root / "current").resolve()
+    command: list[str | Path]
+    if operation == "deploy":
+        command = [deploy, head_commit]
+        recorded_commit = reviewed_commit
+    else:
+        assert _run([deploy, head_commit], env=env).returncode == 0
+        command = [rollback]
+        recorded_commit = reviewed_commit
+    before = _operational_snapshot(app_root)
+    ready = tmp_path / f"{operation}-venv-authority-ready"
+    proceed = tmp_path / f"{operation}-venv-authority-proceed"
+    _install_manifest_barrier(
+        deploy.parent / "run-release-validation.py",
+        target,
+        ready,
+        proceed,
+    )
+    process = subprocess.Popen(
+        [str(item) for item in command],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    _wait_for_operation_barrier(ready, process)
+    assert _advance_head_without_tree_change(target) != recorded_commit
+    proceed.touch()
+    _stdout, stderr = process.communicate(timeout=30)
+
+    assert process.returncode == 1
+    assert "Release HEAD differs from its recorded commit" in stderr
+    assert _operational_snapshot(app_root) == before
+    assert "Restoring exact pre-" not in stderr
+
+
 def test_rollback_rejects_launcher_drift_before_switching(
     tmp_path: Path,
 ) -> None:
@@ -984,6 +1263,94 @@ def test_rollback_rejects_launcher_drift_before_switching(
     assert result.returncode == 1
     assert "launcher does not match its deployment state" in result.stderr
     assert _operational_snapshot(app_root) == before
+
+
+@pytest.mark.parametrize(
+    ("release_role", "drift"),
+    (
+        ("current", "source"),
+        ("current", "venv"),
+        ("previous", "source"),
+        ("previous", "venv"),
+    ),
+)
+def test_rollback_rejects_current_and_previous_authority_drift(
+    tmp_path: Path,
+    release_role: str,
+    drift: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    assert _run([deploy, reviewed_commit], env=env).returncode == 0
+    previous = (app_root / "current").resolve()
+    assert _run([deploy, head_commit], env=env).returncode == 0
+    current = (app_root / "current").resolve()
+    target = current if release_role == "current" else previous
+    if drift == "source":
+        _git(target, "update-index", "--skip-worktree", "version.txt")
+        (target / "version.txt").write_text(
+            f"hidden {release_role} drift\n",
+            encoding="utf-8",
+        )
+    else:
+        with (target / ".venv" / "bin" / "python").open("ab") as handle:
+            handle.write(f"# {release_role} venv drift\n".encode())
+    before = _operational_snapshot(app_root)
+
+    failed = _run([ROLLBACK], env=env)
+
+    assert failed.returncode == 1
+    label = "Current release" if release_role == "current" else "Previous release"
+    if drift == "source":
+        assert "source tree differs from its reviewed commit" in failed.stderr
+    else:
+        assert f"{label} venv does not match RELEASE_STATE" in failed.stderr
+    assert _operational_snapshot(app_root) == before
+    assert not list((app_root / "shared").glob("rollback-transaction.*"))
+
+
+@pytest.mark.parametrize("release_role", ("current", "previous"))
+def test_rollback_rejects_head_change_at_authority_barrier(
+    tmp_path: Path,
+    release_role: str,
+) -> None:
+    source_repo = tmp_path / "source"
+    reviewed_commit, head_commit = _source_repository(source_repo)
+    deploy, _controls = _deploy_fixture(tmp_path)
+    app_root = tmp_path / "app"
+    env = _deploy_env(app_root, source_repo)
+
+    assert _run([deploy, reviewed_commit], env=env).returncode == 0
+    previous = (app_root / "current").resolve()
+    assert _run([deploy, head_commit], env=env).returncode == 0
+    current = (app_root / "current").resolve()
+    target = current if release_role == "current" else previous
+    recorded = head_commit if release_role == "current" else reviewed_commit
+    before = _operational_snapshot(app_root)
+    ready = tmp_path / f"rollback-{release_role}-authority-ready"
+    proceed = tmp_path / f"rollback-{release_role}-authority-proceed"
+    env["HUB_OPTIMUS_TEST_ROLLBACK_BEFORE_AUTHORITY_READY"] = str(ready)
+    env["HUB_OPTIMUS_TEST_ROLLBACK_BEFORE_AUTHORITY_PROCEED"] = str(proceed)
+    process = subprocess.Popen(
+        [str(ROLLBACK)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    _wait_for_operation_barrier(ready, process)
+    assert _advance_head_without_tree_change(target) != recorded
+    proceed.touch()
+    _stdout, stderr = process.communicate(timeout=30)
+
+    assert process.returncode == 1
+    assert "Release HEAD differs from its recorded commit" in stderr
+    assert _operational_snapshot(app_root) == before
+    assert "Restoring exact pre-rollback" not in stderr
 
 
 def test_every_injected_rollback_failure_restores_exact_state(

--- a/tests/test_ec2_runbook_attestation.py
+++ b/tests/test_ec2_runbook_attestation.py
@@ -70,7 +70,17 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
 
     deployment_dir = release / ".hub-deployment"
     validation_log = deployment_dir / "validation.log"
-    validation_log_raw = b"collecting tests\n692 passed in 30.45s\n\n"
+    source_tree_sha256 = "1" * 64
+    venv_tree_sha256 = "2" * 64
+    nodeids_sha256 = "3" * 64
+    validation_result = (
+        "HUB_OPTIMUS_VALIDATION_V1 collected=692 terminal=692 passed=692 "
+        "skipped=0 failed=0 pytest_exit_code=0 "
+        f"nodeids_sha256={nodeids_sha256} descendants=0 "
+        f"source_tree_sha256={source_tree_sha256} "
+        f"venv_tree_sha256={venv_tree_sha256} worker_uid=65534 result=passed"
+    )
+    validation_log_raw = f"collecting tests\n{validation_result}\n".encode()
     _write_bytes(validation_log, validation_log_raw, 0o600)
     dependency_digest = hashlib.sha256()
     for relative in DEPENDENCY_LOCKS:
@@ -90,14 +100,27 @@ def _deploy_fixture(tmp_path: Path) -> dict[str, object]:
         "path": str(release),
         "validated_at_utc": "2026-08-02T12:00:00Z",
         "validation_command": (
-            f"/usr/bin/env -i HOME={release} LANG=C.UTF-8 PATH=/usr/bin:/bin "
-            f"PYTHONNOUSERSITE=1 {release}/.venv/bin/python -m pytest -q"
+            "/usr/bin/env -i HOME=/nonexistent LANG=C.UTF-8 PATH=/usr/bin:/bin "
+            f"/usr/bin/python3 -I {release}/ops/ec2/run-release-validation.py "
+            f"{release} {commit} {release}/ops/ec2/verify-release-worktree.py"
         ),
         "validation_exit_code": "0",
-        "validation_result": "692 passed in 30.45s",
+        "validation_result": validation_result,
         "validation_log": str(validation_log),
         "validation_log_exit_code": "0",
         "validation_log_sha256": hashlib.sha256(validation_log_raw).hexdigest(),
+        "validation_protocol": "isolated-pytest-v1",
+        "validation_collected": "692",
+        "validation_terminal": "692",
+        "validation_passed": "692",
+        "validation_skipped": "0",
+        "validation_failed": "0",
+        "validation_pytest_exit_code": "0",
+        "validation_nodeids_sha256": nodeids_sha256,
+        "validation_descendants": "0",
+        "validation_worker_uid": "65534",
+        "source_tree_sha256": source_tree_sha256,
+        "venv_tree_sha256": venv_tree_sha256,
         "dependency_tier": "runtime+validation-v1",
         "dependency_lock": str(dependency_lock),
         "dependency_lock_sha256": dependency_digest.hexdigest(),
@@ -245,9 +268,12 @@ def test_post_deploy_disk_attestation_rejects_every_identity_drift(
         _replace_state_pair(
             release_state,
             shared_state,
-            lambda raw: raw.replace(
-                b"validation_result=692 passed in 30.45s\n",
+            lambda raw: re.sub(
+                rb"^validation_result=.*\n",
                 b"validation_result=forged result\n",
+                raw,
+                count=1,
+                flags=re.MULTILINE,
             ),
         )
     elif invalid_case == "validation-log-invalid-utf8":
@@ -418,9 +444,11 @@ def _rollback_fixture(tmp_path: Path) -> dict[str, object]:
         ),
         "validation_log": "not-applicable",
         "validation_log_exit_code": "not-run",
+        "source_tree_sha256": "1" * 64,
+        "venv_tree_sha256": "2" * 64,
         "launcher_sha256": launcher_sha256,
         "status": "adopted-legacy-current",
-        "provenance": "adopted-legacy-current-v1",
+        "provenance": "adopted-legacy-current-v2",
         "legacy_state_sha256": hashlib.sha256(legacy_raw).hexdigest(),
         "legacy_commit_prefix": legacy_prefix,
     }

--- a/tests/test_ec2_validation_boundary.py
+++ b/tests/test_ec2_validation_boundary.py
@@ -85,9 +85,9 @@ def isolated_release() -> tuple[Path, Path, Path, Path]:
         encoding="utf-8",
     )
     verifier.chmod(0o644)
-    # The sandbox running these tests maps only UID 0, so chown/setuid(nobody)
-    # is impossible. Instrument a private copy to exercise the supervisor,
-    # evidence, subreaper and cleanup paths as the current UID. A separate
+    # Instrument a private copy to exercise the supervisor, evidence,
+    # subreaper and cleanup paths as the current UID.  This works both in the
+    # root-only local sandbox and on an unprivileged hosted runner.  A separate
     # assertion below keeps the production root->nobody contract exact.
     runner = fixture_root / RUNNER.name
     runner_source = RUNNER.read_text(encoding="utf-8")
@@ -124,9 +124,16 @@ def isolated_release() -> tuple[Path, Path, Path, Path]:
         encoding="utf-8",
     )
     runner.chmod(0o644)
+    # The hosted runner owns this fixture.  Make the candidate root itself
+    # non-writable so the test exercises the same read-only source boundary as
+    # the production root->nobody transition instead of accidentally granting
+    # the worker owner-write access.
+    release.chmod(0o555)
     try:
         yield release, tests, verifier, runner
     finally:
+        for directory, _subdirectories, _files in os.walk(release):
+            Path(directory).chmod(0o755)
         shutil.rmtree(fixture_root, ignore_errors=True)
 
 

--- a/tests/test_ec2_validation_boundary.py
+++ b/tests/test_ec2_validation_boundary.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pwd
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "ops" / "ec2" / "run-release-validation.py"
+COMMIT = "a" * 40
+PYTEST_MODULES = (
+    "_pytest",
+    "pytest",
+    "pluggy",
+    "iniconfig",
+    "packaging",
+    "pygments",
+    "py",
+)
+
+
+def _copy_module(name: str, destination: Path) -> None:
+    spec = importlib.util.find_spec(name)
+    assert spec is not None
+    if spec.submodule_search_locations:
+        source = Path(next(iter(spec.submodule_search_locations)))
+        shutil.copytree(source, destination / source.name, symlinks=True)
+    else:
+        assert spec.origin is not None
+        source = Path(spec.origin)
+        shutil.copy2(source, destination / source.name)
+
+
+@pytest.fixture(scope="module")
+def isolated_release() -> tuple[Path, Path, Path, Path]:
+    fixture_root = Path(tempfile.mkdtemp(prefix="hub-1853-validation-", dir="/tmp"))
+    fixture_root.chmod(0o755)
+    release = fixture_root / "release"
+    tests = release / "tests"
+    site_packages = release / ".venv" / "site-packages"
+    bin_directory = release / ".venv" / "bin"
+    tests.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    bin_directory.mkdir(parents=True)
+    for module in PYTEST_MODULES:
+        _copy_module(module, site_packages)
+
+    base_python = Path(sys.executable).resolve()
+    python = bin_directory / "python"
+    python.write_text(
+        "#!/bin/bash\n"
+        "set -eu\n"
+        f"export PYTHONPATH={site_packages!s}\n"
+        "if [ \"${1:-}\" = '-I' ]; then shift; fi\n"
+        f"exec {base_python!s} \"$@\"\n",
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    for directory, _subdirectories, _files in os.walk(release):
+        Path(directory).chmod(0o755)
+    for path in release.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            mode = stat.S_IMODE(path.stat().st_mode)
+            path.chmod((mode | 0o444) & ~0o022)
+
+    verifier = fixture_root / "source-verifier.py"
+    verifier.write_text(
+        "import json\n"
+        "import sys\n"
+        "print(json.dumps({\n"
+        "    'commit': sys.argv[2],\n"
+        "    'source_tree_sha256': 'b' * 64,\n"
+        "}, sort_keys=True, separators=(',', ':')))\n",
+        encoding="utf-8",
+    )
+    verifier.chmod(0o644)
+    # The sandbox running these tests maps only UID 0, so chown/setuid(nobody)
+    # is impossible. Instrument a private copy to exercise the supervisor,
+    # evidence, subreaper and cleanup paths as the current UID. A separate
+    # assertion below keeps the production root->nobody contract exact.
+    runner = fixture_root / RUNNER.name
+    runner_source = RUNNER.read_text(encoding="utf-8")
+    direct_start = runner_source.index("def direct_children()")
+    direct_end = runner_source.index("\ndef kill_and_reap_descendants", direct_start)
+    runner_source = (
+        runner_source[:direct_start]
+        + "def direct_children() -> set[int]:\n"
+        + "    registry = os.environ.get('HUB_1853_TEST_CHILD_PID')\n"
+        + "    if not registry:\n"
+        + "        return set()\n"
+        + "    path = Path(registry)\n"
+        + "    if not path.exists():\n"
+        + "        return set()\n"
+        + "    pid = int(path.read_text(encoding='ascii'))\n"
+        + "    path.unlink()\n"
+        + "    return {pid}\n"
+        + runner_source[direct_end:]
+    )
+    start = runner_source.index("def worker_identity(")
+    end = runner_source.index("\ndef make_preexec", start)
+    preexec_end = runner_source.index("\ndef marker", end)
+    runner.write_text(
+        runner_source[:start]
+        + "def worker_identity(release: Path, venv: Path) -> tuple[int, int]:\n"
+        + "    del release, venv\n"
+        + "    return os.getegid(), os.geteuid()\n"
+        + "\n\ndef make_preexec(gid: int, uid: int):\n"
+        + "    del gid, uid\n"
+        + "    def prepare() -> None:\n"
+        + "        no_new_privileges()\n"
+        + "    return prepare\n"
+        + runner_source[preexec_end:],
+        encoding="utf-8",
+    )
+    runner.chmod(0o644)
+    try:
+        yield release, tests, verifier, runner
+    finally:
+        shutil.rmtree(fixture_root, ignore_errors=True)
+
+
+def _write_test(tests: Path, source: str) -> None:
+    for path in tests.iterdir():
+        if path.is_file():
+            path.unlink()
+    candidate = tests / "test_candidate.py"
+    candidate.write_text(source, encoding="utf-8")
+    candidate.chmod(0o644)
+
+
+def _run_boundary(
+    release: Path,
+    verifier: Path,
+    runner: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "/usr/bin/python3",
+            "-I",
+            str(runner),
+            str(release),
+            COMMIT,
+            str(verifier),
+            "--timeout",
+            "10",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _marker(stdout: str) -> dict[str, str]:
+    line = stdout.rstrip().splitlines()[-1]
+    assert line.startswith("HUB_OPTIMUS_VALIDATION_V1 ")
+    return dict(field.split("=", 1) for field in line.split()[1:])
+
+
+def test_production_supervisor_selects_nobody_when_root(
+    isolated_release: tuple[Path, Path, Path, Path],
+) -> None:
+    release, _tests, _verifier, _runner = isolated_release
+    spec = importlib.util.spec_from_file_location("validation_boundary", RUNNER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    gid, uid = module.worker_identity(release, release / ".venv")
+
+    if os.geteuid() == 0:
+        account = pwd.getpwnam("nobody")
+        assert (gid, uid) == (account.pw_gid, account.pw_uid)
+        source = RUNNER.read_text(encoding="utf-8")
+        assert source.index("os.setgroups([])") < source.index("os.setgid(gid)")
+        assert source.index("os.setgid(gid)") < source.index("os.setuid(uid)")
+    else:
+        assert (gid, uid) == (os.getegid(), os.geteuid())
+
+
+def test_real_pytest_execution_ignores_ambient_poison_and_is_non_writable(
+    isolated_release: tuple[Path, Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    release, tests, verifier, runner = isolated_release
+    _write_test(
+        tests,
+        "import os\n"
+        "import pathlib\n"
+        "import pytest\n"
+        "def test_passes_under_restricted_uid(tmp_path):\n"
+        "    assert tmp_path.is_dir()\n"
+        "    if os.geteuid() != 0:\n"
+        "        with pytest.raises(PermissionError):\n"
+        "            pathlib.Path(__file__).parents[1].joinpath('poison').write_text('x')\n"
+        "@pytest.mark.skip(reason='reviewed skip')\n"
+        "def test_reviewed_skip():\n"
+        "    pass\n",
+    )
+    sentinel = tmp_path / "sitecustomize-ran"
+    poison = tmp_path / "poison"
+    poison.mkdir()
+    (poison / "sitecustomize.py").write_text(
+        f"open({str(sentinel)!r}, 'w').write('poison')\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONPATH": str(poison),
+            "PYTEST_ADDOPTS": "--collect-only",
+            "PYTEST_PLUGINS": "not_a_reviewed_plugin",
+        }
+    )
+
+    result = _run_boundary(release, verifier, runner, env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert not sentinel.exists()
+    evidence = _marker(result.stdout)
+    assert evidence["collected"] == "2"
+    assert evidence["terminal"] == "2"
+    assert evidence["passed"] == "1"
+    assert evidence["skipped"] == "1"
+    assert evidence["failed"] == "0"
+    assert evidence["descendants"] == "0"
+    assert evidence["result"] == "passed"
+    assert evidence["worker_uid"] == str(os.geteuid())
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_collected"),
+    (
+        ("# intentionally no tests\n", "0"),
+        ("def test_failure():\n    assert False\n", "1"),
+    ),
+)
+def test_zero_tests_and_failures_never_pass_boundary(
+    isolated_release: tuple[Path, Path, Path, Path],
+    source: str,
+    expected_collected: str,
+) -> None:
+    release, tests, verifier, runner = isolated_release
+    _write_test(tests, source)
+
+    result = _run_boundary(release, verifier, runner)
+
+    assert result.returncode == 1
+    evidence = _marker(result.stdout)
+    assert evidence["collected"] == expected_collected
+    assert evidence["result"] == "failed"
+
+
+def test_double_fork_style_delayed_descendant_is_killed_and_rejected(
+    isolated_release: tuple[Path, Path, Path, Path],
+) -> None:
+    release, tests, verifier, runner = isolated_release
+    token = uuid.uuid4().hex
+    pid_path = Path("/tmp") / f"hub-1853-{token}.pid"
+    sentinel = Path("/tmp") / f"hub-1853-{token}.sentinel"
+    child_code = (
+        "import os,time;"
+        f"open({str(pid_path)!r}, 'w').write(str(os.getpid()));"
+        "time.sleep(2);"
+        f"open({str(sentinel)!r}, 'w').write('late')"
+    )
+    _write_test(
+        tests,
+        "import pathlib\n"
+        "import subprocess\n"
+        "import sys\n"
+        "import time\n"
+        f"CODE = {child_code!r}\n"
+        f"PID_PATH = pathlib.Path({str(pid_path)!r})\n"
+        "def test_spawns_delayed_descendant():\n"
+        "    subprocess.Popen([sys.executable, '-c', CODE], start_new_session=True)\n"
+        "    deadline = time.monotonic() + 5\n"
+        "    while not PID_PATH.exists():\n"
+        "        assert time.monotonic() < deadline\n"
+        "        time.sleep(0.01)\n",
+    )
+    try:
+        environment = os.environ.copy()
+        environment["HUB_1853_TEST_CHILD_PID"] = str(pid_path)
+        result = _run_boundary(release, verifier, runner, env=environment)
+        assert result.returncode == 1, result.stderr
+        evidence = _marker(result.stdout)
+        assert int(evidence["descendants"]) >= 1
+        assert evidence["result"] == "failed"
+        time.sleep(2.1)
+        assert not sentinel.exists()
+    finally:
+        pid_path.unlink(missing_ok=True)
+        sentinel.unlink(missing_ok=True)
+
+
+def test_manifest_mode_detects_venv_drift(
+    isolated_release: tuple[Path, Path, Path, Path],
+) -> None:
+    release, _tests, _verifier, _runner = isolated_release
+    command = [
+        "/usr/bin/python3",
+        "-I",
+        str(RUNNER),
+        "manifest-venv",
+        str(release),
+    ]
+    before = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert before.returncode == 0, before.stderr
+    target = release / ".venv" / "manifest-poison"
+    target.write_bytes(b"poison\n")
+    target.chmod(0o644)
+    after = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert after.returncode == 0, after.stderr
+    assert before.stdout != after.stdout
+    target.unlink()


### PR DESCRIPTION
## Decision

Draft only. This PR addresses #1853 and is stacked on #1859 at `1c886a5eabb112fcf68eaf03df168a15138df302`.

It does **not** authorize merge, deployment, AWS mutation, DNS, TLS, OIDC, nginx, or service restart.

## Scope

- replace the supported Bash-facing operator entrypoint with an isolated Python boundary before any reviewed operation;
- construct allowlisted environments for Bash, Python, pytest, pip, and Git;
- compare the release directly with the pinned commit without consulting the mutable index, status, fsmonitor, or replace refs;
- independently authenticate canonical SHA-1 identities for the commit, every tree, and every blob before trusting object bytes;
- reject hidden tracked drift, injected environment, unexpected descendants and corrupted Git objects;
- run pytest under a supervised boundary with explicit execution evidence, restricted UID, `no_new_privs`, subreaper and descendant cleanup;
- bind source and venv manifests before/after validation and immediately before the operational switch;
- authenticate current and rollback-target `HEAD`, source bytes and venv against exact `RELEASE_STATE` authority before deploy/rollback/adoption mutation;
- repeat `HEAD` checks around source/venv calculation and sweep every participating release immediately before mutation;
- record adopted legacy authority under exact schema `adopted-legacy-current-v2`;
- prevent normal API/core/test execution from creating `__pycache__` or `.pytest_cache` drift;
- extend release state, preflight and runbook validation with structured evidence.

## Adversarial coverage

- `BASH_ENV`, exported functions, `PYTHONPATH`, `PYTEST_ADDOPTS`, `PYTEST_PLUGINS`, and `GIT_*` cannot cross the supported entrypoint;
- corrupted loose commit/tree/blob objects, hidden index flags, zero-test, collect-only and delayed-child cases fail closed;
- `HEAD` changes during source or venv calculation fail before mutation for deploy, rollback and adoption;
- normal analyze/test commands preserve a source-verifiable release;
- negative cases preserve operational state byte-for-byte.

## Validation

- original focused #1853 pack: **36 passed**;
- original EC2 integration pack: **163 passed**;
- authority/cache/schema follow-up: **204 focused + 104 runbook/validator + 6 TOCTOU regressions passed**;
- prior full suite: **915 passed, 15 skipped**;
- Bash syntax, Python compilation, encoding, mojibake and `git diff --check`: PASS;
- follow-up independent review: initial BLOCK reproduced mutable-HEAD races; final rereview: **PUBLISH**.

## Remaining blocks

#1854 and #1855 remain unresolved. #1831 and every AWS mutation remain blocked. This draft must not be merged or deployed independently. Internal Bash scripts are not supported direct entrypoints; use `hub-ops` or `run-reviewed-operation.py`.