### PR TITLE
feat(admin-gateway): add governed API, validation and DryRun core

### DIFF
--- a/.github/workflows/optimus-admin-gateway.yml
+++ b/.github/workflows/optimus-admin-gateway.yml
@@ -1,0 +1,34 @@
+name: Optimus Admin Gateway
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/admin-gateway/**'
+      - '.github/workflows/optimus-admin-gateway.yml'
+  pull_request:
+    paths:
+      - 'products/admin-gateway/**'
+      - '.github/workflows/optimus-admin-gateway.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-contract:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: products/admin-gateway
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+      - name: Install module test dependencies
+        run: python -m pip install -e '.[dev]'
+      - name: Run API and authentication contract tests
+        run: python -m pytest -q

--- a/.github/workflows/optimus-admin-gateway.yml
+++ b/.github/workflows/optimus-admin-gateway.yml
@@ -31,4 +31,6 @@ jobs:
       - name: Install module test dependencies
         run: python -m pip install -e '.[dev]'
       - name: Run API and authentication contract tests
-        run: python -m pytest -q
+        run: >-
+          python -m pytest -q
+          -W error::starlette.exceptions.StarletteDeprecationWarning

--- a/.github/workflows/optimus-admin-gateway.yml
+++ b/.github/workflows/optimus-admin-gateway.yml
@@ -31,6 +31,4 @@ jobs:
       - name: Install module test dependencies
         run: python -m pip install -e '.[dev]'
       - name: Run API and authentication contract tests
-        run: >-
-          python -m pytest -q
-          -W error::starlette.exceptions.StarletteDeprecationWarning
+        run: python -m pytest -q

--- a/docs/context/WORKFLOWS.md
+++ b/docs/context/WORKFLOWS.md
@@ -39,6 +39,19 @@ powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1
   - `benchmarks`: non-blocking benchmark pack with `continue-on-error: true`.
 - Writes to repo: no.
 
+### optimus-admin-gateway.yml
+
+- Triggers:
+  - `push` to `main` when the Admin Gateway package or this workflow changes;
+  - `pull_request` for the same paths;
+  - `workflow_dispatch`.
+- Permissions: `contents: read`.
+- Job `python-contract`:
+  - installs the package with its development dependencies on Python 3.11;
+  - runs the complete product test suite;
+  - treats the Starlette legacy-TestClient deprecation as an error.
+- Writes to repo: no.
+
 ### link-check.yml
 
 - Triggers:

--- a/products/admin-gateway/VALIDATION.md
+++ b/products/admin-gateway/VALIDATION.md
@@ -1,20 +1,27 @@
 # Validation record
 
-Validation target: Optimus Admin Gateway foundation boundary.
+Validation target: Optimus Admin Gateway API and authentication slice.
 
-This slice contains product-boundary documentation only. It does not contain
-the API, operation catalog, runbook, Power Platform assets or deployment
-templates, so it makes no runtime-test or deployable-package claim.
+Executed locally for this stacked head:
 
-Verified for this slice:
+```text
+python -m pip install -e '.[dev]'
+python -m pytest -q
+28 passed
+```
 
-- the five tracked Admin Gateway files are the README, this validation record,
-  architecture, client-boundary and security documentation;
-- no pilot mailbox address, tenant ID, client environment URL, credential or
-  execution output is stored in the public foundation;
-- executable validation is deferred to the focused implementation slices that
-  introduce the corresponding assets.
+Verified in this slice:
 
-The complete package must be validated again at its final stacked head before
-review or deployment. A package manifest is intentionally absent until it can
-be generated from the files that actually exist in Git.
+- JSON syntax and model validation for the operation catalog;
+- YAML parsing and route parity for the canonical OpenAPI contract;
+- strict EasyAuth client-principal parsing and synthetic tenant binding;
+- rejection of legacy production headers and malformed identity claims;
+- independent `Optimus.Reader` and `Optimus.Mutator` role gates before the
+  approval gate;
+- public-boundary checks for tenant identifiers, mailbox addresses and client
+  environment URLs.
+
+PowerShell, Power Platform, Dataverse and deployment assets are not present in
+this slice and are not certified here. A package manifest remains intentionally
+absent until the final stacked package can generate it from files that actually
+exist in Git.

--- a/products/admin-gateway/config/operations.catalog.json
+++ b/products/admin-gateway/config/operations.catalog.json
@@ -1,0 +1,148 @@
+{
+  "catalog_version": "2026-08-08.1",
+  "operations": [
+    {
+      "operation_id": "exchange.diagnose_mailbox",
+      "title": "Diagnose mailbox",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "Inspect recipient, mailbox, store and folder state without mutation."
+    },
+    {
+      "operation_id": "exchange.get_mailbox_state",
+      "title": "Get mailbox state",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "Return normalized mailbox configuration and state."
+    },
+    {
+      "operation_id": "exchange.get_mailbox_folder_health",
+      "title": "Get mailbox folder health",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "Probe standard mailbox folders and report failures."
+    },
+    {
+      "operation_id": "exchange.get_mailbox_permissions",
+      "title": "Get mailbox permissions",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "List delegated mailbox permissions."
+    },
+    {
+      "operation_id": "exchange.test_delegated_access",
+      "title": "Test delegated access",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxAndDelegate",
+      "description": "Determine whether a delegate has effective FullAccess."
+    },
+    {
+      "operation_id": "exchange.grant_full_access",
+      "title": "Grant FullAccess",
+      "category": "exchange",
+      "mutation": true,
+      "approval_required": true,
+      "risk": "high",
+      "executor": "runbook.exchange",
+      "parameter_schema": "FullAccessChange",
+      "description": "Grant narrowly scoped FullAccess after explicit approval."
+    },
+    {
+      "operation_id": "exchange.revoke_full_access",
+      "title": "Revoke FullAccess",
+      "category": "exchange",
+      "mutation": true,
+      "approval_required": true,
+      "risk": "high",
+      "executor": "runbook.exchange",
+      "parameter_schema": "FullAccessChange",
+      "description": "Remove narrowly scoped FullAccess after explicit approval."
+    },
+    {
+      "operation_id": "exchange.get_shared_mailbox_configuration",
+      "title": "Get shared mailbox configuration",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "Read mailbox type, delivery and forwarding settings."
+    },
+    {
+      "operation_id": "exchange.check_forwarding",
+      "title": "Check mailbox forwarding",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "medium",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "Inspect forwarding configuration without changing it."
+    },
+    {
+      "operation_id": "exchange.verify_recipient_alignment",
+      "title": "Verify recipient alignment",
+      "category": "exchange",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "medium",
+      "executor": "runbook.exchange",
+      "parameter_schema": "MailboxTarget",
+      "description": "Compare Exchange recipient and mailbox identifiers."
+    },
+    {
+      "operation_id": "powershell.get_job_status",
+      "title": "Get runbook job status",
+      "category": "powershell",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "low",
+      "executor": "azure.automation",
+      "parameter_schema": "JobTarget",
+      "description": "Read the state of an approved runbook job."
+    },
+    {
+      "operation_id": "powershell.get_job_output",
+      "title": "Get runbook job output",
+      "category": "powershell",
+      "mutation": false,
+      "approval_required": false,
+      "risk": "medium",
+      "executor": "azure.automation",
+      "parameter_schema": "JobTarget",
+      "description": "Read sanitized output from an approved runbook job."
+    },
+    {
+      "operation_id": "powershell.cancel_job",
+      "title": "Cancel runbook job",
+      "category": "powershell",
+      "mutation": true,
+      "approval_required": true,
+      "risk": "medium",
+      "executor": "azure.automation",
+      "parameter_schema": "JobTarget",
+      "description": "Cancel an approved runbook job after explicit approval."
+    }
+  ]
+}

--- a/products/admin-gateway/docs/SECURITY.md
+++ b/products/admin-gateway/docs/SECURITY.md
@@ -9,6 +9,34 @@
 5. The reference executor returns `503 EXECUTOR_NOT_CONFIGURED` until a tenant adapter is configured.
 6. Arbitrary command text, script text, script paths and module names are not accepted by any API contract.
 7. Secrets are referenced externally and never stored in the operation catalog.
+8. Production identity is accepted only from the canonical EasyAuth client-principal header and must match the configured Entra tenant.
+9. Catalog, planning, read execution and DryRun require `Optimus.Reader`; live mutation additionally requires `Optimus.Mutator`.
+
+## Identity and authorization boundary
+
+Azure App Service EasyAuth is the production authentication boundary. The API
+decodes `X-MS-CLIENT-PRINCIPAL`, requires the `aad` provider, uses the immutable
+Entra object ID as the subject, compares the mapped tenant claim with
+`OPTIMUS_ENTRA_TENANT_ID`, and extracts roles only from the claim type named by
+`role_typ`.
+
+`X-MS-CLIENT-PRINCIPAL-ID`, `X-MS-CLIENT-PRINCIPAL-NAME` and
+`X-OPTIMUS-ROLES` are not authorization inputs. Local simulation uses only
+`X-OPTIMUS-DEV-PRINCIPAL` and `X-OPTIMUS-DEV-ROLES`, and only while
+`OPTIMUS_DEV_MODE=true`.
+
+The tenant deployment must configure EasyAuth to require authentication, use a
+tenant-specific issuer, restrict allowed token audiences and scopes, and ensure
+that clients cannot reach the application while bypassing EasyAuth. Decoding
+the injected header is not a substitute for cryptographic token validation. If
+that network and platform boundary cannot be guaranteed, the deployment must
+validate token signature, issuer and audience in the application instead.
+
+The application roles are additive:
+
+- `Optimus.Reader` permits catalog discovery, planning, read operations and DryRun.
+- `Optimus.Mutator` is additionally required for a mutation with `dry_run=false`.
+- `Optimus.Mutator` does not silently imply `Optimus.Reader`.
 
 ## Recommended tenant controls
 
@@ -19,7 +47,7 @@
 - Dataverse table permissions separating requester, approver and executor.
 - Conditional Access and named locations as appropriate to the tenant.
 - Private networking or access restrictions for the API where practical.
-- Separate read and mutation application roles.
+- Assign the separate `Optimus.Reader` and `Optimus.Mutator` application roles.
 
 ## Approval binding
 

--- a/products/admin-gateway/openapi/optimus-admin-gateway.openapi.yaml
+++ b/products/admin-gateway/openapi/optimus-admin-gateway.openapi.yaml
@@ -1,0 +1,105 @@
+openapi: 3.1.0
+info:
+  title: Optimus Admin Gateway
+  version: 0.1.0
+  description: Governed allowlisted administration API for HUB_Optimus
+paths:
+  /healthz:
+    get:
+      tags: [system]
+      summary: Healthz
+      operationId: healthz_healthz_get
+      responses:
+        '200':
+          description: Successful Response
+  /api/v1/operations:
+    get:
+      tags: [operations]
+      summary: List Operations
+      operationId: list_operations_api_v1_operations_get
+      responses:
+        '200':
+          description: Successful Response
+        '401':
+          description: Authenticated Entra principal required
+  /api/v1/operations/{operation_id}:plan:
+    post:
+      tags: [operations]
+      summary: Plan Operation
+      operationId: plan_operation_api_v1_operations__operation_id__plan_post
+      parameters:
+        - in: path
+          name: operation_id
+          required: true
+          schema: {type: string}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/OperationRequest'}
+      responses:
+        '200':
+          description: Validated deterministic operation plan
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/OperationPlan'}
+        '404': {description: Operation not found}
+        '422': {description: Parameter validation failed}
+  /api/v1/operations/{operation_id}:execute:
+    post:
+      tags: [operations]
+      summary: Execute Operation
+      operationId: execute_operation_api_v1_operations__operation_id__execute_post
+      parameters:
+        - in: path
+          name: operation_id
+          required: true
+          schema: {type: string}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/OperationRequest'}
+      responses:
+        '200': {description: DryRun or configured execution result}
+        '403': {description: Approval missing or invalid}
+        '503': {description: Tenant executor not configured}
+components:
+  schemas:
+    ApprovalReceipt:
+      type: object
+      additionalProperties: false
+      required: [approval_id, plan_hash, approved_by, approved_at, signature]
+      properties:
+        approval_id: {type: string, minLength: 8, maxLength: 128}
+        plan_hash: {type: string, pattern: '^[a-f0-9]{64}$'}
+        approved_by: {type: string, minLength: 1, maxLength: 256}
+        approved_at: {type: string, format: date-time}
+        signature: {type: string, minLength: 32, maxLength: 512}
+    OperationRequest:
+      type: object
+      additionalProperties: false
+      required: [parameters, idempotency_key]
+      properties:
+        parameters: {type: object, additionalProperties: true}
+        dry_run: {type: boolean, default: true}
+        idempotency_key: {type: string, minLength: 8, maxLength: 128}
+        approval:
+          oneOf:
+            - {$ref: '#/components/schemas/ApprovalReceipt'}
+            - {type: 'null'}
+    OperationPlan:
+      type: object
+      additionalProperties: false
+      required: [operation_id, title, mutation, approval_required, risk, dry_run, parameters, plan_hash, catalog_version, state]
+      properties:
+        operation_id: {type: string}
+        title: {type: string}
+        mutation: {type: boolean}
+        approval_required: {type: boolean}
+        risk: {type: string, enum: [low, medium, high]}
+        dry_run: {type: boolean}
+        parameters: {type: object, additionalProperties: true}
+        plan_hash: {type: string, pattern: '^[a-f0-9]{64}$'}
+        catalog_version: {type: string}
+        state: {type: string, enum: [PLANNED, APPROVAL_REQUIRED, QUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED]}

--- a/products/admin-gateway/openapi/optimus-admin-gateway.openapi.yaml
+++ b/products/admin-gateway/openapi/optimus-admin-gateway.openapi.yaml
@@ -17,16 +17,24 @@ paths:
       tags: [operations]
       summary: List Operations
       operationId: list_operations_api_v1_operations_get
+      security:
+        - EntraOAuth2: [access_as_user]
       responses:
         '200':
           description: Successful Response
         '401':
           description: Authenticated Entra principal required
+        '403':
+          description: Optimus.Reader role required
+        '503':
+          description: Entra tenant binding not configured
   /api/v1/operations/{operation_id}:plan:
     post:
       tags: [operations]
       summary: Plan Operation
       operationId: plan_operation_api_v1_operations__operation_id__plan_post
+      security:
+        - EntraOAuth2: [access_as_user]
       parameters:
         - in: path
           name: operation_id
@@ -43,13 +51,18 @@ paths:
           content:
             application/json:
               schema: {$ref: '#/components/schemas/OperationPlan'}
+        '401': {description: Authenticated Entra principal required}
+        '403': {description: Optimus.Reader role required}
         '404': {description: Operation not found}
+        '503': {description: Entra tenant binding not configured}
         '422': {description: Parameter validation failed}
   /api/v1/operations/{operation_id}:execute:
     post:
       tags: [operations]
       summary: Execute Operation
       operationId: execute_operation_api_v1_operations__operation_id__execute_post
+      security:
+        - EntraOAuth2: [access_as_user]
       parameters:
         - in: path
           name: operation_id
@@ -62,9 +75,20 @@ paths:
             schema: {$ref: '#/components/schemas/OperationRequest'}
       responses:
         '200': {description: DryRun or configured execution result}
-        '403': {description: Approval missing or invalid}
-        '503': {description: Tenant executor not configured}
+        '401': {description: Authenticated Entra principal required}
+        '403': {description: Required application role or approval missing or invalid}
+        '503': {description: Entra tenant binding or tenant executor not configured}
 components:
+  securitySchemes:
+    EntraOAuth2:
+      type: oauth2
+      description: Replace the tenant placeholder and bind the client-specific API audience before deployment.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://login.microsoftonline.com/REPLACE_WITH_TENANT_ID/oauth2/v2.0/authorize
+          tokenUrl: https://login.microsoftonline.com/REPLACE_WITH_TENANT_ID/oauth2/v2.0/token
+          scopes:
+            access_as_user: Request governed Admin Gateway operations as the signed-in principal.
   schemas:
     ApprovalReceipt:
       type: object

--- a/products/admin-gateway/pyproject.toml
+++ b/products/admin-gateway/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "optimus-admin-gateway"
+version = "0.1.0"
+description = "Governed administration gateway for HUB_Optimus"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.110,<1",
+  "pydantic>=2.6,<3",
+  "uvicorn>=0.29,<1"
+]
+
+[project.optional-dependencies]
+dev = [
+  "httpx>=0.27,<1",
+  "pytest>=8,<9",
+  "pytest-cov>=5,<7",
+  "PyYAML>=6,<7"
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/products/admin-gateway/pyproject.toml
+++ b/products/admin-gateway/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "httpx>=0.27,<1",
+  "httpx2>=2,<3",
   "pytest>=8,<9",
   "pytest-cov>=5,<7",
   "PyYAML>=6,<7"

--- a/products/admin-gateway/scripts/export-openapi.py
+++ b/products/admin-gateway/scripts/export-openapi.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from optimus_admin_gateway.main import app
+
+output = Path(__file__).parents[1] / "openapi" / "optimus-admin-gateway.openapi.json"
+output.write_text(json.dumps(app.openapi(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(output)

--- a/products/admin-gateway/src/optimus_admin_gateway/__init__.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/__init__.py
@@ -1,0 +1,3 @@
+"""Optimus Admin Gateway."""
+
+__version__ = "0.1.0"

--- a/products/admin-gateway/src/optimus_admin_gateway/approvals.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/approvals.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+from datetime import datetime, timezone
+
+from .models import ApprovalReceipt
+
+
+class ApprovalVerifier:
+    def __init__(self, secret: str | None):
+        self._secret = secret.encode("utf-8") if secret else None
+
+    @property
+    def configured(self) -> bool:
+        return self._secret is not None
+
+    def verify(self, receipt: ApprovalReceipt, expected_plan_hash: str) -> bool:
+        if self._secret is None or receipt.plan_hash != expected_plan_hash:
+            return False
+        if receipt.approved_at > datetime.now(timezone.utc):
+            return False
+        material = "|".join(
+            [receipt.approval_id, receipt.plan_hash, receipt.approved_by, receipt.approved_at.isoformat()]
+        ).encode("utf-8")
+        expected = hmac.new(self._secret, material, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, receipt.signature)

--- a/products/admin-gateway/src/optimus_admin_gateway/auth.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/auth.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import Header, HTTPException, status
+
+from .config import Settings
+from .models import Principal
+
+
+def build_principal_dependency(settings: Settings):
+    async def get_principal(
+        x_ms_client_principal_id: str | None = Header(default=None),
+        x_ms_client_principal_name: str | None = Header(default=None),
+        x_optimus_roles: str | None = Header(default=None),
+        x_optimus_dev_principal: str | None = Header(default=None),
+    ) -> Principal:
+        if x_ms_client_principal_id:
+            roles = {role.strip() for role in (x_optimus_roles or "").split(",") if role.strip()}
+            return Principal(
+                subject_id=x_ms_client_principal_id,
+                display_name=x_ms_client_principal_name,
+                roles=roles,
+            )
+        if settings.dev_mode and x_optimus_dev_principal:
+            roles = {role.strip() for role in (x_optimus_roles or "").split(",") if role.strip()}
+            return Principal(subject_id=x_optimus_dev_principal, display_name="Local developer", roles=roles)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "AUTH_REQUIRED", "message": "Authenticated Entra principal required"},
+        )
+
+    return get_principal

--- a/products/admin-gateway/src/optimus_admin_gateway/auth.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/auth.py
@@ -1,27 +1,191 @@
 from __future__ import annotations
 
+import base64
+import binascii
+import json
+from typing import Any
+from uuid import UUID
+
 from fastapi import Header, HTTPException, status
+from pydantic import ValidationError
 
 from .config import Settings
 from .models import Principal
 
+AAD_AUTH_TYPE = "aad"
+OBJECT_ID_CLAIM_TYPES = frozenset(
+    {
+        "oid",
+        "http://schemas.microsoft.com/identity/claims/objectidentifier",
+    }
+)
+TENANT_ID_CLAIM_TYPES = frozenset(
+    {
+        "tid",
+        "http://schemas.microsoft.com/identity/claims/tenantid",
+    }
+)
+ROLE_CLAIM_TYPES = frozenset(
+    {
+        "roles",
+        "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+    }
+)
+MAX_PRINCIPAL_HEADER_BYTES = 32_768
+MAX_CLAIMS = 256
+
+
+class _DuplicateJsonKey(ValueError):
+    pass
+
+
+def _reject_auth(code: str, message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail={"code": code, "message": message},
+    )
+
+
+def _load_unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKey(key)
+        result[key] = value
+    return result
+
+
+def _single_claim(
+    claims: list[tuple[str, str]],
+    claim_types: frozenset[str],
+    *,
+    required: bool,
+    label: str,
+) -> str | None:
+    values = [value for claim_type, value in claims if claim_type in claim_types]
+    if not values and not required:
+        return None
+    if len(values) != 1:
+        raise _reject_auth("AUTH_INVALID", f"EasyAuth principal must contain one unambiguous {label} claim")
+    return values[0]
+
+
+def _normalize_uuid(value: str, *, code: str, message: str) -> str:
+    try:
+        return str(UUID(value))
+    except (ValueError, AttributeError) as exc:
+        raise _reject_auth(code, message) from exc
+
+
+def _normalize_configured_tenant(value: str) -> str:
+    try:
+        return str(UUID(value))
+    except (ValueError, AttributeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "AUTH_NOT_CONFIGURED",
+                "message": "Configured Entra tenant ID is invalid",
+            },
+        ) from exc
+
+
+def parse_easyauth_principal(encoded_principal: str, expected_tenant_id: str) -> Principal:
+    if not encoded_principal or len(encoded_principal) > MAX_PRINCIPAL_HEADER_BYTES:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth principal header is missing or too large")
+
+    try:
+        decoded = base64.b64decode(encoded_principal, validate=True)
+        payload = json.loads(decoded.decode("utf-8"), object_pairs_hook=_load_unique_object)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKey) as exc:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth principal header is malformed") from exc
+
+    if not isinstance(payload, dict):
+        raise _reject_auth("AUTH_INVALID", "EasyAuth principal payload must be an object")
+    if payload.get("auth_typ") != AAD_AUTH_TYPE:
+        raise _reject_auth("AUTH_INVALID", "Microsoft Entra authentication is required")
+
+    role_type = payload.get("role_typ")
+    name_type = payload.get("name_typ")
+    raw_claims = payload.get("claims")
+    if not isinstance(role_type, str) or not role_type:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth role claim type is missing")
+    if role_type not in ROLE_CLAIM_TYPES:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth role claim type is not recognized")
+    if not isinstance(name_type, str) or not name_type:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth name claim type is missing")
+    if not isinstance(raw_claims, list) or len(raw_claims) > MAX_CLAIMS:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth claims must be a bounded array")
+
+    claims: list[tuple[str, str]] = []
+    for claim in raw_claims:
+        if not isinstance(claim, dict) or set(claim) != {"typ", "val"}:
+            raise _reject_auth("AUTH_INVALID", "EasyAuth claim shape is invalid")
+        claim_type = claim.get("typ")
+        claim_value = claim.get("val")
+        if not isinstance(claim_type, str) or not claim_type or not isinstance(claim_value, str) or not claim_value:
+            raise _reject_auth("AUTH_INVALID", "EasyAuth claim values must be non-empty strings")
+        claims.append((claim_type, claim_value))
+
+    subject_id = _single_claim(
+        claims,
+        OBJECT_ID_CLAIM_TYPES,
+        required=True,
+        label="object ID",
+    )
+    tenant_id = _single_claim(
+        claims,
+        TENANT_ID_CLAIM_TYPES,
+        required=True,
+        label="tenant ID",
+    )
+    if subject_id is None or tenant_id is None:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth identity claims are missing")
+    normalized_subject = _normalize_uuid(
+        subject_id,
+        code="AUTH_INVALID",
+        message="EasyAuth object ID claim is invalid",
+    )
+    normalized_tenant = _normalize_uuid(
+        tenant_id,
+        code="AUTH_INVALID",
+        message="EasyAuth tenant ID claim is invalid",
+    )
+    configured_tenant = _normalize_configured_tenant(expected_tenant_id)
+    if normalized_tenant != configured_tenant:
+        raise _reject_auth("TENANT_MISMATCH", "Authenticated principal belongs to a different tenant")
+
+    display_name = _single_claim(
+        claims,
+        frozenset({name_type}),
+        required=False,
+        label="display name",
+    )
+    roles = {value for claim_type, value in claims if claim_type == role_type}
+    try:
+        return Principal(subject_id=normalized_subject, display_name=display_name, roles=roles)
+    except ValidationError as exc:
+        raise _reject_auth("AUTH_INVALID", "EasyAuth principal claims are invalid") from exc
+
 
 def build_principal_dependency(settings: Settings):
     async def get_principal(
-        x_ms_client_principal_id: str | None = Header(default=None),
-        x_ms_client_principal_name: str | None = Header(default=None),
-        x_optimus_roles: str | None = Header(default=None),
-        x_optimus_dev_principal: str | None = Header(default=None),
+        x_ms_client_principal: str | None = Header(default=None, include_in_schema=False),
+        x_optimus_dev_principal: str | None = Header(default=None, include_in_schema=False),
+        x_optimus_dev_roles: str | None = Header(default=None, include_in_schema=False),
     ) -> Principal:
-        if x_ms_client_principal_id:
-            roles = {role.strip() for role in (x_optimus_roles or "").split(",") if role.strip()}
-            return Principal(
-                subject_id=x_ms_client_principal_id,
-                display_name=x_ms_client_principal_name,
-                roles=roles,
-            )
+        if x_ms_client_principal:
+            if settings.entra_tenant_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail={
+                        "code": "AUTH_NOT_CONFIGURED",
+                        "message": "Entra tenant binding is not configured",
+                    },
+                )
+            return parse_easyauth_principal(x_ms_client_principal, settings.entra_tenant_id)
         if settings.dev_mode and x_optimus_dev_principal:
-            roles = {role.strip() for role in (x_optimus_roles or "").split(",") if role.strip()}
+            roles = {role.strip() for role in (x_optimus_dev_roles or "").split(",") if role.strip()}
             return Principal(subject_id=x_optimus_dev_principal, display_name="Local developer", roles=roles)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/products/admin-gateway/src/optimus_admin_gateway/catalog.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/catalog.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import OperationDefinition, PARAMETER_MODELS, StrictModel
+
+
+class CatalogDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    catalog_version: str = Field(min_length=1)
+    operations: list[OperationDefinition]
+
+
+class OperationCatalog:
+    def __init__(self, document: CatalogDocument):
+        self.version = document.catalog_version
+        self._operations = {item.operation_id: item for item in document.operations}
+        if len(self._operations) != len(document.operations):
+            raise ValueError("duplicate operation_id in catalog")
+        for item in document.operations:
+            if item.parameter_schema not in PARAMETER_MODELS:
+                raise ValueError(f"unknown parameter schema: {item.parameter_schema}")
+
+    @classmethod
+    def load(cls, path: Path) -> "OperationCatalog":
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return cls(CatalogDocument.model_validate(raw))
+
+    def list(self) -> list[OperationDefinition]:
+        return sorted(self._operations.values(), key=lambda item: item.operation_id)
+
+    def get(self, operation_id: str) -> OperationDefinition | None:
+        return self._operations.get(operation_id)
+
+    def validate_parameters(self, definition: OperationDefinition, parameters: dict) -> StrictModel:
+        model_type = PARAMETER_MODELS[definition.parameter_schema]
+        return model_type.model_validate(parameters)

--- a/products/admin-gateway/src/optimus_admin_gateway/config.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Settings:
+    dev_mode: bool
+    catalog_path: Path
+    executor_mode: str
+    approval_hmac_secret: str | None
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        package_root = Path(__file__).resolve().parents[2]
+        default_catalog = package_root / "config" / "operations.catalog.json"
+        return cls(
+            dev_mode=os.getenv("OPTIMUS_DEV_MODE", "false").lower() == "true",
+            catalog_path=Path(os.getenv("OPTIMUS_OPERATION_CATALOG", default_catalog)),
+            executor_mode=os.getenv("OPTIMUS_EXECUTOR_MODE", "disabled"),
+            approval_hmac_secret=os.getenv("OPTIMUS_APPROVAL_HMAC_SECRET") or None,
+        )

--- a/products/admin-gateway/src/optimus_admin_gateway/config.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/config.py
@@ -11,6 +11,15 @@ class Settings:
     catalog_path: Path
     executor_mode: str
     approval_hmac_secret: str | None
+    entra_tenant_id: str | None
+    reader_role: str
+    mutator_role: str
+
+    def __post_init__(self) -> None:
+        if not self.reader_role or not self.mutator_role:
+            raise ValueError("Admin Gateway application roles must be non-empty")
+        if self.reader_role == self.mutator_role:
+            raise ValueError("Read and mutation application roles must remain separate")
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -21,4 +30,7 @@ class Settings:
             catalog_path=Path(os.getenv("OPTIMUS_OPERATION_CATALOG", default_catalog)),
             executor_mode=os.getenv("OPTIMUS_EXECUTOR_MODE", "disabled"),
             approval_hmac_secret=os.getenv("OPTIMUS_APPROVAL_HMAC_SECRET") or None,
+            entra_tenant_id=os.getenv("OPTIMUS_ENTRA_TENANT_ID") or None,
+            reader_role=os.getenv("OPTIMUS_READER_ROLE", "Optimus.Reader"),
+            mutator_role=os.getenv("OPTIMUS_MUTATOR_ROLE", "Optimus.Mutator"),
         )

--- a/products/admin-gateway/src/optimus_admin_gateway/executors.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/executors.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from .models import ExecutionResult, JobState, OperationDefinition, OperationPlan, Principal
+
+
+@dataclass(frozen=True)
+class ExecutorContext:
+    principal: Principal
+    definition: OperationDefinition
+    plan: OperationPlan
+    idempotency_key: str
+
+
+class ExecutorUnavailable(RuntimeError):
+    pass
+
+
+class OperationExecutor:
+    def __init__(self, mode: str):
+        self._mode = mode
+
+    async def execute(self, context: ExecutorContext) -> ExecutionResult:
+        if context.plan.dry_run:
+            return ExecutionResult(
+                job_id=f"dryrun-{uuid.uuid4()}",
+                operation_id=context.definition.operation_id,
+                state=JobState.planned,
+                dry_run=True,
+                plan_hash=context.plan.plan_hash,
+                message="DryRun completed; no external action was executed",
+                output={"validated_parameters": context.plan.parameters},
+            )
+        if self._mode == "disabled":
+            raise ExecutorUnavailable("No tenant execution adapter is configured")
+        raise ExecutorUnavailable(f"Unsupported executor mode: {self._mode}")

--- a/products/admin-gateway/src/optimus_admin_gateway/main.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/main.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from pydantic import ValidationError
+
+from .approvals import ApprovalVerifier
+from .auth import build_principal_dependency
+from .catalog import OperationCatalog
+from .config import Settings
+from .executors import ExecutorContext, ExecutorUnavailable, OperationExecutor
+from .models import (
+    JobState,
+    OperationPlan,
+    OperationRequest,
+    Principal,
+    canonical_plan_hash,
+)
+
+settings = Settings.from_env()
+catalog = OperationCatalog.load(settings.catalog_path)
+approvals = ApprovalVerifier(settings.approval_hmac_secret)
+executor = OperationExecutor(settings.executor_mode)
+get_principal = build_principal_dependency(settings)
+
+app = FastAPI(
+    title="Optimus Admin Gateway",
+    version="0.1.0",
+    description="Governed allowlisted administration API for HUB_Optimus",
+)
+
+
+def build_plan(operation_id: str, request: OperationRequest) -> tuple[OperationPlan, object]:
+    definition = catalog.get(operation_id)
+    if definition is None:
+        raise HTTPException(status_code=404, detail={"code": "OPERATION_NOT_FOUND"})
+    try:
+        validated = catalog.validate_parameters(definition, request.parameters)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={"code": "PARAMETER_VALIDATION_FAILED", "errors": exc.errors()},
+        ) from exc
+    normalized = validated.model_dump(mode="json")
+    payload = {
+        "operation_id": definition.operation_id,
+        "parameters": normalized,
+        "mutation": definition.mutation,
+        "risk": definition.risk.value,
+        "dry_run": request.dry_run,
+        "catalog_version": catalog.version,
+    }
+    plan_hash = canonical_plan_hash(payload)
+    state = JobState.approval_required if definition.mutation and not request.dry_run else JobState.planned
+    return (
+        OperationPlan(
+            operation_id=definition.operation_id,
+            title=definition.title,
+            mutation=definition.mutation,
+            approval_required=definition.approval_required,
+            risk=definition.risk,
+            dry_run=request.dry_run,
+            parameters=normalized,
+            plan_hash=plan_hash,
+            catalog_version=catalog.version,
+            state=state,
+        ),
+        definition,
+    )
+
+
+@app.get("/healthz", tags=["system"])
+async def healthz() -> dict[str, str]:
+    return {"status": "ok", "catalog_version": catalog.version, "executor_mode": settings.executor_mode}
+
+
+@app.get("/api/v1/operations", tags=["operations"])
+async def list_operations(principal: Principal = Depends(get_principal)) -> dict:
+    return {
+        "principal": principal.subject_id,
+        "catalog_version": catalog.version,
+        "operations": [item.model_dump(mode="json") for item in catalog.list()],
+    }
+
+
+@app.post("/api/v1/operations/{operation_id}:plan", response_model=OperationPlan, tags=["operations"])
+async def plan_operation(
+    operation_id: str,
+    request: OperationRequest,
+    principal: Principal = Depends(get_principal),
+) -> OperationPlan:
+    del principal
+    plan, _definition = build_plan(operation_id, request)
+    return plan
+
+
+@app.post("/api/v1/operations/{operation_id}:execute", tags=["operations"])
+async def execute_operation(
+    operation_id: str,
+    request: OperationRequest,
+    principal: Principal = Depends(get_principal),
+):
+    plan, definition = build_plan(operation_id, request)
+    if definition.mutation and not request.dry_run:
+        if request.approval is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"code": "APPROVAL_REQUIRED", "plan_hash": plan.plan_hash},
+            )
+        if not approvals.verify(request.approval, plan.plan_hash):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"code": "APPROVAL_INVALID", "plan_hash": plan.plan_hash},
+            )
+    try:
+        result = await executor.execute(
+            ExecutorContext(
+                principal=principal,
+                definition=definition,
+                plan=plan,
+                idempotency_key=request.idempotency_key,
+            )
+        )
+    except ExecutorUnavailable as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "EXECUTOR_NOT_CONFIGURED", "message": str(exc), "plan_hash": plan.plan_hash},
+        ) from exc
+    return result

--- a/products/admin-gateway/src/optimus_admin_gateway/main.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/main.py
@@ -29,6 +29,14 @@ app = FastAPI(
 )
 
 
+def require_role(principal: Principal, role: str) -> None:
+    if role not in principal.roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "ROLE_REQUIRED", "required_role": role},
+        )
+
+
 def build_plan(operation_id: str, request: OperationRequest) -> tuple[OperationPlan, object]:
     definition = catalog.get(operation_id)
     if definition is None:
@@ -75,6 +83,7 @@ async def healthz() -> dict[str, str]:
 
 @app.get("/api/v1/operations", tags=["operations"])
 async def list_operations(principal: Principal = Depends(get_principal)) -> dict:
+    require_role(principal, settings.reader_role)
     return {
         "principal": principal.subject_id,
         "catalog_version": catalog.version,
@@ -88,7 +97,7 @@ async def plan_operation(
     request: OperationRequest,
     principal: Principal = Depends(get_principal),
 ) -> OperationPlan:
-    del principal
+    require_role(principal, settings.reader_role)
     plan, _definition = build_plan(operation_id, request)
     return plan
 
@@ -99,8 +108,10 @@ async def execute_operation(
     request: OperationRequest,
     principal: Principal = Depends(get_principal),
 ):
+    require_role(principal, settings.reader_role)
     plan, definition = build_plan(operation_id, request)
     if definition.mutation and not request.dry_run:
+        require_role(principal, settings.mutator_role)
         if request.approval is None:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/products/admin-gateway/src/optimus_admin_gateway/models.py
+++ b/products/admin-gateway/src/optimus_admin_gateway/models.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+MAILBOX_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+SAFE_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class RiskLevel(StrEnum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+class JobState(StrEnum):
+    planned = "PLANNED"
+    approval_required = "APPROVAL_REQUIRED"
+    queued = "QUEUED"
+    running = "RUNNING"
+    succeeded = "SUCCEEDED"
+    failed = "FAILED"
+    cancelled = "CANCELLED"
+
+
+class Principal(StrictModel):
+    subject_id: str = Field(min_length=1, max_length=128)
+    display_name: str | None = Field(default=None, max_length=256)
+    roles: set[str] = Field(default_factory=set)
+
+
+class OperationDefinition(StrictModel):
+    operation_id: str
+    title: str
+    category: Literal["exchange", "powershell"]
+    mutation: bool
+    approval_required: bool
+    risk: RiskLevel
+    executor: str
+    parameter_schema: str
+    description: str
+
+    @field_validator("operation_id", "executor", "parameter_schema")
+    @classmethod
+    def validate_safe_id(cls, value: str) -> str:
+        if not SAFE_ID_PATTERN.fullmatch(value):
+            raise ValueError("must be an allowlisted identifier")
+        return value
+
+    @model_validator(mode="after")
+    def mutation_requires_approval(self) -> "OperationDefinition":
+        if self.mutation and not self.approval_required:
+            raise ValueError("mutation operations must require approval")
+        return self
+
+
+class MailboxTarget(StrictModel):
+    mailbox: str = Field(min_length=3, max_length=320)
+
+    @field_validator("mailbox")
+    @classmethod
+    def validate_mailbox(cls, value: str) -> str:
+        if not MAILBOX_PATTERN.fullmatch(value):
+            raise ValueError("must be a mailbox SMTP address")
+        return value.lower()
+
+
+class MailboxAndDelegate(MailboxTarget):
+    delegate: str = Field(min_length=3, max_length=320)
+
+    @field_validator("delegate")
+    @classmethod
+    def validate_delegate(cls, value: str) -> str:
+        if not MAILBOX_PATTERN.fullmatch(value):
+            raise ValueError("must be a delegate SMTP address")
+        return value.lower()
+
+
+class FullAccessChange(MailboxAndDelegate):
+    automapping: bool = False
+    reason: str = Field(min_length=8, max_length=500)
+    change_ticket: str = Field(min_length=3, max_length=128)
+
+
+class JobTarget(StrictModel):
+    job_id: str = Field(min_length=8, max_length=128)
+
+    @field_validator("job_id")
+    @classmethod
+    def validate_job_id(cls, value: str) -> str:
+        if not SAFE_ID_PATTERN.fullmatch(value):
+            raise ValueError("invalid job identifier")
+        return value
+
+
+PARAMETER_MODELS: dict[str, type[StrictModel]] = {
+    "MailboxTarget": MailboxTarget,
+    "MailboxAndDelegate": MailboxAndDelegate,
+    "FullAccessChange": FullAccessChange,
+    "JobTarget": JobTarget,
+}
+
+
+class ApprovalReceipt(StrictModel):
+    approval_id: str = Field(min_length=8, max_length=128)
+    plan_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    approved_by: str = Field(min_length=1, max_length=256)
+    approved_at: datetime
+    signature: str = Field(min_length=32, max_length=512)
+
+    @field_validator("approved_at")
+    @classmethod
+    def timezone_required(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("approved_at must include a timezone")
+        return value.astimezone(timezone.utc)
+
+
+class OperationRequest(StrictModel):
+    parameters: dict[str, Any]
+    dry_run: bool = True
+    idempotency_key: str = Field(min_length=8, max_length=128)
+    approval: ApprovalReceipt | None = None
+
+    @field_validator("idempotency_key")
+    @classmethod
+    def validate_idempotency_key(cls, value: str) -> str:
+        if not SAFE_ID_PATTERN.fullmatch(value):
+            raise ValueError("invalid idempotency key")
+        return value
+
+
+class OperationPlan(StrictModel):
+    operation_id: str
+    title: str
+    mutation: bool
+    approval_required: bool
+    risk: RiskLevel
+    dry_run: bool
+    parameters: dict[str, Any]
+    plan_hash: str
+    catalog_version: str
+    state: JobState
+
+
+class ExecutionResult(StrictModel):
+    job_id: str
+    operation_id: str
+    state: JobState
+    dry_run: bool
+    plan_hash: str
+    message: str
+    output: dict[str, Any] = Field(default_factory=dict)
+
+
+def canonical_plan_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/products/admin-gateway/tests/conftest.py
+++ b/products/admin-gateway/tests/conftest.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OPTIMUS_DEV_MODE", "true")
+os.environ.setdefault("OPTIMUS_EXECUTOR_MODE", "disabled")

--- a/products/admin-gateway/tests/conftest.py
+++ b/products/admin-gateway/tests/conftest.py
@@ -20,3 +20,16 @@ _REQUIRED_RUNTIME = ("fastapi", "httpx", "httpx2", "pydantic")
 collect_ignore: list[str] = []
 if any(importlib.util.find_spec(module_name) is None for module_name in _REQUIRED_RUNTIME):
     collect_ignore.extend(["test_api.py", "test_auth.py", "test_catalog.py"])
+
+
+def pytest_configure(config) -> None:
+    """Fail on the TestClient fallback warning when this Starlette exposes it."""
+    if importlib.util.find_spec("starlette") is None:
+        return
+    from starlette import exceptions as starlette_exceptions
+
+    if getattr(starlette_exceptions, "StarletteDeprecationWarning", None) is not None:
+        config.addinivalue_line(
+            "filterwarnings",
+            "error::starlette.exceptions.StarletteDeprecationWarning",
+        )

--- a/products/admin-gateway/tests/conftest.py
+++ b/products/admin-gateway/tests/conftest.py
@@ -16,7 +16,7 @@ PACKAGE_ROOT = Path(__file__).parents[1]
 SRC_ROOT = PACKAGE_ROOT / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
-_REQUIRED_RUNTIME = ("fastapi", "httpx", "pydantic")
+_REQUIRED_RUNTIME = ("fastapi", "httpx", "httpx2", "pydantic")
 collect_ignore: list[str] = []
 if any(importlib.util.find_spec(module_name) is None for module_name in _REQUIRED_RUNTIME):
     collect_ignore.extend(["test_api.py", "test_auth.py", "test_catalog.py"])

--- a/products/admin-gateway/tests/conftest.py
+++ b/products/admin-gateway/tests/conftest.py
@@ -1,6 +1,22 @@
 from __future__ import annotations
 
+import importlib.util
 import os
+import sys
+from pathlib import Path
 
 os.environ.setdefault("OPTIMUS_DEV_MODE", "true")
 os.environ.setdefault("OPTIMUS_EXECUTOR_MODE", "disabled")
+os.environ.setdefault("OPTIMUS_ENTRA_TENANT_ID", "11111111-1111-4111-8111-111111111111")
+
+# The repository-wide CI installs only the root dependency set. Keep the
+# product suite isolated there; the product workflow installs this package and
+# executes every API and authentication test with its own dependency contract.
+PACKAGE_ROOT = Path(__file__).parents[1]
+SRC_ROOT = PACKAGE_ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
+_REQUIRED_RUNTIME = ("fastapi", "httpx", "pydantic")
+collect_ignore: list[str] = []
+if any(importlib.util.find_spec(module_name) is None for module_name in _REQUIRED_RUNTIME):
+    collect_ignore.extend(["test_api.py", "test_auth.py", "test_catalog.py"])

--- a/products/admin-gateway/tests/test_api.py
+++ b/products/admin-gateway/tests/test_api.py
@@ -1,0 +1,74 @@
+from fastapi.testclient import TestClient
+
+from optimus_admin_gateway.main import app
+
+client = TestClient(app)
+HEADERS = {"x-optimus-dev-principal": "test-user", "x-optimus-roles": "Optimus.Reader"}
+
+
+def test_health_is_public_and_safe() -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json()["executor_mode"] == "disabled"
+
+
+def test_operations_require_identity() -> None:
+    response = client.get("/api/v1/operations")
+    assert response.status_code == 401
+
+
+def test_read_operation_dry_run() -> None:
+    body = {
+        "parameters": {"mailbox": "pilot@example.com"},
+        "dry_run": True,
+        "idempotency_key": "test-read-0001"
+    }
+    plan = client.post("/api/v1/operations/exchange.diagnose_mailbox:plan", json=body, headers=HEADERS)
+    assert plan.status_code == 200
+    assert plan.json()["state"] == "PLANNED"
+    execute = client.post("/api/v1/operations/exchange.diagnose_mailbox:execute", json=body, headers=HEADERS)
+    assert execute.status_code == 200
+    assert execute.json()["dry_run"] is True
+
+
+def test_mutation_defaults_to_dry_run() -> None:
+    body = {
+        "parameters": {
+            "mailbox": "pilot@example.com",
+            "delegate": "owner@example.com",
+            "automapping": False,
+            "reason": "Restore delegated administrative access",
+            "change_ticket": "CHG-0001"
+        },
+        "idempotency_key": "test-mutate-0001"
+    }
+    response = client.post("/api/v1/operations/exchange.grant_full_access:execute", json=body, headers=HEADERS)
+    assert response.status_code == 200
+    assert response.json()["state"] == "PLANNED"
+
+
+def test_live_mutation_without_approval_is_rejected() -> None:
+    body = {
+        "parameters": {
+            "mailbox": "pilot@example.com",
+            "delegate": "owner@example.com",
+            "automapping": False,
+            "reason": "Restore delegated administrative access",
+            "change_ticket": "CHG-0002"
+        },
+        "dry_run": False,
+        "idempotency_key": "test-mutate-0002"
+    }
+    response = client.post("/api/v1/operations/exchange.grant_full_access:execute", json=body, headers=HEADERS)
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "APPROVAL_REQUIRED"
+
+
+def test_unknown_fields_are_rejected() -> None:
+    body = {
+        "parameters": {"mailbox": "pilot@example.com", "command": "Get-Anything"},
+        "dry_run": True,
+        "idempotency_key": "test-invalid-0001"
+    }
+    response = client.post("/api/v1/operations/exchange.diagnose_mailbox:plan", json=body, headers=HEADERS)
+    assert response.status_code == 422

--- a/products/admin-gateway/tests/test_api.py
+++ b/products/admin-gateway/tests/test_api.py
@@ -1,9 +1,41 @@
+import base64
+import json
+
 from fastapi.testclient import TestClient
 
 from optimus_admin_gateway.main import app
 
 client = TestClient(app)
-HEADERS = {"x-optimus-dev-principal": "test-user", "x-optimus-roles": "Optimus.Reader"}
+READER_HEADERS = {
+    "x-optimus-dev-principal": "test-user",
+    "x-optimus-dev-roles": "Optimus.Reader",
+}
+TENANT_ID = "11111111-1111-4111-8111-111111111111"
+SUBJECT_ID = "33333333-3333-4333-8333-333333333333"
+OID_CLAIM = "http://schemas.microsoft.com/identity/claims/objectidentifier"
+TENANT_CLAIM = "http://schemas.microsoft.com/identity/claims/tenantid"
+NAME_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+ROLE_CLAIM = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+
+
+def easyauth_headers(*roles: str) -> dict[str, str]:
+    payload = {
+        "auth_typ": "aad",
+        "claims": [
+            {"typ": OID_CLAIM, "val": SUBJECT_ID},
+            {"typ": TENANT_CLAIM, "val": TENANT_ID},
+            {"typ": NAME_CLAIM, "val": "Integrated test principal"},
+            *({"typ": ROLE_CLAIM, "val": role} for role in roles),
+        ],
+        "name_typ": NAME_CLAIM,
+        "role_typ": ROLE_CLAIM,
+    }
+    encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+    return {"x-ms-client-principal": encoded}
+
+
+PRODUCTION_READER_HEADERS = easyauth_headers("Optimus.Reader")
+PRODUCTION_MUTATOR_HEADERS = easyauth_headers("Optimus.Reader", "Optimus.Mutator")
 
 
 def test_health_is_public_and_safe() -> None:
@@ -12,9 +44,39 @@ def test_health_is_public_and_safe() -> None:
     assert response.json()["executor_mode"] == "disabled"
 
 
+def test_internal_identity_headers_are_not_exposed_in_generated_openapi() -> None:
+    schema = json.dumps(app.openapi()).lower()
+    assert "x-ms-client-principal" not in schema
+    assert "x-optimus-dev-principal" not in schema
+    assert "x-optimus-dev-roles" not in schema
+
+
 def test_operations_require_identity() -> None:
     response = client.get("/api/v1/operations")
     assert response.status_code == 401
+
+
+def test_operations_require_reader_role() -> None:
+    response = client.get(
+        "/api/v1/operations",
+        headers={"x-optimus-dev-principal": "test-user"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == {
+        "code": "ROLE_REQUIRED",
+        "required_role": "Optimus.Reader",
+    }
+
+
+def test_legacy_role_header_is_not_trusted_in_dev_mode() -> None:
+    response = client.get(
+        "/api/v1/operations",
+        headers={
+            "x-optimus-dev-principal": "test-user",
+            "x-optimus-roles": "Optimus.Reader",
+        },
+    )
+    assert response.status_code == 403
 
 
 def test_read_operation_dry_run() -> None:
@@ -23,10 +85,18 @@ def test_read_operation_dry_run() -> None:
         "dry_run": True,
         "idempotency_key": "test-read-0001"
     }
-    plan = client.post("/api/v1/operations/exchange.diagnose_mailbox:plan", json=body, headers=HEADERS)
+    plan = client.post(
+        "/api/v1/operations/exchange.diagnose_mailbox:plan",
+        json=body,
+        headers=PRODUCTION_READER_HEADERS,
+    )
     assert plan.status_code == 200
     assert plan.json()["state"] == "PLANNED"
-    execute = client.post("/api/v1/operations/exchange.diagnose_mailbox:execute", json=body, headers=HEADERS)
+    execute = client.post(
+        "/api/v1/operations/exchange.diagnose_mailbox:execute",
+        json=body,
+        headers=PRODUCTION_READER_HEADERS,
+    )
     assert execute.status_code == 200
     assert execute.json()["dry_run"] is True
 
@@ -42,12 +112,16 @@ def test_mutation_defaults_to_dry_run() -> None:
         },
         "idempotency_key": "test-mutate-0001"
     }
-    response = client.post("/api/v1/operations/exchange.grant_full_access:execute", json=body, headers=HEADERS)
+    response = client.post(
+        "/api/v1/operations/exchange.grant_full_access:execute",
+        json=body,
+        headers=PRODUCTION_READER_HEADERS,
+    )
     assert response.status_code == 200
     assert response.json()["state"] == "PLANNED"
 
 
-def test_live_mutation_without_approval_is_rejected() -> None:
+def test_live_mutation_requires_mutator_role_before_approval() -> None:
     body = {
         "parameters": {
             "mailbox": "pilot@example.com",
@@ -59,7 +133,35 @@ def test_live_mutation_without_approval_is_rejected() -> None:
         "dry_run": False,
         "idempotency_key": "test-mutate-0002"
     }
-    response = client.post("/api/v1/operations/exchange.grant_full_access:execute", json=body, headers=HEADERS)
+    response = client.post(
+        "/api/v1/operations/exchange.grant_full_access:execute",
+        json=body,
+        headers=PRODUCTION_READER_HEADERS,
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == {
+        "code": "ROLE_REQUIRED",
+        "required_role": "Optimus.Mutator",
+    }
+
+
+def test_live_mutation_with_both_roles_reaches_approval_gate() -> None:
+    body = {
+        "parameters": {
+            "mailbox": "pilot@example.com",
+            "delegate": "owner@example.com",
+            "automapping": False,
+            "reason": "Restore delegated administrative access",
+            "change_ticket": "CHG-0003",
+        },
+        "dry_run": False,
+        "idempotency_key": "test-mutate-0003",
+    }
+    response = client.post(
+        "/api/v1/operations/exchange.grant_full_access:execute",
+        json=body,
+        headers=PRODUCTION_MUTATOR_HEADERS,
+    )
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "APPROVAL_REQUIRED"
 
@@ -70,5 +172,9 @@ def test_unknown_fields_are_rejected() -> None:
         "dry_run": True,
         "idempotency_key": "test-invalid-0001"
     }
-    response = client.post("/api/v1/operations/exchange.diagnose_mailbox:plan", json=body, headers=HEADERS)
+    response = client.post(
+        "/api/v1/operations/exchange.diagnose_mailbox:plan",
+        json=body,
+        headers=READER_HEADERS,
+    )
     assert response.status_code == 422

--- a/products/admin-gateway/tests/test_auth.py
+++ b/products/admin-gateway/tests/test_auth.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import base64
 import json
+import warnings
 from pathlib import Path
 
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
+from starlette import exceptions as starlette_exceptions
 
 from optimus_admin_gateway.auth import build_principal_dependency
 from optimus_admin_gateway.config import Settings
@@ -237,3 +239,11 @@ def test_reader_and_mutator_roles_cannot_collapse() -> None:
             reader_role="Optimus.Reader",
             mutator_role="Optimus.Reader",
         )
+
+
+def test_testclient_deprecation_is_fatal_when_available() -> None:
+    warning_type = getattr(starlette_exceptions, "StarletteDeprecationWarning", None)
+    if warning_type is None:
+        pytest.skip("This supported Starlette version predates the TestClient warning type")
+    with pytest.raises(warning_type):
+        warnings.warn("warning policy probe", warning_type, stacklevel=1)

--- a/products/admin-gateway/tests/test_auth.py
+++ b/products/admin-gateway/tests/test_auth.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from optimus_admin_gateway.auth import build_principal_dependency
+from optimus_admin_gateway.config import Settings
+from optimus_admin_gateway.models import Principal
+
+TENANT_ID = "11111111-1111-4111-8111-111111111111"
+OTHER_TENANT_ID = "22222222-2222-4222-8222-222222222222"
+SUBJECT_ID = "33333333-3333-4333-8333-333333333333"
+OID_CLAIM = "http://schemas.microsoft.com/identity/claims/objectidentifier"
+TENANT_CLAIM = "http://schemas.microsoft.com/identity/claims/tenantid"
+NAME_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+ROLE_CLAIM = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+
+
+def make_settings(*, dev_mode: bool = False, tenant_id: str | None = TENANT_ID) -> Settings:
+    return Settings(
+        dev_mode=dev_mode,
+        catalog_path=Path("unused.json"),
+        executor_mode="disabled",
+        approval_hmac_secret=None,
+        entra_tenant_id=tenant_id,
+        reader_role="Optimus.Reader",
+        mutator_role="Optimus.Mutator",
+    )
+
+
+def encode_principal(
+    *,
+    tenant_id: str = TENANT_ID,
+    auth_type: str = "aad",
+    roles: tuple[str, ...] = ("Optimus.Reader",),
+    extra_claims: tuple[dict[str, str], ...] = (),
+    role_type: str = ROLE_CLAIM,
+) -> str:
+    claims = [
+        {"typ": OID_CLAIM, "val": SUBJECT_ID},
+        {"typ": TENANT_CLAIM, "val": tenant_id},
+        {"typ": NAME_CLAIM, "val": "Test principal"},
+        *({"typ": role_type, "val": role} for role in roles),
+        *extra_claims,
+    ]
+    payload = {
+        "auth_typ": auth_type,
+        "claims": claims,
+        "name_typ": NAME_CLAIM,
+        "role_typ": role_type,
+    }
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+
+def make_client(settings: Settings) -> TestClient:
+    test_app = FastAPI()
+    get_principal = build_principal_dependency(settings)
+
+    @test_app.get("/principal")
+    async def principal_view(principal: Principal = Depends(get_principal)) -> dict:
+        return {
+            "subject_id": principal.subject_id,
+            "display_name": principal.display_name,
+            "roles": sorted(principal.roles),
+        }
+
+    return TestClient(test_app)
+
+
+def test_valid_easyauth_principal_uses_oid_tenant_and_canonical_roles() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={"x-ms-client-principal": encode_principal(roles=("Optimus.Reader", "Optimus.Mutator"))},
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "subject_id": SUBJECT_ID,
+        "display_name": "Test principal",
+        "roles": ["Optimus.Mutator", "Optimus.Reader"],
+    }
+
+
+@pytest.mark.parametrize("principal", ["not-base64", base64.b64encode(b"not-json").decode("ascii")])
+def test_malformed_easyauth_principal_is_rejected(principal: str) -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={"x-ms-client-principal": principal},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "AUTH_INVALID"
+
+
+def test_non_aad_principal_is_rejected() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={"x-ms-client-principal": encode_principal(auth_type="github")},
+    )
+    assert response.status_code == 401
+
+
+def test_principal_from_another_tenant_is_rejected() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={"x-ms-client-principal": encode_principal(tenant_id=OTHER_TENANT_ID)},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "TENANT_MISMATCH"
+
+
+def test_ambiguous_object_id_claim_is_rejected() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={
+            "x-ms-client-principal": encode_principal(
+                extra_claims=({"typ": "oid", "val": "44444444-4444-4444-8444-444444444444"},),
+            )
+        },
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "AUTH_INVALID"
+
+
+def test_duplicate_object_id_claim_is_rejected_even_when_value_matches() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={
+            "x-ms-client-principal": encode_principal(
+                extra_claims=({"typ": "oid", "val": SUBJECT_ID},),
+            )
+        },
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "AUTH_INVALID"
+
+
+def test_duplicate_json_key_is_rejected() -> None:
+    decoded = base64.b64decode(encode_principal()).decode("utf-8")
+    duplicated = decoded.replace('"auth_typ": "aad"', '"auth_typ": "aad", "auth_typ": "aad"', 1)
+    encoded = base64.b64encode(duplicated.encode("utf-8")).decode("ascii")
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={"x-ms-client-principal": encoded},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "AUTH_INVALID"
+
+
+def test_production_auth_fails_closed_without_tenant_binding() -> None:
+    response = make_client(make_settings(tenant_id=None)).get(
+        "/principal",
+        headers={"x-ms-client-principal": encode_principal()},
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "AUTH_NOT_CONFIGURED"
+
+
+def test_production_auth_fails_closed_with_invalid_tenant_binding() -> None:
+    response = make_client(make_settings(tenant_id="not-a-tenant-id")).get(
+        "/principal",
+        headers={"x-ms-client-principal": encode_principal()},
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "AUTH_NOT_CONFIGURED"
+
+
+def test_legacy_identity_and_role_headers_do_not_authenticate() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={
+            "x-ms-client-principal-id": SUBJECT_ID,
+            "x-optimus-roles": "Optimus.Reader",
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_client_controlled_role_header_is_ignored() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={
+            "x-ms-client-principal": encode_principal(roles=()),
+            "x-optimus-roles": "Optimus.Mutator",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["roles"] == []
+
+
+def test_claim_outside_declared_role_type_is_ignored() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={
+            "x-ms-client-principal": encode_principal(
+                roles=(),
+                extra_claims=({"typ": "roles", "val": "Optimus.Mutator"},),
+            )
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["roles"] == []
+
+
+def test_unrecognized_role_claim_type_is_rejected() -> None:
+    response = make_client(make_settings()).get(
+        "/principal",
+        headers={"x-ms-client-principal": encode_principal(role_type="custom-role")},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "AUTH_INVALID"
+
+
+def test_dev_headers_are_available_only_in_dev_mode() -> None:
+    headers = {
+        "x-optimus-dev-principal": "local-user",
+        "x-optimus-dev-roles": "Optimus.Reader",
+    }
+    denied = make_client(make_settings(dev_mode=False)).get("/principal", headers=headers)
+    allowed = make_client(make_settings(dev_mode=True, tenant_id=None)).get("/principal", headers=headers)
+    assert denied.status_code == 401
+    assert allowed.status_code == 200
+    assert allowed.json()["roles"] == ["Optimus.Reader"]
+
+
+def test_reader_and_mutator_roles_cannot_collapse() -> None:
+    with pytest.raises(ValueError, match="must remain separate"):
+        Settings(
+            dev_mode=False,
+            catalog_path=Path("unused.json"),
+            executor_mode="disabled",
+            approval_hmac_secret=None,
+            entra_tenant_id=TENANT_ID,
+            reader_role="Optimus.Reader",
+            mutator_role="Optimus.Reader",
+        )

--- a/products/admin-gateway/tests/test_catalog.py
+++ b/products/admin-gateway/tests/test_catalog.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from optimus_admin_gateway.catalog import OperationCatalog
+
+
+def test_catalog_has_no_unapproved_mutations() -> None:
+    catalog = OperationCatalog.load(Path(__file__).parents[1] / "config" / "operations.catalog.json")
+    mutations = [item for item in catalog.list() if item.mutation]
+    assert mutations
+    assert all(item.approval_required for item in mutations)
+
+
+def test_catalog_does_not_expose_arbitrary_execution() -> None:
+    catalog = OperationCatalog.load(Path(__file__).parents[1] / "config" / "operations.catalog.json")
+    forbidden = {"command", "script", "script_path", "module", "shell"}
+    for operation in catalog.list():
+        assert operation.operation_id not in forbidden
+        assert "arbitrary" not in operation.description.lower()


### PR DESCRIPTION
## Stack

Base: `feature/1869-optimus-admin-gateway-foundation` / draft PR #1870.

## Decision

Harden the API boundary before any tenant deployment. Production identity is accepted only from the canonical Azure App Service EasyAuth principal, bound to an explicitly configured Entra tenant, and authorized per operation.

## Scope

- FastAPI reference service and strict Pydantic request validation.
- Allowlisted operation catalog and deterministic plan hashing.
- `DryRun=true` by default and approval receipts bound to the exact plan hash.
- Strict parsing of `X-MS-CLIENT-PRINCIPAL`, immutable Entra `oid` subject and mapped `tid` comparison.
- `Optimus.Reader` for catalog, plan, reads and DryRun; additional `Optimus.Mutator` for live mutation.
- Dev-only identity under `X-OPTIMUS-DEV-*` only while `OPTIMUS_DEV_MODE=true`.
- Tenant-neutral OAuth/OpenAPI contract with an explicit tenant placeholder.
- Versioned workflow inventory in `docs/context/WORKFLOWS.md`.

## TestClient compatibility

`httpx2` is Starlette's preferred TestClient backend while legacy `httpx` remains in the dev extra for the supported lower FastAPI/Starlette range. The deprecation-warning gate is version-aware: it becomes fatal when Starlette exposes `StarletteDeprecationWarning` and remains compatible with supported older Starlette releases where that class does not exist. This affects tests only; production transport is unchanged.

## Validation

Head: `6d45876319cd0c37b1e5214799b5f0418d606e06`

- All five PR commits have GitHub-verified signatures.
- [Product Python contract: 29 passed](https://github.com/Voxterrae/HUB_Optimus/actions/runs/31413525208/job/93537003615).
- [Repository suite: 731 passed](https://github.com/Voxterrae/HUB_Optimus/actions/runs/31413526207/job/93537007131).
- Kernel Guard, Link Check, PR Safety Check, benchmarks and PowerShell tooling passed.
- The warning policy was also exercised locally against supported Starlette 0.52 and current Starlette 1.6.

## Deployment gates / out of scope

This remains a draft and is not production-ready. Deployment must still prove mandatory EasyAuth, tenant-specific issuer and audiences, no backend bypass, approval expiry/replay controls, durable idempotency, Exchange resource scope, runbook containment, durable audit/post-checks and tenant-side RBAC.

No customer tenant IDs, identities, mailboxes, private URLs, credentials, approvals, logs or evidence are included. `docs/context/AI_HANDOFF.md` is unchanged because this stack is unmerged.

Relates to #1869. Does not close it.
