### PR TITLE
feat(admin-gateway): add allowlisted Exchange PowerShell 7 runbook

### DIFF
--- a/.github/workflows/optimus-admin-gateway.yml
+++ b/.github/workflows/optimus-admin-gateway.yml
@@ -32,3 +32,40 @@ jobs:
         run: python -m pip install -e '.[dev]'
       - name: Run API and authentication contract tests
         run: python -m pytest -q
+
+  powershell-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Parse and inspect PowerShell 7 runbooks
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -Recurse products/admin-gateway/runbooks -Filter *.ps1
+          if ($files.Count -eq 0) { throw 'No PowerShell runbooks found.' }
+          foreach ($file in $files) {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              $file.FullName,
+              [ref]$tokens,
+              [ref]$errors
+            ) | Out-Null
+            if ($errors.Count -gt 0) {
+              $errors | ForEach-Object { Write-Error "$($file.FullName): $($_.Message)" }
+              throw "PowerShell parse failed for $($file.FullName)."
+            }
+          }
+          $runbook = Get-Content -Raw products/admin-gateway/runbooks/Invoke-OptimusExchangeOperation.ps1
+          if ($runbook -match '(?i)Invoke-Expression|\biex\b|DownloadString') {
+            throw 'Dynamic execution is forbidden.'
+          }
+          if ($runbook -notmatch '\[bool\]\$DryRun = \$true') {
+            throw 'DryRun must default to true.'
+          }
+      - name: Run PowerShell safety contracts
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0 -ErrorAction Stop
+          Invoke-Pester -Path products/admin-gateway/runbooks/tests -CI

--- a/docs/context/WORKFLOWS.md
+++ b/docs/context/WORKFLOWS.md
@@ -50,6 +50,10 @@ powershell -ExecutionPolicy Bypass -File tools/trace_repo.ps1
   - installs the package with its development dependencies on Python 3.11;
   - runs the complete product test suite;
   - treats the Starlette legacy-TestClient deprecation as an error.
+- Job `powershell-contract`:
+  - parses every Admin Gateway runbook with PowerShell's language parser;
+  - rejects dynamic execution and a non-safe DryRun default;
+  - runs the versioned Pester safety contracts with `Invoke-Pester -CI`.
 - Writes to repo: no.
 
 ### link-check.yml

--- a/products/admin-gateway/runbooks/Invoke-OptimusExchangeOperation.ps1
+++ b/products/admin-gateway/runbooks/Invoke-OptimusExchangeOperation.ps1
@@ -1,0 +1,206 @@
+#requires -Version 7.4
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet(
+        'exchange.diagnose_mailbox',
+        'exchange.get_mailbox_state',
+        'exchange.get_mailbox_folder_health',
+        'exchange.get_mailbox_permissions',
+        'exchange.test_delegated_access',
+        'exchange.grant_full_access',
+        'exchange.revoke_full_access',
+        'exchange.get_shared_mailbox_configuration',
+        'exchange.check_forwarding',
+        'exchange.verify_recipient_alignment'
+    )]
+    [string]$OperationId,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[^\s@]+@[^\s@]+\.[^\s@]+$')]
+    [string]$Mailbox,
+
+    [ValidatePattern('^$|^[^\s@]+@[^\s@]+\.[^\s@]+$')]
+    [string]$Delegate = '',
+
+    [bool]$AutoMapping = $false,
+    [bool]$DryRun = $true,
+
+    [ValidateSet('ManagedIdentity', 'Certificate')]
+    [string]$AuthenticationMode = 'ManagedIdentity',
+
+    [Parameter(Mandatory)]
+    [string]$Organization,
+
+    [string]$AppId = '',
+    [string]$CertificateAssetName = '',
+    [string]$ApprovalId = '',
+    [string]$PlanHash = '',
+    [string]$Reason = '',
+    [string]$ChangeTicket = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-MutationApproval {
+    param([string]$CurrentOperation)
+    $mutations = @('exchange.grant_full_access', 'exchange.revoke_full_access')
+    if ($CurrentOperation -in $mutations -and -not $DryRun) {
+        if ([string]::IsNullOrWhiteSpace($ApprovalId) -or
+            $PlanHash -notmatch '^[a-f0-9]{64}$' -or
+            [string]::IsNullOrWhiteSpace($Reason) -or
+            [string]::IsNullOrWhiteSpace($ChangeTicket)) {
+            throw 'Mutation requires ApprovalId, PlanHash, Reason and ChangeTicket.'
+        }
+    }
+}
+
+function Connect-OptimusExchangeOnline {
+    Import-Module ExchangeOnlineManagement -ErrorAction Stop
+    if ($AuthenticationMode -eq 'ManagedIdentity') {
+        Connect-ExchangeOnline -ManagedIdentity -Organization $Organization -ShowBanner:$false
+        return
+    }
+    if ([string]::IsNullOrWhiteSpace($AppId) -or [string]::IsNullOrWhiteSpace($CertificateAssetName)) {
+        throw 'Certificate authentication requires AppId and CertificateAssetName.'
+    }
+    $certificate = Get-AutomationCertificate -Name $CertificateAssetName
+    if ($null -eq $certificate) {
+        throw "Automation certificate asset '$CertificateAssetName' was not found."
+    }
+    Connect-ExchangeOnline -AppId $AppId -Certificate $certificate -Organization $Organization -ShowBanner:$false
+}
+
+function New-Result {
+    param(
+        [string]$State,
+        [hashtable]$Data,
+        [string[]]$Warnings = @()
+    )
+    [ordered]@{
+        schemaVersion = '1.0'
+        operationId = $OperationId
+        state = $State
+        dryRun = $DryRun
+        mailbox = $Mailbox.ToLowerInvariant()
+        delegate = if ($Delegate) { $Delegate.ToLowerInvariant() } else { $null }
+        approvalId = if ($ApprovalId) { $ApprovalId } else { $null }
+        planHash = if ($PlanHash) { $PlanHash } else { $null }
+        data = $Data
+        warnings = $Warnings
+        completedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+    }
+}
+
+Assert-MutationApproval -CurrentOperation $OperationId
+Connect-OptimusExchangeOnline
+try {
+    switch ($OperationId) {
+        'exchange.diagnose_mailbox' {
+            $warnings = [System.Collections.Generic.List[string]]::new()
+            $recipient = Get-EXORecipient -Identity $Mailbox -ErrorAction Stop
+            $mailboxObject = $null
+            $statistics = $null
+            $folderCount = $null
+            try { $mailboxObject = Get-EXOMailbox -Identity $Mailbox -PropertySets Minimum,Delivery -ErrorAction Stop }
+            catch { $warnings.Add("Mailbox probe failed: $($_.Exception.Message)") }
+            try { $statistics = Get-EXOMailboxStatistics -Identity $Mailbox -ErrorAction Stop }
+            catch { $warnings.Add("Store statistics probe failed: $($_.Exception.Message)") }
+            try { $folderCount = @(Get-EXOMailboxFolderStatistics -Identity $Mailbox -ErrorAction Stop).Count }
+            catch { $warnings.Add("Folder probe failed: $($_.Exception.Message)") }
+            New-Result -State 'SUCCEEDED' -Warnings $warnings.ToArray() -Data ([ordered]@{
+                recipientType = $recipient.RecipientType
+                recipientTypeDetails = $recipient.RecipientTypeDetails
+                externalDirectoryObjectId = $recipient.ExternalDirectoryObjectId
+                exchangeGuid = $mailboxObject.ExchangeGuid
+                primarySmtpAddress = $recipient.PrimarySmtpAddress
+                mailboxFound = $null -ne $mailboxObject
+                storeFound = $null -ne $statistics
+                folderCount = $folderCount
+            })
+        }
+        'exchange.get_mailbox_state' {
+            $item = Get-EXOMailbox -Identity $Mailbox -PropertySets Minimum,Delivery -ErrorAction Stop
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{
+                displayName = $item.DisplayName
+                recipientTypeDetails = $item.RecipientTypeDetails
+                primarySmtpAddress = $item.PrimarySmtpAddress
+                exchangeGuid = $item.ExchangeGuid
+                forwardingAddress = $item.ForwardingAddress
+                forwardingSmtpAddress = $item.ForwardingSmtpAddress
+                deliverToMailboxAndForward = $item.DeliverToMailboxAndForward
+            })
+        }
+        'exchange.get_mailbox_folder_health' {
+            $folders = @(Get-EXOMailboxFolderStatistics -Identity $Mailbox -ErrorAction Stop)
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{
+                folderCount = $folders.Count
+                standardFolders = @($folders | Where-Object FolderType -ne 'User Created' | Select-Object Name, FolderType, ItemsInFolder)
+            })
+        }
+        'exchange.get_mailbox_permissions' {
+            $permissions = @(Get-EXOMailboxPermission -Identity $Mailbox -ErrorAction Stop |
+                Where-Object { -not $_.IsInherited } |
+                Select-Object User, AccessRights, Deny, InheritanceType)
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{ permissions = $permissions })
+        }
+        'exchange.test_delegated_access' {
+            if ([string]::IsNullOrWhiteSpace($Delegate)) { throw 'Delegate is required.' }
+            $permission = @(Get-EXOMailboxPermission -Identity $Mailbox -User $Delegate -ErrorAction SilentlyContinue |
+                Where-Object { -not $_.Deny -and $_.AccessRights -contains 'FullAccess' })
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{ hasFullAccess = $permission.Count -gt 0 })
+        }
+        'exchange.grant_full_access' {
+            if ([string]::IsNullOrWhiteSpace($Delegate)) { throw 'Delegate is required.' }
+            if ($DryRun) {
+                New-Result -State 'PLANNED' -Data ([ordered]@{ action = 'Add-MailboxPermission'; autoMapping = $AutoMapping })
+            }
+            elseif ($PSCmdlet.ShouldProcess($Mailbox, "Grant FullAccess to $Delegate")) {
+                Add-MailboxPermission -Identity $Mailbox -User $Delegate -AccessRights FullAccess -AutoMapping:$AutoMapping -Confirm:$false -ErrorAction Stop | Out-Null
+                New-Result -State 'SUCCEEDED' -Data ([ordered]@{ granted = $true; autoMapping = $AutoMapping })
+            }
+        }
+        'exchange.revoke_full_access' {
+            if ([string]::IsNullOrWhiteSpace($Delegate)) { throw 'Delegate is required.' }
+            if ($DryRun) {
+                New-Result -State 'PLANNED' -Data ([ordered]@{ action = 'Remove-MailboxPermission' })
+            }
+            elseif ($PSCmdlet.ShouldProcess($Mailbox, "Revoke FullAccess from $Delegate")) {
+                Remove-MailboxPermission -Identity $Mailbox -User $Delegate -AccessRights FullAccess -Confirm:$false -ErrorAction Stop
+                New-Result -State 'SUCCEEDED' -Data ([ordered]@{ revoked = $true })
+            }
+        }
+        'exchange.get_shared_mailbox_configuration' {
+            $item = Get-EXOMailbox -Identity $Mailbox -PropertySets Minimum,Delivery -ErrorAction Stop
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{
+                recipientTypeDetails = $item.RecipientTypeDetails
+                primarySmtpAddress = $item.PrimarySmtpAddress
+                forwardingAddress = $item.ForwardingAddress
+                forwardingSmtpAddress = $item.ForwardingSmtpAddress
+                deliverToMailboxAndForward = $item.DeliverToMailboxAndForward
+            })
+        }
+        'exchange.check_forwarding' {
+            $item = Get-EXOMailbox -Identity $Mailbox -PropertySets Delivery -ErrorAction Stop
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{
+                forwardingAddress = $item.ForwardingAddress
+                forwardingSmtpAddress = $item.ForwardingSmtpAddress
+                deliverToMailboxAndForward = $item.DeliverToMailboxAndForward
+            })
+        }
+        'exchange.verify_recipient_alignment' {
+            $recipient = Get-EXORecipient -Identity $Mailbox -ErrorAction Stop
+            $mailboxObject = Get-EXOMailbox -Identity $Mailbox -PropertySets Minimum -ErrorAction Stop
+            New-Result -State 'SUCCEEDED' -Data ([ordered]@{
+                smtpAligned = $recipient.PrimarySmtpAddress -eq $mailboxObject.PrimarySmtpAddress
+                externalDirectoryObjectId = $recipient.ExternalDirectoryObjectId
+                exchangeGuid = $mailboxObject.ExchangeGuid
+                recipientTypeDetails = $mailboxObject.RecipientTypeDetails
+            })
+        }
+    }
+}
+finally {
+    Disconnect-ExchangeOnline -Confirm:$false -ErrorAction SilentlyContinue
+}

--- a/products/admin-gateway/runbooks/tests/Invoke-OptimusExchangeOperation.Tests.ps1
+++ b/products/admin-gateway/runbooks/tests/Invoke-OptimusExchangeOperation.Tests.ps1
@@ -1,0 +1,19 @@
+#requires -Version 7.4
+Describe 'Optimus Exchange runbook safety contract' {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'Invoke-OptimusExchangeOperation.ps1'
+    $content = Get-Content -Raw -LiteralPath $scriptPath
+
+    It 'uses an allowlisted ValidateSet' {
+        $content | Should -Match '\[ValidateSet\('
+        $content | Should -Match 'exchange\.diagnose_mailbox'
+        $content | Should -Not -Match 'Invoke-Expression'
+    }
+
+    It 'defaults to DryRun' {
+        $content | Should -Match '\[bool\]\$DryRun = \$true'
+    }
+
+    It 'requires approval material for live mutations' {
+        $content | Should -Match 'Mutation requires ApprovalId, PlanHash, Reason and ChangeTicket'
+    }
+}

--- a/products/admin-gateway/runbooks/tests/Invoke-OptimusExchangeOperation.Tests.ps1
+++ b/products/admin-gateway/runbooks/tests/Invoke-OptimusExchangeOperation.Tests.ps1
@@ -1,7 +1,9 @@
 #requires -Version 7.4
 Describe 'Optimus Exchange runbook safety contract' {
-    $scriptPath = Join-Path $PSScriptRoot '..' 'Invoke-OptimusExchangeOperation.ps1'
-    $content = Get-Content -Raw -LiteralPath $scriptPath
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'Invoke-OptimusExchangeOperation.ps1'
+        $content = Get-Content -Raw -LiteralPath $scriptPath
+    }
 
     It 'uses an allowlisted ValidateSet' {
         $content | Should -Match '\[ValidateSet\('

--- a/products/admin-gateway/tests/test_runbook_safety.py
+++ b/products/admin-gateway/tests/test_runbook_safety.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_exchange_runbook_is_allowlisted_and_dry_run_by_default() -> None:
+    content = (Path(__file__).parents[1] / "runbooks" / "Invoke-OptimusExchangeOperation.ps1").read_text(encoding="utf-8")
+    lowered = content.lower()
+    assert "invoke-expression" not in lowered
+    assert "iex " not in lowered
+    assert "downloadstring" not in lowered
+    assert "[validateset(" in lowered
+    assert "[bool]$dryrun = $true" in lowered
+    assert "mutation requires approvalid, planhash, reason and changeticket" in lowered


### PR DESCRIPTION
## Stack

Base: `feature/1869-admin-gateway-api` / draft PR #1871.

## Scope

Adds the governed Exchange Online execution layer:

- PowerShell 7.4 allowlisted dispatcher;
- read-only diagnostic operations and narrowly scoped FullAccess grant/revoke operations;
- `DryRun=true`, `SupportsShouldProcess` and mandatory approval material for live mutations;
- managed-identity and certificate authentication modes;
- structured output, Python static safety checks and Pester contracts;
- versioned `powershell-contract` inventory in `docs/context/WORKFLOWS.md`.

## Safety properties

- No arbitrary command, script path or raw shell input is accepted.
- The product workflow parses every runbook, rejects dynamic execution, checks the safe DryRun default and runs Pester on PowerShell 7.
- Pester fixtures use `BeforeAll`, matching discovery and execution phases.
- Checkout credentials remain disabled and external actions remain pinned.

## Validation

Head: `032a4565fd4704f90a3784e75cfbba8e9c46f1cd`

- All four PR commits have GitHub-verified signatures.
- [Product Python contract: 30 passed](https://github.com/Voxterrae/HUB_Optimus/actions/runs/31413526198/job/93537007496).
- [PowerShell/Pester contract: 3 passed](https://github.com/Voxterrae/HUB_Optimus/actions/runs/31413526198/job/93537007492).
- [Repository suite: 732 passed](https://github.com/Voxterrae/HUB_Optimus/actions/runs/31413526131/job/93537008006).
- Kernel Guard, Link Check, PR Safety Check, benchmarks and PowerShell tooling passed.

## Explicit exclusions

- No mailbox conversion, deletion, forwarding or license mutation.
- No tenant identifiers, customer mailbox addresses, Azure Automation publication, Exchange connection or live mutation.
- Direct Automation invocation must be contained so it cannot bypass the API role and approval boundary before PROD.

This PR remains draft and disconnected from any live tenant. `docs/context/AI_HANDOFF.md` is unchanged because the stack is unmerged.

Relates to #1869. Does not close it.
