### PR TITLE
test(governance): attest Kernel Guard ruleset fixture (#1680)

### DIFF
--- a/tools/kernel_guard.py
+++ b/tools/kernel_guard.py
@@ -121,3 +121,6 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+# Synthetic ruleset validation fixture for issue #1680.
+# This inert comment exists only on temporary branches and must never reach main.


### PR DESCRIPTION
Temporary isolated provenance gate for issue #1680.

Source head: `745ece54531f820b56495a849a18ea4fccba5204`
Pinned base: `30e985226347b4bc59b0e187b96633a09647ca42`
Changed path: `tools/kernel_guard.py`
Change type: two inert comments only.

This PR targets only a temporary branch. It does not target or modify `main`, and authorizes no merge of the final fixture, ruleset deletion, permission, workflow, CODEOWNERS, deployment, or release change.