### PR TITLE
test(governance): re-attest Kernel Guard ruleset fixture (#1680)

### DIFF
--- a/tools/kernel_guard.py
+++ b/tools/kernel_guard.py
@@ -121,3 +121,6 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+# Synthetic ruleset validation fixture for issue #1680.
+# This inert comment exists only on temporary branches and must never reach main.


### PR DESCRIPTION
Second isolated provenance gate for issue #1680.

Source head: `745ece54531f820b56495a849a18ea4fccba5204`
Pinned base: `30e985226347b4bc59b0e187b96633a09647ca42`
Changed path: `tools/kernel_guard.py`
Tree must match the first attestation exactly.

Purpose: create a fresh GitHub-verified owner-authored single commit so PR #1893 receives a new `synchronize` event while `allow-kernel-change` is already present. This PR targets only a temporary branch and never `main`.