### PR TITLE
test(governance): validate negative ruleset gates on Kernel Guard (#1680)

### DIFF
--- a/tools/kernel_guard.py
+++ b/tools/kernel_guard.py
@@ -121,3 +121,6 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+# Synthetic ruleset validation fixture for issue #1680.
+# This inert comment exists only on temporary branches and must never reach main.


### PR DESCRIPTION
## Purpose

Complete the negative-control validation of retained ruleset `11665521` using a path actually protected by Kernel Guard.

Related to #1680

## Exact boundary

```text
base: 30e985226347b4bc59b0e187b96633a09647ca42
head: 8c4eb59f0087d44c304c273c67725c15066ed6bd
tree: 38855179a09d138c77f1cdb6bf1477ff54df56c6
changed path: tools/kernel_guard.py
change: two inert comments only
ruleset retained: 11665521
ruleset legacy preserved: 11637867
required integration: 15368
```

## Authorized validation sequence

1. Apply `allow-kernel-change` and confirm all seven required contexts are green with zero unresolved review threads.
2. Mark this PR temporarily Ready; this is test state only and never merge authorization.
3. Remove `allow-kernel-change`, require a failing `guard` check and a blocked merge state.
4. Restore `allow-kernel-change`, require `guard` recovery and the positive baseline.
5. Create exactly one synthetic inline review thread, require the unresolved thread to block merge, resolve it, and reconfirm recovery.
6. Return this PR to Draft.

## Provenance refresh

The final branch was force-updated from the first verified attestation to a second owner-authored GitHub-verified commit with the exact same tree and parent. This produced a clean `synchronize` event while `allow-kernel-change` was already present; the final PR still contains exactly one commit.

## Absolute safety boundary

This synthetic PR must never be merged into `main`. No commit beyond the verified head above, no `main` update, no ruleset update or deletion, no branch deletion, no permission, workflow, CODEOWNERS, deployment, release, licensing, customer, or external-service change is authorized. Ruleset `11637867` must remain present throughout this validation.