### PR TITLE
docs(governance): reconcile AI handoff baseline

### DIFF
--- a/docs/context/AI_HANDOFF.md
+++ b/docs/context/AI_HANDOFF.md
@@ -17,7 +17,9 @@ control, assignment, collaboration, or joint ventures, read:
 4. `docs/context/SOURCE_OF_TRUTH.md`
 5. the active governance issue and pull request
 
-The proposal recorded by issue `#1861` and draft PR `#1862` identifies:
+The protected baseline at
+`main@30e985226347b4bc59b0e187b96633a09647ca42`, linked to issue
+`#1861`, contains the Founder Ownership and Authority Charter and identifies:
 
 - **Benjamin Gerrit Hoff** as founder, architect, creator, project owner, and
   final human authority of HUB_Optimus;
@@ -26,9 +28,15 @@ The proposal recorded by issue `#1861` and draft PR `#1862` identifies:
 - HUB_Optimus as the foundational tool and technological parent platform through
   which Benjamin Gerrit Hoff develops LCDH-OS and the wider ecosystem.
 
-This proposal is not ratified merely because it appears on a branch. Draft PR
-`#1862` must remain unmerged until its reviewed final tree is recreated in
-verified owner-authored history and all protected review gates are satisfied.
+Presence of the Charter on `main` does not by itself change the
+machine-readable ratification state. The current
+`config/governance/owner_identity.v1.json` remains
+`RATIFICATION_PROPOSED`, hardware-backed owner-key enrollment remains pending,
+and PR `#1896` is the separate open proposal to change that record. No operator
+may describe the identity record as `RATIFIED` unless the exact protected
+change, live required checks, explicit owner record, and applicable
+cryptographic gate are all satisfied. Draft PR `#1862` is historical proposal
+provenance rather than the current merge gate.
 
 ## CODEOWNERS and review policy
 


### PR DESCRIPTION
## Decision

Reconcile the operational handoff with the exact protected baseline currently present on `main`.

Related to #1914.

## Scope

- update only `docs/context/AI_HANDOFF.md`;
- replace the stale statement that the Charter exists only in Draft PR #1862;
- record `main@30e985226347b4bc59b0e187b96633a09647ca42` as the exact baseline containing the Charter;
- retain `RATIFICATION_PROPOSED`, pending hardware-key enrollment, and PR #1896 as the separate ratification proposal.

## Files changed

- `docs/context/AI_HANDOFF.md`

## Acceptance criteria

- [x] No claim that the machine-readable identity record is ratified.
- [x] Anti-impersonation and protected-review boundaries remain unchanged.
- [x] PR #1896 remains separate.
- [x] No runtime, CI, schema, workflow, settings, permission, deployment or production change.

## Validation

- `git diff --check` — passed
- `python tools/check_mojibake.py docs/context/AI_HANDOFF.md` — passed
- exact base SHA — `30e985226347b4bc59b0e187b96633a09647ca42`
- exact head SHA — `4c44797fbff84d869d4467360aba26cfc45b89d7`

## Risks

This is a governance-adjacent handoff correction. It remains Draft and requires the normal protected checks and explicit human merge action.

## AI handoff update

The changed file is the handoff itself; no historical archive is modified.

## Next PR recommendation

After this correction, refresh issue #1881 against the live 26-PR portfolio without mixing the portfolio rewrite into this one-file change.