### PR TITLE
superseded: add governed capability registry foundation

### DIFF
--- a/docs/architecture/public_surface_sync.md
+++ b/docs/architecture/public_surface_sync.md
@@ -78,7 +78,7 @@ Its Draft 2020-12 JSON Schema lives beside it. Each component records:
 
 The registry is intentionally static and human-reviewed in v1. A future generator may consume it, but no generator may infer product state directly from labels, titles, mergeability, check status, branch names, or chat instructions.
 
-The schema must independently reject invalid cross-field combinations. Repository tests supplement the schema by binding evidence references to their exact commit, pull-request, or issue URL.
+The schema must independently reject invalid cross-field combinations. Repository tests supplement the schema by binding source status to evidence type, binding references to exact commit, pull-request, or issue URLs, and proving that every commit-path target exists at the declared immutable Git object type.
 
 ## Presentation rules
 
@@ -132,6 +132,8 @@ Consequences:
 - current product status must be changed through a reviewed site/registry change;
 - draft branches and pull requests must never deploy to the canonical public domain through this path.
 
+The validation contract parses the workflow structure and compares the upload step's exact `with.path` value with the registry's declared artifact path. A substring, comment, or similarly named directory is not sufficient evidence.
+
 Because this foundation PR changes both `site/**` and `docs/**`, merging it will trigger GitHub Pages. The future owner merge decision must explicitly acknowledge and authorize that deployment consequence. The resulting run must be validated and recorded before the work proceeds. Until that separate decision exists, the PR remains draft and no deployment is authorized.
 
 ## Protected Sites mirror boundary
@@ -161,13 +163,17 @@ Repository checks for this boundary must fail when:
 - a public portfolio component has no registry entry;
 - component IDs or evidence records are duplicated;
 - evidence type, reference, and URL identity do not agree;
+- a component's source status does not match every evidence type it carries;
+- a commit-path target is absent at its declared immutable commit or has the wrong blob/tree type;
 - a draft or issue-only component claims a public browser runtime, production deployment, production writes, or live external transport;
 - an in-development component is silently placed under **What exists today**;
 - the registry evidence SHA differs from the site document-route evidence SHA;
+- the Pages workflow's parsed upload artifact path differs from the registry declaration;
 - the protected Sites observation is described as matching when its recorded source differs from the source baseline;
 - an observed pre-merge SHA or run is represented as the future merged SHA or post-merge receipt;
 - evidence leaves the canonical GitHub repository;
-- private identifiers or secret-like fields enter the registry.
+- private identifiers or secret-like fields enter the registry;
+- the controlling AI handoff omits the registry flow or its outstanding presentation and Sites slices.
 
 ## Update procedure
 
@@ -175,15 +181,17 @@ Repository checks for this boundary must fail when:
 2. Inspect the exact merged, draft, and issue evidence.
 3. Update the registry on a dedicated branch.
 4. Validate the schema itself and validate the registry against it with format checking.
-5. Bind every evidence type, reference, and URL to the same identity.
-6. Update public markup only when the desired presentation change is explicitly in scope.
-7. Run registry, public-portfolio, link, locale, accessibility-proxy, encoding, and repository tests.
-8. Review wording for deployment and authorization overclaim.
-9. Reconstruct the exact approved tree through the verified owner-signing boundary.
-10. Merge only after the owner decision explicitly covers the Pages side effect.
-11. Confirm the GitHub Pages artifact, source SHA, run, and public files.
-12. Synchronize Sites separately from the exact merged tree.
-13. Record provenance and QA without overwriting historical evidence.
+5. Bind source status, evidence type, reference, URL, immutable commit, repository path, and Git object type.
+6. Parse the Pages workflow and compare its exact upload artifact path with the registry declaration.
+7. Update public markup only when the desired presentation change is explicitly in scope.
+8. Update `docs/context/AI_HANDOFF.md` when the change affects the operational flow or outstanding slices.
+9. Run registry, public-portfolio, link, locale, accessibility-proxy, encoding, and repository tests.
+10. Review wording for deployment and authorization overclaim.
+11. Reconstruct the exact approved tree through the verified owner-signing boundary.
+12. Merge only after the owner decision explicitly covers the Pages side effect.
+13. Confirm the GitHub Pages artifact, source SHA, run, and public files.
+14. Synchronize Sites separately from the exact merged tree.
+15. Record provenance and QA without overwriting historical evidence.
 
 ## Rollback
 
@@ -193,6 +201,6 @@ After a canonical merge, revert the exact site/registry commit through a reviewe
 
 ## Foundation-slice limitation
 
-The first PR under #1888 adds the registry, schema, documentation, and validation only. It does not modify `site/index.html`, translations, styles, JavaScript, the Pages workflow, the protected Sites project, or any runtime. The visible portfolio remains unchanged until a separate reviewed presentation slice consumes the registry.
+The first PR under #1888 adds the registry, schema, architecture documentation, focused validation, and the operational AI handoff update required to inherit this flow. It does not modify `site/index.html`, translations, styles, JavaScript, the Pages workflow, the protected Sites project, or any runtime. The visible portfolio remains unchanged until a separate reviewed presentation slice consumes the registry.
 
 The registry and schema are nevertheless public files under `site/data/` after an authorized merge. That non-visible deployment is an explicit effect, not an implication that the presentation update or Sites synchronization has already occurred.

--- a/docs/architecture/public_surface_sync.md
+++ b/docs/architecture/public_surface_sync.md
@@ -1,0 +1,198 @@
+# Public surface and Sites synchronization boundary
+
+Status: foundation contract for review under issue #1888. This document records the operating boundary; it does not by itself authorize merge, GitHub Pages deployment, Sites publication, access changes, tenant mutation, or external transport.
+
+## Purpose
+
+HUB_Optimus needs one truthful product-status boundary between the governed repository and its presentation surfaces. The public portfolio and the protected Sites mirror must show only claims supported by reviewed evidence, while still making important draft work discoverable without describing it as released or deployed.
+
+The canonical authority is:
+
+```text
+Voxterrae/HUB_Optimus
+```
+
+GitHub Pages and the protected OpenAI Sites project are presentation surfaces. Neither may redefine repository state.
+
+## Reviewed observations
+
+The registry is a dated observation, not a self-referential claim that it already knows the SHA of the commit that will eventually contain it.
+
+Observed and rechecked on 21 August 2026:
+
+- source baseline: `main@30e985226347b4bc59b0e187b96633a09647ca42`;
+- public evidence baseline used by document routes: `8426b08e5f88b650c4d79e41d3ce3afd7d42746b`;
+- GitHub Pages observation: run `31957372253`, source `30e985226347b4bc59b0e187b96633a09647ca42`, conclusion `success`, observed on 16 August 2026;
+- GitHub Pages uploads the static `site/` directory;
+- the portfolio in `site/index.html` is manually maintained;
+- protected Sites observation: version 8 from `main@b64203fc8c784fd50053872767b179d97f451cc1`, observed on 30 July 2026;
+- the protected Sites mirror did not match the source baseline at the time of review.
+
+A successful GitHub Pages run proves that the selected static artifact was deployed. It does not prove that manually maintained portfolio claims include every recent issue or draft pull request.
+
+The fields `source_baseline_sha`, `observed_run_id`, `observed_source_sha`, and `observed_at` deliberately describe evidence already observed. They must not be renamed or presented as the future merged commit, the current run forever, or a post-merge receipt.
+
+## Canonical flow
+
+```text
+reviewed repository evidence
+        ↓
+human-reviewed capability registry
+        ↓
+validated exact pull-request head
+        ↓
+owner-signed reconstruction or squash
+        ↓
+explicit owner merge decision
+        ↓
+GitHub Pages deployment and receipt
+        ↓
+separate presentation update, when authorized
+        ↓
+separate deterministic Sites mirror synchronization
+```
+
+Unreviewed issues and pull requests do not enter the public surface automatically. Automation may validate an approved registry, but it must not decide that a draft is released, deployed, production-ready, authorized, endorsed, or safe.
+
+## Capability registry
+
+The v1 registry lives at:
+
+```text
+site/data/capability-registry.v1.json
+```
+
+Its Draft 2020-12 JSON Schema lives beside it. Each component records:
+
+- a stable component identifier;
+- a lifecycle state;
+- whether its evidence is merged, a draft pull request, a draft stack, or an open issue;
+- the public section in which it may appear;
+- whether it is currently listed;
+- whether a static public surface exists;
+- whether a browser runtime exists;
+- whether a production service is deployed;
+- production-write and live-external-transport claims;
+- exact GitHub evidence;
+- a human-readable claim boundary.
+
+The registry is intentionally static and human-reviewed in v1. A future generator may consume it, but no generator may infer product state directly from labels, titles, mergeability, check status, branch names, or chat instructions.
+
+The schema must independently reject invalid cross-field combinations. Repository tests supplement the schema by binding evidence references to their exact commit, pull-request, or issue URL.
+
+## Presentation rules
+
+### What exists today
+
+A component may appear under **What exists today** only when:
+
+1. its source status is `merged`;
+2. it has an exact evidence path;
+3. its visible wording matches the recorded lifecycle and execution fields;
+4. any deployment limitation is visible rather than implied away.
+
+A merged repository prototype may be public without being a production runtime. Those are separate claims.
+
+### In development
+
+Draft pull requests, draft stacks, and issue-only foundations may appear only under a visibly separate **In development** surface. They must not use language such as:
+
+- live;
+- released;
+- production-ready;
+- deployed;
+- connected;
+- enabled;
+- partner or endorsed;
+- automatically publishing;
+- operating on real tenant or customer data;
+
+unless a separate reviewed record proves that exact statement.
+
+### Hidden or restricted work
+
+Private identifiers, protected URLs, tenant details, credentials, certificates, customer information, private evidence, unpublished source snapshots, authorization receipts, and operational logs do not belong in the public registry or site.
+
+## Current truthful treatment of recent work
+
+- **Optimus Admin Gateway** remains the exact draft PR stack #1870–#1873 plus #1875–#1876. Private Sandbox recovery evidence does not authorize production deployment, connector activation, or another tenant mutation.
+- **Optimus Evidence Lab** remains draft PR #1879 and an offline package boundary. It is not a production deployment or a public runtime.
+- **HUB_Optimus Connect — xAI and X Foundation** remains draft PR #1877 and a disabled provider boundary. It has no credentials, live calls, automatic publication, or partnership claim.
+- **Optimus Global Graph** remains issue-only under #1880. It has no implementation, person-level graph, Dataverse mutation, public API, public globe integration, or Sites deployment.
+
+## GitHub Pages boundary
+
+`.github/workflows/pages.yml` triggers when selected site, documentation, brand, or workflow paths change, but it uploads only `site/`.
+
+Consequences:
+
+- a documentation-only merge can redeploy unchanged site bytes;
+- a merge that changes `site/data/**` deploys those new public files even when visible HTML is unchanged;
+- a successful deployment does not mean the portfolio was regenerated;
+- current product status must be changed through a reviewed site/registry change;
+- draft branches and pull requests must never deploy to the canonical public domain through this path.
+
+Because this foundation PR changes both `site/**` and `docs/**`, merging it will trigger GitHub Pages. The future owner merge decision must explicitly acknowledge and authorize that deployment consequence. The resulting run must be validated and recorded before the work proceeds. Until that separate decision exists, the PR remains draft and no deployment is authorized.
+
+## Protected Sites mirror boundary
+
+The Sites project is a mirror and prototyping surface, not the canonical product repository. Synchronization must occur only after the relevant canonical site change is reviewed and merged.
+
+A synchronization receipt must record:
+
+- canonical repository;
+- exact merged commit;
+- exact `site/` tree;
+- complete path and content-hash inventory;
+- build and lint results;
+- routing and provenance tests;
+- saved Sites version;
+- access level;
+- visual QA actually performed;
+- limitations not exercised by the available browser.
+
+Saving a Sites version does not authorize public access. Widening access or publishing a different Sites endpoint requires a separate owner decision.
+
+## Required checks
+
+Repository checks for this boundary must fail when:
+
+- the registry or schema is not valid Draft 2020-12 JSON Schema;
+- a public portfolio component has no registry entry;
+- component IDs or evidence records are duplicated;
+- evidence type, reference, and URL identity do not agree;
+- a draft or issue-only component claims a public browser runtime, production deployment, production writes, or live external transport;
+- an in-development component is silently placed under **What exists today**;
+- the registry evidence SHA differs from the site document-route evidence SHA;
+- the protected Sites observation is described as matching when its recorded source differs from the source baseline;
+- an observed pre-merge SHA or run is represented as the future merged SHA or post-merge receipt;
+- evidence leaves the canonical GitHub repository;
+- private identifiers or secret-like fields enter the registry.
+
+## Update procedure
+
+1. Open or identify the governing issue.
+2. Inspect the exact merged, draft, and issue evidence.
+3. Update the registry on a dedicated branch.
+4. Validate the schema itself and validate the registry against it with format checking.
+5. Bind every evidence type, reference, and URL to the same identity.
+6. Update public markup only when the desired presentation change is explicitly in scope.
+7. Run registry, public-portfolio, link, locale, accessibility-proxy, encoding, and repository tests.
+8. Review wording for deployment and authorization overclaim.
+9. Reconstruct the exact approved tree through the verified owner-signing boundary.
+10. Merge only after the owner decision explicitly covers the Pages side effect.
+11. Confirm the GitHub Pages artifact, source SHA, run, and public files.
+12. Synchronize Sites separately from the exact merged tree.
+13. Record provenance and QA without overwriting historical evidence.
+
+## Rollback
+
+Before merge, close the draft pull request or delete its branch. No public rollback is required because no canonical deployment occurred.
+
+After a canonical merge, revert the exact site/registry commit through a reviewed pull request and let GitHub Pages deploy the reverted `site/` tree. The protected Sites mirror must then be resynchronized as a new retained version; historical versions and receipts must not be rewritten.
+
+## Foundation-slice limitation
+
+The first PR under #1888 adds the registry, schema, documentation, and validation only. It does not modify `site/index.html`, translations, styles, JavaScript, the Pages workflow, the protected Sites project, or any runtime. The visible portfolio remains unchanged until a separate reviewed presentation slice consumes the registry.
+
+The registry and schema are nevertheless public files under `site/data/` after an authorized merge. That non-visible deployment is an explicit effect, not an implication that the presentation update or Sites synchronization has already occurred.

--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -101,6 +101,47 @@ protected `main` and the later ruleset decision requires the head-bound check.
 Issue `#1881` is the current owner-facing reorganization ledger. Its execution
 order and safety gates remain controlling for the open pull-request portfolio.
 
+## Public surface capability registry boundary
+
+Issue `#1888` governs reconciliation between the canonical repository, the
+public GitHub Pages artifact, and the protected Sites mirror. Pull request
+`#1889` is the foundation record for the human-reviewed capability registry and
+its validation contract. The current merge, deployment, and receipt state must
+always be read from the exact issue, pull request, commit, checks, and Pages run;
+this handoff does not turn a draft or proposed SHA into merged evidence.
+
+The foundation paths are:
+
+- `site/data/capability-registry.v1.json`;
+- `site/data/capability-registry.v1.schema.json`;
+- `docs/architecture/public_surface_sync.md`;
+- the focused registry tests.
+
+The registry separates a public static surface, a public browser runtime, a
+production service, production writes, and live external transport. It must keep
+merged evidence distinct from draft pull requests, draft stacks, and issue-only
+work. Evidence type, reference, immutable commit, repository path, and URL must
+remain mutually consistent and testable.
+
+The existing Pages workflow is triggered by changes under `site/**` and
+`docs/**`, but deploys the exact `site/` artifact. Therefore any merge of the
+foundation requires an explicit owner decision that covers the resulting Pages
+deployment and a post-merge receipt for the merged commit, tree, workflow run,
+and public registry/schema resources.
+
+Outstanding slices remain separate:
+
+1. the visible presentation must consume the reviewed registry through its own
+   scoped pull request and must not present draft or issue-only work as live;
+2. the protected Sites mirror must be synchronized only after the canonical
+   presentation change is reviewed, merged, deployed, and bound to an exact SHA;
+3. Sites publication, access changes, tenant mutation, external transport, and
+   production-service writes require their own explicit owner authorization.
+
+Until those slices have exact repository and platform evidence, future operators
+must continue to describe GitHub Pages as the canonical public static surface
+and Sites as a non-authoritative, separately synchronized mirror.
+
 ## Historical handoff archive
 
 The previous broad handoff is preserved byte-for-byte at

--- a/site/data/capability-registry.v1.json
+++ b/site/data/capability-registry.v1.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "./capability-registry.v1.schema.json",
+  "schema_version": "1.0.0",
+  "registry_id": "hub_optimus.public_capabilities.v1",
+  "registry_mode": "human-reviewed-static",
+  "reviewed_at": "2026-08-21",
+  "baseline": {
+    "canonical_repository": "Voxterrae/HUB_Optimus",
+    "source_baseline_sha": "30e985226347b4bc59b0e187b96633a09647ca42",
+    "public_evidence_sha": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+    "github_pages": {
+      "observed_at": "2026-08-16",
+      "public_url": "https://huboptimus.dev/",
+      "workflow_path": ".github/workflows/pages.yml",
+      "artifact_path": "site",
+      "observed_run_id": 31957372253,
+      "observed_source_sha": "30e985226347b4bc59b0e187b96633a09647ca42",
+      "observed_conclusion": "success",
+      "portfolio_generation": "manual",
+      "merge_path_triggers_pages": true
+    },
+    "sites_mirror": {
+      "observed_at": "2026-07-30",
+      "authoritative": false,
+      "visibility": "owner-only",
+      "synchronization": "manual-deterministic",
+      "observed_version": 8,
+      "observed_source_sha": "b64203fc8c784fd50053872767b179d97f451cc1",
+      "matches_source_baseline": false,
+      "tracking_issue": "https://github.com/Voxterrae/HUB_Optimus/issues/1809"
+    }
+  },
+  "components": [
+    {
+      "id": "core",
+      "display_name": "HUB_Optimus Core",
+      "lifecycle_state": "active-methodology",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/v1_core/languages/es"
+        }
+      ],
+      "claim_boundary": "Versioned methodology and workflow; not a deployed autonomous authority or decision maker."
+    },
+    {
+      "id": "simulator",
+      "display_name": "Deterministic Scenario Simulator",
+      "lifecycle_state": "working-deterministic-prototype",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/SIMULATION_README.md"
+        }
+      ],
+      "claim_boundary": "Deterministic repository prototype; no claim of live institutional or production execution."
+    },
+    {
+      "id": "semantic-engine",
+      "display_name": "Semantic Engine Contracts and CLI",
+      "lifecycle_state": "early-implementation",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/semantic_engine"
+        }
+      ],
+      "claim_boundary": "Local contracts and CLI; it does not establish a public hosted engine or verify truth."
+    },
+    {
+      "id": "operator",
+      "display_name": "HUB_Optimus Operator",
+      "lifecycle_state": "browser-prototype",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": true,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/tree/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/site/operator"
+        }
+      ],
+      "claim_boundary": "Public browser-side prototype; local drafts are not verified evidence and no private runtime is implied."
+    },
+    {
+      "id": "controlled-url-intake",
+      "display_name": "Controlled URL Intake",
+      "lifecycle_state": "implementation-present-deployment-unverified",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/rfc/operator_controlled_url_intake.md"
+        }
+      ],
+      "claim_boundary": "Repository implementation and tests exist; no public authenticated URL-retrieval service is established."
+    },
+    {
+      "id": "research",
+      "display_name": "Scenario and Narrative Research",
+      "lifecycle_state": "experimental-tooling",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/lab_state.md"
+        }
+      ],
+      "claim_boundary": "Experimental repository tooling; not a promoted benchmark, production service or autonomous research authority."
+    },
+    {
+      "id": "governance-intelligence",
+      "display_name": "Governance Intelligence",
+      "lifecycle_state": "active-ratified-protocol",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/docs/governance/GOVERNANCE_INTELLIGENCE.md"
+        }
+      ],
+      "claim_boundary": "Versioned human-governance protocol; it does not create automatic legal, political or technical authority."
+    },
+    {
+      "id": "labs",
+      "display_name": "HUB-Optimus Labs",
+      "lifecycle_state": "official-empty-incubation",
+      "source_status": "merged",
+      "public_section": "what-exists-today",
+      "publicly_listed": true,
+      "public_static_surface_available": true,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "commit-path",
+          "ref": "8426b08e5f88b650c4d79e41d3ce3afd7d42746b",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/blob/8426b08e5f88b650c4d79e41d3ce3afd7d42746b/site/index.html"
+        }
+      ],
+      "claim_boundary": "Official public incubation surface; the separate Labs repository is presented as empty and no unreleased engine, dataset, deployment or security capability is attributed to it."
+    },
+    {
+      "id": "admin-gateway",
+      "display_name": "Optimus Admin Gateway",
+      "lifecycle_state": "draft",
+      "source_status": "draft-pr-stack",
+      "public_section": "in-development",
+      "publicly_listed": false,
+      "public_static_surface_available": false,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "pull-request",
+          "ref": "1870",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1870"
+        },
+        {
+          "type": "pull-request",
+          "ref": "1871",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1871"
+        },
+        {
+          "type": "pull-request",
+          "ref": "1872",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1872"
+        },
+        {
+          "type": "pull-request",
+          "ref": "1873",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1873"
+        },
+        {
+          "type": "pull-request",
+          "ref": "1875",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1875"
+        },
+        {
+          "type": "pull-request",
+          "ref": "1876",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1876"
+        }
+      ],
+      "claim_boundary": "Draft tenant-neutral stack; historical private Sandbox recovery evidence does not authorize production deployment, connector activation or further tenant mutation."
+    },
+    {
+      "id": "evidence-lab",
+      "display_name": "Optimus Evidence Lab",
+      "lifecycle_state": "draft",
+      "source_status": "draft-pr",
+      "public_section": "in-development",
+      "publicly_listed": false,
+      "public_static_surface_available": false,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "pull-request",
+          "ref": "1879",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1879"
+        }
+      ],
+      "claim_boundary": "Draft offline Dataverse package; no production deployment, public runtime or business-data seed is claimed."
+    },
+    {
+      "id": "connect-xai-x",
+      "display_name": "HUB_Optimus Connect — xAI and X Foundation",
+      "lifecycle_state": "draft",
+      "source_status": "draft-pr",
+      "public_section": "in-development",
+      "publicly_listed": false,
+      "public_static_surface_available": false,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "pull-request",
+          "ref": "1877",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/pull/1877"
+        }
+      ],
+      "claim_boundary": "Draft provider boundary only; no credentials, live calls, automatic publication, partnership claim or external transport is enabled."
+    },
+    {
+      "id": "global-graph",
+      "display_name": "Optimus Global Graph",
+      "lifecycle_state": "issue-only",
+      "source_status": "open-issue",
+      "public_section": "in-development",
+      "publicly_listed": false,
+      "public_static_surface_available": false,
+      "public_browser_runtime_available": false,
+      "production_service_deployed": false,
+      "production_writes_executed": 0,
+      "live_external_transport_enabled": false,
+      "evidence": [
+        {
+          "type": "issue",
+          "ref": "1880",
+          "url": "https://github.com/Voxterrae/HUB_Optimus/issues/1880"
+        }
+      ],
+      "claim_boundary": "Governed foundation issue only; no implementation, person-level graph, public globe integration, API, Dataverse mutation or Sites deployment exists under this record."
+    }
+  ]
+}

--- a/site/data/capability-registry.v1.schema.json
+++ b/site/data/capability-registry.v1.schema.json
@@ -404,6 +404,64 @@
           "if": {
             "properties": {
               "source_status": {
+                "const": "draft-pr"
+              }
+            },
+            "required": [
+              "source_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "minItems": 1,
+                "items": {
+                  "properties": {
+                    "type": {
+                      "const": "pull-request"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source_status": {
+                "const": "draft-pr-stack"
+              }
+            },
+            "required": [
+              "source_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "minItems": 2,
+                "items": {
+                  "properties": {
+                    "type": {
+                      "const": "pull-request"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source_status": {
                 "const": "open-issue"
               }
             },
@@ -430,6 +488,18 @@
               },
               "live_external_transport_enabled": {
                 "const": false
+              },
+              "evidence": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "const": "issue"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
               }
             }
           }
@@ -452,6 +522,18 @@
                   "enum": [
                     "draft",
                     "issue-only"
+                  ]
+                }
+              },
+              "evidence": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "const": "commit-path"
+                    }
+                  },
+                  "required": [
+                    "type"
                   ]
                 }
               }

--- a/site/data/capability-registry.v1.schema.json
+++ b/site/data/capability-registry.v1.schema.json
@@ -1,0 +1,577 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://huboptimus.dev/data/capability-registry.v1.schema.json",
+  "title": "HUB_Optimus Public Capability Registry v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "registry_id",
+    "registry_mode",
+    "reviewed_at",
+    "baseline",
+    "components"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "registry_id": {
+      "const": "hub_optimus.public_capabilities.v1"
+    },
+    "registry_mode": {
+      "const": "human-reviewed-static"
+    },
+    "reviewed_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "baseline": {
+      "$ref": "#/$defs/baseline"
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/component"
+      }
+    }
+  },
+  "$defs": {
+    "sha40": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_repository",
+        "source_baseline_sha",
+        "public_evidence_sha",
+        "github_pages",
+        "sites_mirror"
+      ],
+      "properties": {
+        "canonical_repository": {
+          "const": "Voxterrae/HUB_Optimus"
+        },
+        "source_baseline_sha": {
+          "$ref": "#/$defs/sha40"
+        },
+        "public_evidence_sha": {
+          "$ref": "#/$defs/sha40"
+        },
+        "github_pages": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "observed_at",
+            "public_url",
+            "workflow_path",
+            "artifact_path",
+            "observed_run_id",
+            "observed_source_sha",
+            "observed_conclusion",
+            "portfolio_generation",
+            "merge_path_triggers_pages"
+          ],
+          "properties": {
+            "observed_at": {
+              "$ref": "#/$defs/date"
+            },
+            "public_url": {
+              "const": "https://huboptimus.dev/"
+            },
+            "workflow_path": {
+              "const": ".github/workflows/pages.yml"
+            },
+            "artifact_path": {
+              "const": "site"
+            },
+            "observed_run_id": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "observed_source_sha": {
+              "$ref": "#/$defs/sha40"
+            },
+            "observed_conclusion": {
+              "enum": [
+                "success",
+                "failure",
+                "cancelled",
+                "unknown"
+              ]
+            },
+            "portfolio_generation": {
+              "enum": [
+                "manual",
+                "registry-derived"
+              ]
+            },
+            "merge_path_triggers_pages": {
+              "type": "boolean"
+            }
+          }
+        },
+        "sites_mirror": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "observed_at",
+            "authoritative",
+            "visibility",
+            "synchronization",
+            "observed_version",
+            "observed_source_sha",
+            "matches_source_baseline",
+            "tracking_issue"
+          ],
+          "properties": {
+            "observed_at": {
+              "$ref": "#/$defs/date"
+            },
+            "authoritative": {
+              "const": false
+            },
+            "visibility": {
+              "enum": [
+                "owner-only",
+                "restricted",
+                "public"
+              ]
+            },
+            "synchronization": {
+              "enum": [
+                "manual-deterministic",
+                "automatic-reviewed-merge"
+              ]
+            },
+            "observed_version": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "observed_source_sha": {
+              "$ref": "#/$defs/sha40"
+            },
+            "matches_source_baseline": {
+              "type": "boolean"
+            },
+            "tracking_issue": {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^https://github\\.com/Voxterrae/HUB_Optimus/issues/[1-9][0-9]*$"
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "ref",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "commit-path",
+            "pull-request",
+            "issue"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "commit-path"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "ref": {
+                "$ref": "#/$defs/sha40"
+              },
+              "url": {
+                "pattern": "^https://github\\.com/Voxterrae/HUB_Optimus/(blob|tree)/[0-9a-f]{40}/.+"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pull-request"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "ref": {
+                "pattern": "^[1-9][0-9]*$"
+              },
+              "url": {
+                "pattern": "^https://github\\.com/Voxterrae/HUB_Optimus/pull/[1-9][0-9]*$"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "issue"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "ref": {
+                "pattern": "^[1-9][0-9]*$"
+              },
+              "url": {
+                "pattern": "^https://github\\.com/Voxterrae/HUB_Optimus/issues/[1-9][0-9]*$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "display_name",
+        "lifecycle_state",
+        "source_status",
+        "public_section",
+        "publicly_listed",
+        "public_static_surface_available",
+        "public_browser_runtime_available",
+        "production_service_deployed",
+        "production_writes_executed",
+        "live_external_transport_enabled",
+        "evidence",
+        "claim_boundary"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "lifecycle_state": {
+          "enum": [
+            "active-methodology",
+            "working-deterministic-prototype",
+            "early-implementation",
+            "browser-prototype",
+            "implementation-present-deployment-unverified",
+            "experimental-tooling",
+            "active-ratified-protocol",
+            "official-empty-incubation",
+            "draft",
+            "issue-only"
+          ]
+        },
+        "source_status": {
+          "enum": [
+            "merged",
+            "draft-pr",
+            "draft-pr-stack",
+            "open-issue"
+          ]
+        },
+        "public_section": {
+          "enum": [
+            "what-exists-today",
+            "in-development",
+            "not-publicly-listed"
+          ]
+        },
+        "publicly_listed": {
+          "type": "boolean"
+        },
+        "public_static_surface_available": {
+          "type": "boolean"
+        },
+        "public_browser_runtime_available": {
+          "type": "boolean"
+        },
+        "production_service_deployed": {
+          "type": "boolean"
+        },
+        "production_writes_executed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "live_external_transport_enabled": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        },
+        "claim_boundary": {
+          "type": "string",
+          "minLength": 20,
+          "maxLength": 500
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "source_status": {
+                "enum": [
+                  "draft-pr",
+                  "draft-pr-stack"
+                ]
+              }
+            },
+            "required": [
+              "source_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "lifecycle_state": {
+                "const": "draft"
+              },
+              "public_section": {
+                "const": "in-development"
+              },
+              "public_browser_runtime_available": {
+                "const": false
+              },
+              "production_service_deployed": {
+                "const": false
+              },
+              "production_writes_executed": {
+                "const": 0
+              },
+              "live_external_transport_enabled": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source_status": {
+                "const": "open-issue"
+              }
+            },
+            "required": [
+              "source_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "lifecycle_state": {
+                "const": "issue-only"
+              },
+              "public_section": {
+                "const": "in-development"
+              },
+              "public_browser_runtime_available": {
+                "const": false
+              },
+              "production_service_deployed": {
+                "const": false
+              },
+              "production_writes_executed": {
+                "const": 0
+              },
+              "live_external_transport_enabled": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source_status": {
+                "const": "merged"
+              }
+            },
+            "required": [
+              "source_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "lifecycle_state": {
+                "not": {
+                  "enum": [
+                    "draft",
+                    "issue-only"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "public_section": {
+                "const": "what-exists-today"
+              }
+            },
+            "required": [
+              "public_section"
+            ]
+          },
+          "then": {
+            "properties": {
+              "source_status": {
+                "const": "merged"
+              },
+              "publicly_listed": {
+                "const": true
+              },
+              "public_static_surface_available": {
+                "const": true
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "public_section": {
+                "const": "not-publicly-listed"
+              }
+            },
+            "required": [
+              "public_section"
+            ]
+          },
+          "then": {
+            "properties": {
+              "publicly_listed": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "publicly_listed": {
+                "const": true
+              }
+            },
+            "required": [
+              "publicly_listed"
+            ]
+          },
+          "then": {
+            "properties": {
+              "public_section": {
+                "enum": [
+                  "what-exists-today",
+                  "in-development"
+                ]
+              },
+              "public_static_surface_available": {
+                "const": true
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "public_browser_runtime_available": {
+                "const": true
+              }
+            },
+            "required": [
+              "public_browser_runtime_available"
+            ]
+          },
+          "then": {
+            "properties": {
+              "source_status": {
+                "const": "merged"
+              },
+              "publicly_listed": {
+                "const": true
+              },
+              "public_static_surface_available": {
+                "const": true
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "production_service_deployed": {
+                "const": true
+              }
+            },
+            "required": [
+              "production_service_deployed"
+            ]
+          },
+          "then": {
+            "properties": {
+              "source_status": {
+                "const": "merged"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_site_capability_registry.py
+++ b/tests/test_site_capability_registry.py
@@ -1,0 +1,381 @@
+import copy
+import json
+import re
+from datetime import date, timedelta
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "site" / "data" / "capability-registry.v1.json"
+SCHEMA_PATH = ROOT / "site" / "data" / "capability-registry.v1.schema.json"
+INDEX_PATH = ROOT / "site" / "index.html"
+DOCUMENT_ROUTES_PATH = ROOT / "site" / "i18n" / "document-routes.v1.js"
+PAGES_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "pages.yml"
+
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+COMMIT_PATH_URL = re.compile(
+    r"^https://github\.com/Voxterrae/HUB_Optimus/(?:blob|tree)/"
+    r"(?P<ref>[0-9a-f]{40})/.+"
+)
+PULL_REQUEST_URL = re.compile(
+    r"^https://github\.com/Voxterrae/HUB_Optimus/pull/(?P<ref>[1-9][0-9]*)$"
+)
+ISSUE_URL = re.compile(
+    r"^https://github\.com/Voxterrae/HUB_Optimus/issues/(?P<ref>[1-9][0-9]*)$"
+)
+EMAIL = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+UUID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+
+PUBLIC_COMPONENTS = {
+    "core",
+    "simulator",
+    "semantic-engine",
+    "operator",
+    "controlled-url-intake",
+    "research",
+    "governance-intelligence",
+    "labs",
+}
+IN_DEVELOPMENT_COMPONENTS = {
+    "admin-gateway",
+    "evidence-lab",
+    "connect-xai-x",
+    "global-graph",
+}
+ADMIN_GATEWAY_STACK = {"1870", "1871", "1872", "1873", "1875", "1876"}
+ALLOWED_LIFECYCLE_STATES = {
+    "active-methodology",
+    "working-deterministic-prototype",
+    "early-implementation",
+    "browser-prototype",
+    "implementation-present-deployment-unverified",
+    "experimental-tooling",
+    "active-ratified-protocol",
+    "official-empty-incubation",
+    "draft",
+    "issue-only",
+}
+ALLOWED_SOURCE_STATUSES = {
+    "merged",
+    "draft-pr",
+    "draft-pr-stack",
+    "open-issue",
+}
+NON_MERGED_SOURCE_STATUSES = {"draft-pr", "draft-pr-stack", "open-issue"}
+FORBIDDEN_FIELD_NAMES = {
+    "access_token",
+    "api_key",
+    "certificate",
+    "client_secret",
+    "email",
+    "environment_id",
+    "password",
+    "phone",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "tenant_id",
+}
+
+
+class PortfolioStatusParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.statuses = {}
+
+    def handle_starttag(self, tag, attributes):
+        attrs = dict(attributes)
+        component_id = attrs.get("data-portfolio-component")
+        if not component_id:
+            return
+
+        status = attrs.get("data-status")
+        assert status, f"public component {component_id!r} must declare data-status"
+        assert component_id not in self.statuses, (
+            f"duplicate public component status for {component_id!r}"
+        )
+        self.statuses[component_id] = status
+
+
+def load_registry():
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def load_schema():
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def component_map(registry):
+    return {component["id"]: component for component in registry["components"]}
+
+
+def parse_public_component_statuses():
+    parser = PortfolioStatusParser()
+    parser.feed(INDEX_PATH.read_text(encoding="utf-8"))
+    return parser.statuses
+
+
+def walk_keys(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield key
+            yield from walk_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk_keys(child)
+
+
+def schema_errors(registry, schema):
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    return sorted(validator.iter_errors(registry), key=lambda error: list(error.path))
+
+
+def test_registry_is_valid_against_checked_draft_2020_12_schema():
+    registry = load_registry()
+    schema = load_schema()
+
+    Draft202012Validator.check_schema(schema)
+    errors = schema_errors(registry, schema)
+
+    assert not errors, "\n".join(
+        f"{'/'.join(map(str, error.absolute_path))}: {error.message}"
+        for error in errors
+    )
+    assert registry["$schema"] == "./capability-registry.v1.schema.json"
+    assert registry["schema_version"] == "1.0.0"
+    assert registry["registry_id"] == "hub_optimus.public_capabilities.v1"
+    assert registry["registry_mode"] == "human-reviewed-static"
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == (
+        "https://huboptimus.dev/data/capability-registry.v1.schema.json"
+    )
+
+
+def test_baseline_is_a_dated_observation_not_a_self_referential_main_claim():
+    registry = load_registry()
+    baseline = registry["baseline"]
+    pages = baseline["github_pages"]
+    sites = baseline["sites_mirror"]
+
+    current_date_boundary = date.today() + timedelta(days=1)
+    reviewed_at = date.fromisoformat(registry["reviewed_at"])
+    pages_observed_at = date.fromisoformat(pages["observed_at"])
+    sites_observed_at = date.fromisoformat(sites["observed_at"])
+
+    assert reviewed_at <= current_date_boundary
+    for observed_at in (pages_observed_at, sites_observed_at):
+        assert observed_at <= reviewed_at
+        assert observed_at <= current_date_boundary
+
+    assert baseline["canonical_repository"] == "Voxterrae/HUB_Optimus"
+    assert SHA40.fullmatch(baseline["source_baseline_sha"])
+    assert SHA40.fullmatch(baseline["public_evidence_sha"])
+    assert "reviewed_main_sha" not in baseline
+
+    assert pages["artifact_path"] == "site"
+    assert pages["workflow_path"] == ".github/workflows/pages.yml"
+    assert pages["portfolio_generation"] == "manual"
+    assert pages["observed_conclusion"] == "success"
+    assert pages["observed_source_sha"] == baseline["source_baseline_sha"]
+    assert pages["merge_path_triggers_pages"] is True
+    assert not any(key.startswith("latest_") for key in pages)
+
+    assert sites["authoritative"] is False
+    assert sites["synchronization"] == "manual-deterministic"
+    assert sites["matches_source_baseline"] is False
+    assert sites["observed_source_sha"] != baseline["source_baseline_sha"]
+    assert not any(key.startswith("current_") for key in sites)
+
+
+def test_pages_side_effect_is_explicitly_bound_to_the_real_workflow():
+    registry = load_registry()
+    pages = registry["baseline"]["github_pages"]
+    workflow = PAGES_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert pages["merge_path_triggers_pages"] is True
+    assert '- "site/**"' in workflow
+    assert '- "docs/**"' in workflow
+    assert "path: site" in workflow
+
+
+def test_public_evidence_sha_matches_document_route_resolver():
+    registry = load_registry()
+    route_source = DOCUMENT_ROUTES_PATH.read_text(encoding="utf-8")
+    match = re.search(r'const EVIDENCE_SHA = "([0-9a-f]{40})";', route_source)
+
+    assert match, "document route resolver must expose one immutable evidence SHA"
+    assert match.group(1) == registry["baseline"]["public_evidence_sha"]
+
+
+def test_registry_contains_exact_current_and_development_component_sets():
+    registry = load_registry()
+    components = component_map(registry)
+
+    assert len(components) == len(registry["components"]), "component IDs must be unique"
+    assert set(components) == PUBLIC_COMPONENTS | IN_DEVELOPMENT_COMPONENTS
+
+    markup_statuses = parse_public_component_statuses()
+    expected_public_statuses = {
+        component_id: components[component_id]["lifecycle_state"]
+        for component_id in PUBLIC_COMPONENTS
+    }
+
+    assert set(markup_statuses) == PUBLIC_COMPONENTS
+    assert markup_statuses == expected_public_statuses
+    assert {
+        component["id"]
+        for component in registry["components"]
+        if component["public_section"] == "what-exists-today"
+    } == PUBLIC_COMPONENTS
+    assert not (set(markup_statuses) & IN_DEVELOPMENT_COMPONENTS)
+
+
+def test_evidence_type_ref_and_url_identity_are_exact_and_unique():
+    registry = load_registry()
+    public_evidence_sha = registry["baseline"]["public_evidence_sha"]
+    seen = set()
+
+    patterns = {
+        "commit-path": COMMIT_PATH_URL,
+        "pull-request": PULL_REQUEST_URL,
+        "issue": ISSUE_URL,
+    }
+
+    for component in registry["components"]:
+        for evidence in component["evidence"]:
+            identity = (evidence["type"], evidence["ref"], evidence["url"])
+            assert identity not in seen, identity
+            seen.add(identity)
+
+            match = patterns[evidence["type"]].fullmatch(evidence["url"])
+            assert match, evidence
+            assert match.group("ref") == evidence["ref"], evidence
+            if evidence["type"] == "commit-path":
+                assert evidence["ref"] == public_evidence_sha, evidence
+
+            parsed = urlsplit(evidence["url"])
+            assert parsed.scheme == "https"
+            assert parsed.netloc == "github.com"
+            assert not parsed.query
+            assert not parsed.fragment
+
+
+def test_admin_gateway_stack_lists_only_exact_open_pull_requests():
+    registry = load_registry()
+    admin_gateway = component_map(registry)["admin-gateway"]
+
+    refs = {evidence["ref"] for evidence in admin_gateway["evidence"]}
+    urls = {evidence["url"] for evidence in admin_gateway["evidence"]}
+
+    assert refs == ADMIN_GATEWAY_STACK
+    assert urls == {
+        f"https://github.com/Voxterrae/HUB_Optimus/pull/{number}"
+        for number in ADMIN_GATEWAY_STACK
+    }
+    assert "1874" not in refs
+
+
+def test_component_states_and_present_claims_are_bounded():
+    registry = load_registry()
+
+    for component in registry["components"]:
+        assert component["lifecycle_state"] in ALLOWED_LIFECYCLE_STATES
+        assert component["source_status"] in ALLOWED_SOURCE_STATUSES
+        assert component["claim_boundary"].strip()
+        assert component["evidence"]
+
+        if component["source_status"] == "merged":
+            assert component["lifecycle_state"] not in {"draft", "issue-only"}
+        elif component["source_status"] == "open-issue":
+            assert component["lifecycle_state"] == "issue-only"
+        else:
+            assert component["lifecycle_state"] == "draft"
+
+        if component["source_status"] in NON_MERGED_SOURCE_STATUSES:
+            assert component["public_section"] == "in-development"
+            assert component["publicly_listed"] is False
+            assert component["public_static_surface_available"] is False
+            assert component["public_browser_runtime_available"] is False
+            assert component["production_service_deployed"] is False
+            assert component["production_writes_executed"] == 0
+            assert component["live_external_transport_enabled"] is False
+
+
+def test_current_public_components_are_merged_and_truthfully_listed():
+    registry = load_registry()
+    components = component_map(registry)
+
+    for component_id in PUBLIC_COMPONENTS:
+        component = components[component_id]
+        assert component["source_status"] == "merged"
+        assert component["public_section"] == "what-exists-today"
+        assert component["publicly_listed"] is True
+        assert component["public_static_surface_available"] is True
+
+    assert components["operator"]["public_browser_runtime_available"] is True
+    assert all(
+        component["production_service_deployed"] is False
+        for component in components.values()
+    )
+
+
+def test_schema_rejects_non_merged_release_transport_and_write_overclaims():
+    registry = load_registry()
+    schema = load_schema()
+
+    for component_id, field, value in (
+        ("evidence-lab", "public_browser_runtime_available", True),
+        ("connect-xai-x", "live_external_transport_enabled", True),
+        ("admin-gateway", "production_service_deployed", True),
+        ("global-graph", "production_writes_executed", 1),
+    ):
+        mutated = copy.deepcopy(registry)
+        component_map(mutated)[component_id][field] = value
+        assert schema_errors(mutated, schema), (component_id, field)
+
+
+def test_schema_rejects_lifecycle_and_public_section_promotion_without_source_change():
+    registry = load_registry()
+    schema = load_schema()
+
+    mutated_issue = copy.deepcopy(registry)
+    component_map(mutated_issue)["global-graph"]["lifecycle_state"] = "draft"
+    assert schema_errors(mutated_issue, schema)
+
+    mutated_draft = copy.deepcopy(registry)
+    component_map(mutated_draft)["evidence-lab"]["public_section"] = "what-exists-today"
+    component_map(mutated_draft)["evidence-lab"]["public_static_surface_available"] = True
+    component_map(mutated_draft)["evidence-lab"]["publicly_listed"] = True
+    assert schema_errors(mutated_draft, schema)
+
+
+def test_registry_contains_no_private_identifiers_or_secret_fields():
+    registry = load_registry()
+    serialized = REGISTRY_PATH.read_text(encoding="utf-8")
+    keys = {key.lower() for key in walk_keys(registry)}
+
+    assert not (keys & FORBIDDEN_FIELD_NAMES)
+    assert not EMAIL.search(serialized)
+    assert not UUID.search(serialized)
+
+
+def test_schema_contains_cross_field_fail_closed_rules():
+    schema = load_schema()
+    component = schema["$defs"]["component"]
+    properties = component["properties"]
+
+    assert set(properties["lifecycle_state"]["enum"]) == ALLOWED_LIFECYCLE_STATES
+    assert set(properties["source_status"]["enum"]) == ALLOWED_SOURCE_STATUSES
+    assert properties["production_writes_executed"]["minimum"] == 0
+    assert len(component["allOf"]) >= 8
+    assert schema["$defs"]["baseline"]["properties"]["sites_mirror"]["properties"][
+        "authoritative"
+    ]["const"] is False

--- a/tests/test_site_capability_registry_integrity.py
+++ b/tests/test_site_capability_registry_integrity.py
@@ -159,7 +159,8 @@ def test_ai_handoff_records_the_registry_flow_and_outstanding_slices():
         "site/data/capability-registry.v1.json",
         "GitHub Pages",
         "visible presentation",
-        "Sites synchronization",
+        "protected Sites mirror",
+        "must be synchronized only after",
     }
     missing = sorted(marker for marker in required_markers if marker not in handoff)
     assert not missing, f"AI handoff is missing registry markers: {missing}"

--- a/tests/test_site_capability_registry_integrity.py
+++ b/tests/test_site_capability_registry_integrity.py
@@ -1,0 +1,165 @@
+import copy
+import json
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "site" / "data" / "capability-registry.v1.json"
+SCHEMA_PATH = ROOT / "site" / "data" / "capability-registry.v1.schema.json"
+PAGES_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "pages.yml"
+AI_HANDOFF_PATH = ROOT / "docs" / "context" / "AI_HANDOFF.md"
+
+COMMIT_PATH_URL = re.compile(
+    r"^https://github\.com/Voxterrae/HUB_Optimus/"
+    r"(?P<kind>blob|tree)/(?P<ref>[0-9a-f]{40})/(?P<path>.+)$"
+)
+EXPECTED_EVIDENCE_TYPE = {
+    "merged": "commit-path",
+    "draft-pr": "pull-request",
+    "draft-pr-stack": "pull-request",
+    "open-issue": "issue",
+}
+
+
+def load_registry():
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def load_schema():
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def component_map(registry):
+    return {component["id"]: component for component in registry["components"]}
+
+
+def schema_errors(registry):
+    validator = Draft202012Validator(
+        load_schema(),
+        format_checker=FormatChecker(),
+    )
+    return list(validator.iter_errors(registry))
+
+
+def load_pages_workflow():
+    workflow = yaml.safe_load(PAGES_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+
+    # PyYAML follows YAML 1.1 and may parse the unquoted key `on` as True.
+    if "on" not in workflow and True in workflow:
+        workflow["on"] = workflow.pop(True)
+    return workflow
+
+
+def git_object_type(ref, path):
+    result = subprocess.run(
+        ["git", "cat-file", "-t", f"{ref}:{path}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"missing evidence object {ref}:{path}: {result.stderr.strip()}"
+    )
+    return result.stdout.strip()
+
+
+def test_source_status_matches_every_evidence_type():
+    registry = load_registry()
+
+    for component in registry["components"]:
+        expected_type = EXPECTED_EVIDENCE_TYPE[component["source_status"]]
+        actual_types = {evidence["type"] for evidence in component["evidence"]}
+        assert actual_types == {expected_type}, component["id"]
+
+    assert len(component_map(registry)["admin-gateway"]["evidence"]) >= 2
+
+
+def test_schema_rejects_source_status_and_evidence_type_mismatches():
+    registry = load_registry()
+
+    relabeled_stack = copy.deepcopy(registry)
+    component = component_map(relabeled_stack)["admin-gateway"]
+    component["source_status"] = "merged"
+    component["lifecycle_state"] = "active-methodology"
+    assert schema_errors(relabeled_stack)
+
+    relabeled_issue = copy.deepcopy(registry)
+    component = component_map(relabeled_issue)["global-graph"]
+    component["source_status"] = "draft-pr"
+    component["lifecycle_state"] = "draft"
+    assert schema_errors(relabeled_issue)
+
+    wrong_draft_evidence = copy.deepcopy(registry)
+    component = component_map(wrong_draft_evidence)["evidence-lab"]
+    component["evidence"] = [
+        {
+            "type": "issue",
+            "ref": "1880",
+            "url": "https://github.com/Voxterrae/HUB_Optimus/issues/1880",
+        }
+    ]
+    assert schema_errors(wrong_draft_evidence)
+
+
+def test_every_commit_evidence_path_exists_at_the_declared_object_type():
+    registry = load_registry()
+
+    for component in registry["components"]:
+        for evidence in component["evidence"]:
+            if evidence["type"] != "commit-path":
+                continue
+
+            match = COMMIT_PATH_URL.fullmatch(evidence["url"])
+            assert match, evidence
+            assert match.group("ref") == evidence["ref"]
+
+            path = unquote(match.group("path"))
+            path_parts = PurePosixPath(path)
+            assert path and not path_parts.is_absolute()
+            assert ".." not in path_parts.parts
+
+            expected_type = "blob" if match.group("kind") == "blob" else "tree"
+            assert git_object_type(evidence["ref"], path) == expected_type, evidence
+
+
+def test_pages_workflow_uploads_the_exact_declared_artifact_path():
+    registry = load_registry()
+    pages = registry["baseline"]["github_pages"]
+    workflow = load_pages_workflow()
+
+    triggers = workflow["on"]
+    push_paths = set(triggers["push"]["paths"])
+    assert {"site/**", "docs/**"} <= push_paths
+
+    steps = workflow["jobs"]["deploy"]["steps"]
+    upload_steps = [
+        step
+        for step in steps
+        if str(step.get("uses", "")).startswith("actions/upload-pages-artifact@")
+    ]
+    assert len(upload_steps) == 1
+    assert upload_steps[0]["with"]["path"] == pages["artifact_path"] == "site"
+
+
+def test_ai_handoff_records_the_registry_flow_and_outstanding_slices():
+    handoff = AI_HANDOFF_PATH.read_text(encoding="utf-8")
+
+    required_markers = {
+        "## Public surface capability registry boundary",
+        "#1888",
+        "#1889",
+        "site/data/capability-registry.v1.json",
+        "GitHub Pages",
+        "visible presentation",
+        "Sites synchronization",
+    }
+    missing = sorted(marker for marker in required_markers if marker not in handoff)
+    assert not missing, f"AI handoff is missing registry markers: {missing}"


### PR DESCRIPTION
## Current disposition — exact authorization no longer transferable

The owner authorization recorded for this work was limited to exact head:

```text
29b8da8bc80b9fac37003aca4e904e642c676159
```

GitHub surfaced four additional P2 review findings before merge. They are being remediated on the draft branch. Because the tree and scope changed, the earlier merge and Pages authorization does **not** transfer to the current or future replacement head.

Current remediation head:

```text
4f0d8708cebe6f715008802cf98849f194072efa
```

This head is connector-created and not a merge candidate. #1889 remains draft and unmerged. No GitHub Pages deployment, visible presentation update, Sites synchronization, access change, tenant mutation, external transport, or production-service write is authorized for it.

## Decision

Create the first governed capability-registry foundation for #1888 without changing the visible portfolio, the GitHub Pages workflow, the protected Sites project, runtime, tenant, or production-service state.

Because the PR changes `site/**` and `docs/**`, a later specifically authorized merge will trigger the existing GitHub Pages workflow and publish the registry/schema as static files even though visible HTML remains unchanged.

## Current scope

The foundation now changes six files:

- `site/data/capability-registry.v1.json`;
- `site/data/capability-registry.v1.schema.json`;
- `docs/architecture/public_surface_sync.md`;
- `docs/context/AI_HANDOFF.md`;
- `tests/test_site_capability_registry.py`;
- `tests/test_site_capability_registry_integrity.py`.

The handoff and second focused test were added because the latest review correctly identified operational-handoff and integrity gaps. The visible HTML, CSS, JavaScript, translations, Pages workflow, and Sites project remain unchanged.

## Registry coverage

The registry covers every currently visible component, including HUB-Optimus Labs, plus these in-development boundaries:

- Optimus Admin Gateway — exact draft stack #1870–#1873 plus #1875–#1876;
- Optimus Evidence Lab — draft PR #1879;
- HUB_Optimus Connect / xAI-X — draft PR #1877;
- Optimus Global Graph — issue-only #1880.

Issue #1874 is not represented as an Admin Gateway PR.

## Resolved earlier findings

- snapshot semantics replace self-referential future-main claims;
- the merge-triggered Pages side effect is explicit;
- Draft 2020-12 schema validation and fail-closed negative cases are enforced;
- commit, PR and issue evidence bind type, ref and URL exactly;
- public `data-status` values must equal registry lifecycle states;
- every commit-path evidence SHA is bound to `baseline.public_evidence_sha`;
- Pages and Sites observation dates cannot postdate the review or tolerated current date.

## Latest review remediation

The current remediation adds:

1. schema and test enforcement that `merged`, `draft-pr`, `draft-pr-stack`, and `open-issue` source statuses carry only their corresponding evidence types;
2. offline Git-object validation that every immutable `commit-path` target exists and has the declared blob/tree type;
3. parsed YAML validation that the Pages upload step's exact `with.path` equals the registry artifact path;
4. an operational AI handoff section for #1888/#1889, the Pages receipt, the separate visible-presentation slice, and later Sites synchronization.

The architecture document and focused tests bind these requirements against future drift.

## Provenance and validation gate

The current remediation history is not owner-verified. Before any new merge decision:

1. every hosted check must pass on the exact final remediation head;
2. all current review conversations must be resolved through code or a supported explanation;
3. the exact final tree must be reconstructed through the verified owner-history boundary from the current `main` parent;
4. all checks, including Founder Authority Guard, must rerun on that verified exact head;
5. Benjamin Gerrit Hoff must issue a fresh authorization tied to the new exact SHA and tree, explicitly covering the changed six-file scope and merge-triggered Pages deployment;
6. merge must use expected-head protection;
7. the resulting merged commit, parent, tree, signature, Pages run, and public JSON resources must be validated.

## Explicit exclusions

- no visible portfolio update;
- no public `In development` UI yet;
- no GitHub Pages workflow modification;
- no current merge or Pages deployment authorization;
- no protected Sites synchronization, save, publication, or access change;
- no merge of #1870–#1879;
- no implementation of #1880;
- no Dataverse, Microsoft 365, Azure, xAI, X, OAuth, API, social, tenant, or production-service action;
- no customer, tenant, or private evidence data.

Relates to #1888 and #1809. Does not close either issue.